### PR TITLE
Adiciona cpf-validador — validação e descoberta de CPF via TRT3

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,12 @@ Este repositório contém duas ferramentas úteis para a manipulação e consult
 
 - https://github.com/fernandobortotti/CPF-Tools
 
+### CPF Validador — Validação e Descoberta de CPF via TRT3
+
+Valida CPFs, confirma titularidade pelo nome e descobre o CPF correto a partir de dígitos parciais ou ilegíveis. Resolve CAPTCHA automaticamente via rede neural local (CRNN ~99% de acurácia), sem depender de serviços externos. Expõe as operações como MCP tools para integração com agentes AI.
+
+- https://github.com/opastorello/cpf-validador
+
 ### Busca Nome Usando CPF/CNPJ
 
 A intenção deste serviço é ajudar você descobrir e confirmar qual a situação cadastral do documento de CPF (Cadastro de Pessoa Física) e/ou CNPJ (Cadastro Nacional da Pessoa Jurídica).


### PR DESCRIPTION
## Tipo de contribuição

- [x] Adicionar nova fonte/ferramenta

## Descrição

Adiciona o **CPF Validador** na seção *Busca de Informações via CPF/CNPJ/CRM/CNA*, logo após a entrada do CPF-Tools.

A ferramenta:
- Valida CPFs matematicamente (módulo-11)
- Confirma titularidade pelo nome consultando o TRT3
- Descobre o CPF correto a partir de dígitos parciais ou ilegíveis
- Processa dezenas de CPFs em paralelo
- Resolve CAPTCHA automaticamente via rede neural local (CRNN ~99% de acurácia), sem depender de serviços externos
- Expõe as operações como **MCP tools** para integração com agentes AI

## Checklist de verificação

- [x] Conteúdo relevante para o contexto brasileiro
- [x] URLs testadas e funcionais
- [x] Entrada sem duplicatas
- [x] Categoria correta
- [x] Acesso público (open source, MIT)
- [x] Sem dados pessoais expostos no repositório