### PR TITLE
Add juridicoonline.com.br to CNPJ lookup sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ Consulta pública da situação cadastral do CPF na Receita Federal.
 - https://www.contabilizei.com.br/consulta-cnpj-cartao/resultado?cnpj=00000000000191
 - https://www.esimplesauditoria.com/consulta-cnpj
 - https://receitaws.com.br/
+- https://juridicoonline.com.br/ 
 
 </details>
 


### PR DESCRIPTION
Adicionando https://juridicoonline.com.br/ à seção **Busca Dados Usando CNPJ**.

Ferramenta gratuita de consulta de CNPJ, QSA (Quadro de Sócios e Administradores) e dados cadastrais construída sobre os dados abertos da Receita Federal. Interface web sem necessidade de instalar nada.