### PR TITLE
Adiciona validação automática do catálogo (CI, pre-commit e ferramentas locais)

### DIFF
--- a/.github/workflows/validar-dataset.yml
+++ b/.github/workflows/validar-dataset.yml
@@ -1,0 +1,37 @@
+name: Validar catálogo e dataset
+
+on:
+  push:
+    branches: [main]
+    paths: ["*.md", "data/**", "tools/**", ".github/workflows/validar-dataset.yml"]
+  pull_request:
+    paths: ["*.md", "data/**", "tools/**", ".github/workflows/validar-dataset.yml"]
+
+jobs:
+  validar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Dataset atualizado e válido
+        run: python3 tools/build_dataset.py --check
+
+      - name: Fontes sem link ou sem classificação
+        run: |
+          relatorio=$(python3 tools/build_dataset.py --report)
+          echo "$relatorio"
+          if echo "$relatorio" | grep -q "fontes sem nenhum link"; then
+            echo "::error::Há fontes sem nenhum link no README.md"
+            exit 1
+          fi
+          if echo "$relatorio" | grep -q "sem classificação, candidatas a override"; then
+            echo "::error::Há fontes sem classificação. Adicione-as em data/overrides.json"
+            exit 1
+          fi
+
+      - name: Regras de formatação dos documentos
+        run: python3 tools/validar_docs.py

--- a/CONTRIBUICAO.md
+++ b/CONTRIBUICAO.md
@@ -229,6 +229,30 @@ A chave é o `id` da fonte, visível em `sources.json`. Campos aceitos: `input`,
 
 Todo termo é validado contra `taxonomy.json`. Para usar um termo novo, adicione-o lá antes, senão o build falha. Rode `--report` para ver a lista de fontes ainda sem classificação: são as que mais precisam de curadoria.
 
+### Validação automática
+
+Todo pull request passa pelo workflow `.github/workflows/validar-dataset.yml`, que falha se:
+
+- `sources.json` ou `index.json` estiverem desatualizados (`build_dataset.py --check`)
+- houver fonte sem nenhum link ou sem classificação (`--report`)
+- houver travessão (`—`) fora de crases, menu de navegação diferente entre os documentos ou link interno sem âncora (`tools/validar_docs.py`)
+
+Para rodar as mesmas verificações antes de cada commit, ative o hook do repositório uma única vez:
+
+```bash
+git config core.hooksPath tools/hooks
+```
+
+### Ferramentas de curadoria (só local)
+
+```bash
+python3 tools/validar_docs.py --avisos   # lista URLs repetidas em mais de uma fonte e URLs em http://
+python3 tools/checar_links.py            # testa todas as URLs do catálogo e resume ok/redirect/bloqueio/offline
+python3 tools/checar_links.py --filtro detran --csv links.csv
+```
+
+Esses avisos não bloqueiam o commit: URL repetida pode ser legítima (a mesma consulta em duas categorias) e muitos sites só existem em `http://`. Sites `.gov.br` costumam bloquear robôs (`bloqueio` = 401/403/405/429/503), então confira no navegador antes de reportar um link como quebrado.
+
 ---
 
 ## 📐 Padrões de Formatação

--- a/README.md
+++ b/README.md
@@ -1138,6 +1138,10 @@ Plataforma unificada de licitações conforme nova Lei de Licitações (Lei 14.1
 Consulta pública de pessoas físicas, jurídicas e estrangeiros com restrição para contratar com a Administração Pública, por CNPJ, CPF ou razão social.
 - https://www3.comprasnet.gov.br/sicaf-web/public/pages/consultas/consultarRestricaoContratarAdministracaoPublica.jsf
 
+### MTE - Cadastro de Empregadores que Submeteram Trabalhadores a Condições Análogas à Escravidão
+Lista pública do Ministério do Trabalho e Emprego com os empregadores flagrados em fiscalização, em formato PDF.
+- https://www.gov.br/trabalho-e-emprego/pt-br/assuntos/inspecao-do-trabalho/areas-de-atuacao/cadastro_de_empregadores.pdf
+
 ### TCU - Tribunal de Contas da União
 Fiscalização de gastos públicos federais, relatórios de auditoria e decisões.
 - https://portal.tcu.gov.br/

--- a/README.md
+++ b/README.md
@@ -894,6 +894,22 @@ Emissão de certidão que comprova a regularidade da situação eleitoral do cid
 Emissão de certidão informando se o eleitor possui condenações por crimes eleitorais registradas na Justiça Eleitoral.
 - https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/certidao-crimes-eleitorais
 
+### Certidão Negativa de Alistamento
+Emissão de certidão que comprova a inexistência de inscrição eleitoral para o cidadão.
+- https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/certidao-negativa-alistamento
+
+### Certidão Simplificada de Dados e Biometria
+Emissão de certidão com os dados cadastrais do eleitor e a situação da coleta biométrica.
+- https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/certidao-simplificada-dados-cadastrais
+
+### Certidão de Ausência de Débito da Última Eleição
+Emissão de certidão que comprova a inexistência de débito referente à última eleição.
+- https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/certidao-ausencia-debito-ultima-eleicao
+
+### Validação de Documento da Justiça Eleitoral
+Verifica a autenticidade de certidões e documentos emitidos pela Justiça Eleitoral a partir do código de validação.
+- https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/validacao
+
 ### Consulta Débitos Eleitorais
 Verifica se o eleitor possui débitos eleitorais pendentes, como multas por ausência nas eleições sem justificativa.
 - https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/debitos/listar

--- a/README.md
+++ b/README.md
@@ -1037,30 +1037,6 @@ Consulta pública de sanções aplicadas a pessoas físicas e jurídicas.
 Interface REST oficial permitindo consultas automatizadas a despesas, convênios, favorecidos e dados de pessoal.
 - https://portaldatransparencia.gov.br/api-de-dados
 
-### Dados.gov.br - Portal Brasileiro de Dados Abertos
-Catálogo central de dados abertos do governo federal com mais de 10 mil conjuntos de dados.
-- https://dados.gov.br/
-
-### Painel de Compras Governamentais
-Centralização de informações sobre licitações, contratos e compras do governo federal.
-- https://paineldecompras.economia.gov.br/
-
-### ComprasNet - Portal de Compras do Governo Federal
-Sistema oficial de compras e licitações públicas do governo federal.
-- https://www.gov.br/compras/pt-br
-
-### PNCP - Portal Nacional de Contratações Públicas
-Plataforma unificada de licitações conforme nova Lei de Licitações (Lei 14.133/2021).
-- https://www.gov.br/pncp/
-
-### TCU - Tribunal de Contas da União
-Fiscalização de gastos públicos federais, relatórios de auditoria e decisões.
-- https://portal.tcu.gov.br/
-
-### TCU - Consulta de Acórdãos
-Busca de decisões do TCU sobre prestação de contas e irregularidades.
-- https://pesquisa.apps.tcu.gov.br/
-
 **📖 Documentação da API:**
 <details>
 <summary>Exemplos de Uso da API</summary>
@@ -1097,6 +1073,30 @@ print(response.json())
 - Formato de resposta: JSON
 
 </details>
+
+### Dados.gov.br - Portal Brasileiro de Dados Abertos
+Catálogo central de dados abertos do governo federal com mais de 10 mil conjuntos de dados.
+- https://dados.gov.br/
+
+### Painel de Compras Governamentais
+Centralização de informações sobre licitações, contratos e compras do governo federal.
+- https://paineldecompras.economia.gov.br/
+
+### ComprasNet - Portal de Compras do Governo Federal
+Sistema oficial de compras e licitações públicas do governo federal.
+- https://www.gov.br/compras/pt-br
+
+### PNCP - Portal Nacional de Contratações Públicas
+Plataforma unificada de licitações conforme nova Lei de Licitações (Lei 14.133/2021).
+- https://www.gov.br/pncp/
+
+### TCU - Tribunal de Contas da União
+Fiscalização de gastos públicos federais, relatórios de auditoria e decisões.
+- https://portal.tcu.gov.br/
+
+### TCU - Consulta de Acórdãos
+Busca de decisões do TCU sobre prestação de contas e irregularidades.
+- https://pesquisa.apps.tcu.gov.br/
 
 ### TCU - Plataforma de Certidões
 Emissão de certidões do Tribunal de Contas da União por CPF ou CNPJ (contas julgadas irregulares, inabilitados, licitantes inidôneos e processos) e listas públicas pesquisáveis por nome, CPF/CNPJ, UF e município, com download em CSV. A lista eleitoral cobre as eleições de 2014 a 2026.

--- a/README.md
+++ b/README.md
@@ -3705,6 +3705,9 @@ Consultas de registro profissional e certidões em conselhos federais e regionai
 <details>
 <summary>Conselhos de Medicina (CRM)</summary>
 
+**CFM - Conselho Federal de Medicina**
+- Busca por médicos: https://portal.cfm.org.br/busca-medicos/
+
 **CREMESP - Conselho Regional de Medicina do Estado de São Paulo**
 - Portal: https://www.cremesp.org.br/
 

--- a/README.md
+++ b/README.md
@@ -2481,6 +2481,10 @@ O Portal Brasileiro de Dados Abertos do Banco Central é o meio utilizado pelo B
 
 - https://dadosabertos.bcb.gov.br/dataset
 
+### IF.data - Dados Selecionados de Instituições Financeiras
+Relatórios do Banco Central com dados contábeis e prudenciais das instituições financeiras, por data-base, tipo de instituição e tipo de relatório.
+- https://www3.bcb.gov.br/ifdata/
+
 ### Dados MTur - Ministério do Meio Ambiente e Mudança do Clima
 
 O Plano de Dados Abertos do MTur abrange os setores do turismo e da cultura, e é o documento orientador para as ações de implementação e promoção de abertura de dados produzidos ou que estão sob a responsabilidade do Ministério do Turismo (MTur)

--- a/README.md
+++ b/README.md
@@ -436,6 +436,10 @@ Consulta pública de processos de improbidade administrativa por número do proc
 Consulta de pessoas e entidades requeridas em ações de improbidade administrativa.
 - https://www.cnj.jus.br/improbidade_adm/consultar_requerido.php
 
+### CADE - Pesquisa Pública de Processos
+Pesquisa pública de processos e documentos do Conselho Administrativo de Defesa Econômica por número SEI, texto, interessado, unidade geradora e tipo de processo.
+- https://sei.cade.gov.br/sei/modulos/pesquisa/md_pesq_processo_pesquisar.php?acao_externa=protocolo_pesquisar&acao_origem_externa=protocolo_pesquisar&id_orgao_acesso_externo=0
+
 ### CNJ - Consulta de Classes Processuais SGT
 Sistema de Gestão de Tabelas Processuais Unificadas - consulta de classes processuais.
 - https://www.cnj.jus.br/sgt/consulta_publica_classes.php

--- a/README.md
+++ b/README.md
@@ -733,6 +733,18 @@ Pesquisa informações sobre entrevistador do IBGE. Para consulta é necessário
 Pesquisa pública de corretores de seguros habilitados pela Superintendência de Seguros Privados, pessoa natural ou jurídica. Permite filtrar por tipo de pessoa, CNPJ (pessoa jurídica), nome, produto e situação do registro (ativo ou cancelado).
 - https://www2.susep.gov.br/safe/Corretores/pesquisa
 
+### PGFN - Dívida Aberta
+Consulta pública de devedores inscritos em dívida ativa da União e do FGTS em situação irregular. Pesquisa por CPF, CNPJ, nome ou razão social, com filtros por natureza e valor da dívida e exportação dos resultados.
+- https://www.dividaaberta.pgfn.gov.br/consultar-devedores
+
+### TST - Certidão Negativa de Débitos Trabalhistas (CNDT)
+Emissão de certidão que informa se a pessoa física ou jurídica consta no Banco Nacional de Devedores Trabalhistas. Para consulta é necessário apenas o CPF ou CNPJ.
+- https://cndt-certidao.tst.jus.br/inicio.faces
+
+### Caixa - Consulta Regularidade do Empregador (CRF)
+Consulta do Certificado de Regularidade do FGTS do empregador. Para consulta é necessário o CNPJ ou CEI e a UF.
+- https://consulta-crf.caixa.gov.br/consultacrf/pages/consultaEmpregador.jsf
+
 ##### [![](https://img.shields.io/badge/Voltar-Sum%C3%A1rio-1E88E5?style=flat-square&logo=github&logoColor=white)](#sumário)
 
 ---

--- a/README.md
+++ b/README.md
@@ -206,10 +206,6 @@ Comprovante de Inscrição e de Situação Cadastral de Pessoa Jurídica, obtido
 
 - https://solucoes.receita.fazenda.gov.br/Servicos/cnpjreva/
 
-### Extrato do Benefício de Prestação Continuada (INSS)
-
-- ...
-
 ### Meu INSS
 Portal oficial para consulta de benefícios previdenciários, extrato de contribuições, agendamentos e outros serviços do INSS.
 - https://meu.inss.gov.br/
@@ -683,6 +679,7 @@ Consulta de inutilização de numeração de documentos fiscais eletrônicos e v
 ### Consulta Restituição do Imposto de Renda
 
 Nesta consulta serão exibidas informações (banco, agência e data de restituição) da Restituição do Imposto de Renda. Para consulta é necessário apenas o CPF e data de nascimento.
+- https://www.restituicao.receita.fazenda.gov.br/
 
 ### Portal e-CAC Receita Federal
 Centro de Atendimento Virtual (e-CAC) da Receita Federal permite acesso a serviços digitais.
@@ -906,7 +903,8 @@ Emite declaração para eleitores que exerceram função de mesário ou trabalha
 - https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/declaracao-trabalho-eleitoral
 
 
-## Consultar Zonas Eleitorais por UF
+### Consultar Zonas Eleitorais por UF
+Lista as zonas eleitorais e unidades da Justiça Eleitoral de cada estado.
 - https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/unidades-justica-eleitoral/por-uf
 
 ### Base dos Dados - Eleições
@@ -1472,7 +1470,7 @@ Por meio da busca é possível encontrar orelhões pelo número, localizar ruas,
 
 - http://sistemas.anatel.gov.br/sgmu/fiqueligado/tups.asp
 
-### Painéis de Telecomunicações (ANATEL)
+#### Painéis de Telecomunicações (ANATEL)
 
 ### Painel Geral - Indicadores de Telecomunicações
 
@@ -3183,10 +3181,6 @@ Câmeras de monitoramento de rodovias, segurança pública e clima por estado.
 ### Câmera do Aeroporto Internacional de Florianópolis - SBFL Com Fonia
 
 - https://www.youtube.com/@maaxcamaovivo
-
-### Câmera do Aeroporto da Pampulha - Belo Horizonte 24 horas (BHZ)(SBBH)
-
-- ...
 
 ### Câmera do Aeroporto Guararapes - Recife - SBRF
 

--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,23 @@ print(response.json())
 
 </details>
 
+### TCU - Plataforma de Certidões
+Emissão de certidões do Tribunal de Contas da União por CPF ou CNPJ (contas julgadas irregulares, inabilitados, licitantes inidôneos e processos) e listas públicas pesquisáveis por nome, CPF/CNPJ, UF e município, com download em CSV. A lista eleitoral cobre as eleições de 2014 a 2026.
+
+<details>
+<summary>Links de pesquisa</summary>
+
+- Certidão de contas julgadas irregulares - https://certidoes.apps.tcu.gov.br/emitir-certidao-contas-julgadas-irregulares
+- Certidão de inabilitados para função pública - https://certidoes.apps.tcu.gov.br/emitir-certidao-inabilitados
+- Certidão de licitante inidôneo - https://certidoes.apps.tcu.gov.br/emitir-certidao-inidoneos
+- Certidão de processos - https://certidoes.apps.tcu.gov.br/emitir-certidao-processos
+- Lista eleitoral de contas julgadas irregulares - https://certidoes.apps.tcu.gov.br/lista-implicacao-eleitoral
+- Lista de contas julgadas irregulares - https://certidoes.apps.tcu.gov.br/lista-responsaveis
+- Lista de inabilitados - https://certidoes.apps.tcu.gov.br/lista-inabilitados
+- Lista de licitantes inidôneos - https://certidoes.apps.tcu.gov.br/lista-inidoneos
+
+</details>
+
 ### CGU - Controladoria-Geral da União
 Órgão responsável pela defesa do patrimônio público, combate à corrupção, transparência e controle interno do Governo Federal.
 - https://www.gov.br/cgu/pt-br

--- a/README.md
+++ b/README.md
@@ -729,6 +729,10 @@ Pesquisa informações sobre entrevistador do IBGE. Para consulta é necessário
 - https://respondendo.ibge.gov.br/entrevistador.html
 - https://www.ibge.gov.br/acesso-informacao/institucional/documentos-ibge/1861-novo-portal/institucional/17422-servidores.html
 
+### SUSEP - Consulta de Corretores
+Pesquisa pública de corretores de seguros habilitados pela Superintendência de Seguros Privados, pessoa natural ou jurídica. Permite filtrar por tipo de pessoa, CNPJ (pessoa jurídica), nome, produto e situação do registro (ativo ou cancelado).
+- https://www2.susep.gov.br/safe/Corretores/pesquisa
+
 ##### [![](https://img.shields.io/badge/Voltar-Sum%C3%A1rio-1E88E5?style=flat-square&logo=github&logoColor=white)](#sumário)
 
 ---

--- a/README.md
+++ b/README.md
@@ -1003,6 +1003,10 @@ Cadastro obrigatório de pessoas físicas e jurídicas que realizam atividades p
 Sistema de controle do transporte e armazenamento de produtos e subprodutos florestais.
 - https://sinaflor2.ibama.gov.br/
 
+### IBAMA - Certificado de Regularidade (CTF)
+Consulta da regularidade de pessoas físicas e jurídicas no Cadastro Técnico Federal de Atividades Potencialmente Poluidoras. Para consulta é necessário apenas o CPF ou CNPJ.
+- https://servicos.ibama.gov.br/ctf/publico/certificado_regularidade_consulta.php
+
 ### CETESB - Licenciamento Ambiental São Paulo
 Consulta de licenças ambientais do Estado de São Paulo.
 - https://cetesb.sp.gov.br/licenciamentoambiental/

--- a/README.md
+++ b/README.md
@@ -3485,6 +3485,10 @@ Conjunto de APIs públicas e gratuitas com informações sobre CEP, CNPJ, bancos
 - ISBN
 - Taxas de câmbio
 
+### CNJ - API Pública DataJud
+API pública do Conselho Nacional de Justiça para consulta de metadados e movimentações de processos de todos os tribunais, com documentação, exemplos e modelo de dados na wiki.
+- https://datajud-wiki.cnj.jus.br/api-publica/
+
 ### ReceitaWS - API CNPJ
 API gratuita para consulta de informações cadastrais de empresas brasileiras.
 

--- a/README.md
+++ b/README.md
@@ -2485,7 +2485,7 @@ O Portal Brasileiro de Dados Abertos do Banco Central é o meio utilizado pelo B
 Relatórios do Banco Central com dados contábeis e prudenciais das instituições financeiras, por data-base, tipo de instituição e tipo de relatório.
 - https://www3.bcb.gov.br/ifdata/
 
-### Dados MTur - Ministério do Meio Ambiente e Mudança do Clima
+### Dados MTur - Ministério do Turismo
 
 O Plano de Dados Abertos do MTur abrange os setores do turismo e da cultura, e é o documento orientador para as ações de implementação e promoção de abertura de dados produzidos ou que estão sob a responsabilidade do Ministério do Turismo (MTur)
 

--- a/README.md
+++ b/README.md
@@ -1118,6 +1118,10 @@ Sistema oficial de compras e licitações públicas do governo federal.
 Plataforma unificada de licitações conforme nova Lei de Licitações (Lei 14.133/2021).
 - https://www.gov.br/pncp/
 
+### SICAF - Consulta de Restrição para Contratar com a Administração Pública
+Consulta pública de pessoas físicas, jurídicas e estrangeiros com restrição para contratar com a Administração Pública, por CNPJ, CPF ou razão social.
+- https://www3.comprasnet.gov.br/sicaf-web/public/pages/consultas/consultarRestricaoContratarAdministracaoPublica.jsf
+
 ### TCU - Tribunal de Contas da União
 Fiscalização de gastos públicos federais, relatórios de auditoria e decisões.
 - https://portal.tcu.gov.br/

--- a/README.md
+++ b/README.md
@@ -745,6 +745,14 @@ Emissão de certidão que informa se a pessoa física ou jurídica consta no Ban
 Consulta do Certificado de Regularidade do FGTS do empregador. Para consulta é necessário o CNPJ ou CEI e a UF.
 - https://consulta-crf.caixa.gov.br/consultacrf/pages/consultaEmpregador.jsf
 
+### Banco Central - Encontre uma Instituição
+Consulta de instituições reguladas ou supervisionadas pelo Banco Central, por nome, CNPJ (8 primeiros dígitos), UF e município, com opção de incluir agências e instituições em regime especial ou liquidação.
+- https://www.bcb.gov.br/meubc/encontreinstituicao
+
+### CENPROT - Consulta de Protestos
+Consulta gratuita de protestos em cartórios de todo o Brasil. Para consulta é necessário apenas o CPF ou CNPJ.
+- https://www.pesquisaprotesto.com.br/
+
 ##### [![](https://img.shields.io/badge/Voltar-Sum%C3%A1rio-1E88E5?style=flat-square&logo=github&logoColor=white)](#sumário)
 
 ---

--- a/README.md
+++ b/README.md
@@ -3419,6 +3419,10 @@ Portal oficial do Ministério com informações sobre políticas de ciência, te
 Consulta de unidades credenciadas da Empresa Brasileira de Pesquisa e Inovação Industrial.
 - https://embrapii.org.br/unidades/
 
+### IPEA - Mapa das Organizações da Sociedade Civil
+Busca de organizações da sociedade civil por nome ou CNPJ, com dados cadastrais, projetos e recursos públicos recebidos.
+- https://mapaosc.ipea.gov.br/
+
 ### Finep - Financiadora de Estudos e Projetos
 Portal da agência de fomento à inovação com informações sobre editais, financiamentos e projetos.
 - http://www.finep.gov.br/

--- a/data/index.json
+++ b/data/index.json
@@ -4868,6 +4868,25 @@
     {
       "categoria": "Transparência Pública e Defesa do Consumidor",
       "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "descricao": "Consulta pública de pessoas físicas, jurídicas e estrangeiros com restrição para contratar com a Administração Pública, por CNPJ, CPF ou razão social.",
+      "fonte": "SICAF - Consulta de Restrição para Contratar com a Administração Pública",
+      "fonte_id": "transparencia-publica-e-defesa-do-consumidor/sicaf-consulta-de-restricao-para-contratar-com-a-administracao-publica",
+      "input": [
+        "cnpj",
+        "cpf",
+        "razao_social"
+      ],
+      "label": "",
+      "output": [
+        "sancao"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://www3.comprasnet.gov.br/sicaf-web/public/pages/consultas/consultarRestricaoContratarAdministracaoPublica.jsf"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
       "descricao": "Fiscalização de gastos públicos federais, relatórios de auditoria e decisões.",
       "fonte": "TCU - Tribunal de Contas da União",
       "fonte_id": "transparencia-publica-e-defesa-do-consumidor/tcu-tribunal-de-contas-da-uniao",
@@ -19528,5 +19547,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1057
+  "total": 1058
 }

--- a/data/index.json
+++ b/data/index.json
@@ -3106,15 +3106,11 @@
       "fonte": "Consulta Restituição do Imposto de Renda",
       "fonte_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/consulta-restituicao-do-imposto-de-renda",
       "input": [
-        "cnpj",
-        "cpf",
-        "nome"
+        "cpf"
       ],
       "label": "",
       "output": [
-        "dados_cadastrais",
-        "debito",
-        "situacao_cadastral"
+        "debito"
       ],
       "tipo_fonte": "federal",
       "uf": null,
@@ -4153,13 +4149,13 @@
       "fonte": "Consultar Zonas Eleitorais por UF",
       "fonte_id": "registros-eleitorais-e-politicos/consultar-zonas-eleitorais-por-uf",
       "input": [
-        "cpf",
-        "nome",
-        "titulo_eleitor"
+        "municipio",
+        "uf"
       ],
       "label": "",
       "output": [
-        "dados_cadastrais"
+        "dados_cadastrais",
+        "endereco"
       ],
       "tipo_fonte": "judiciario",
       "uf": null,
@@ -16418,9 +16414,14 @@
       "descricao": "Portal oficial do Ministério com informações sobre políticas de ciência, tecnologia e inovação.",
       "fonte": "MCTI - Ministério da Ciência, Tecnologia e Inovação",
       "fonte_id": "outras-buscas/mcti-ministerio-da-ciencia-tecnologia-e-inovacao",
-      "input": [],
+      "input": [
+        "nenhum"
+      ],
       "label": "",
-      "output": [],
+      "output": [
+        "dataset",
+        "estatistica"
+      ],
       "tipo_fonte": "federal",
       "uf": null,
       "url": "https://www.gov.br/mcti/pt-br"
@@ -16431,9 +16432,14 @@
       "descricao": "Consulta de unidades credenciadas da Empresa Brasileira de Pesquisa e Inovação Industrial.",
       "fonte": "Embrapii - Unidades de Pesquisa e Inovação",
       "fonte_id": "outras-buscas/embrapii-unidades-de-pesquisa-e-inovacao",
-      "input": [],
+      "input": [
+        "nenhum"
+      ],
       "label": "",
-      "output": [],
+      "output": [
+        "dados_cadastrais",
+        "endereco"
+      ],
       "tipo_fonte": "ong",
       "uf": null,
       "url": "https://embrapii.org.br/unidades/"
@@ -16444,9 +16450,14 @@
       "descricao": "Portal da agência de fomento à inovação com informações sobre editais, financiamentos e projetos.",
       "fonte": "Finep - Financiadora de Estudos e Projetos",
       "fonte_id": "outras-buscas/finep-financiadora-de-estudos-e-projetos",
-      "input": [],
+      "input": [
+        "nenhum"
+      ],
       "label": "",
-      "output": [],
+      "output": [
+        "contrato_publico",
+        "estatistica"
+      ],
       "tipo_fonte": "federal",
       "uf": null,
       "url": "http://www.finep.gov.br/"
@@ -16474,9 +16485,14 @@
       "descricao": "Portal oficial da Suframa com informações sobre a Zona Franca de Manaus, incentivos fiscais e projetos aprovados.",
       "fonte": "SUFRAMA - Superintendência da Zona Franca de Manaus",
       "fonte_id": "outras-buscas/suframa-superintendencia-da-zona-franca-de-manaus",
-      "input": [],
+      "input": [
+        "nenhum"
+      ],
       "label": "",
-      "output": [],
+      "output": [
+        "contrato_publico",
+        "estatistica"
+      ],
       "tipo_fonte": "federal",
       "uf": null,
       "url": "https://www.gov.br/suframa/pt-br"
@@ -16519,9 +16535,17 @@
       "descricao": "",
       "fonte": "Sinesp Cidadão (Site a APP)",
       "fonte_id": "outras-buscas/sinesp-cidadao-site-a-app",
-      "input": [],
+      "input": [
+        "chassi",
+        "nome",
+        "placa"
+      ],
       "label": "",
-      "output": [],
+      "output": [
+        "dados_cadastrais",
+        "mandado_prisao",
+        "veiculo"
+      ],
       "tipo_fonte": "federal",
       "uf": null,
       "url": "https://seguranca.sinesp.gov.br/sinesp-seguranca/login.jsf"
@@ -18546,9 +18570,15 @@
       "descricao": "",
       "fonte": "Conhecimento de empreendimentos por dentro",
       "fonte_id": "outras-buscas/conhecimento-de-empreendimentos-por-dentro",
-      "input": [],
+      "input": [
+        "endereco",
+        "municipio"
+      ],
       "label": "",
-      "output": [],
+      "output": [
+        "endereco",
+        "imovel"
+      ],
       "tipo_fonte": "privado",
       "uf": null,
       "url": "https://www.vrbo.com/pt-br/"
@@ -18559,9 +18589,15 @@
       "descricao": "",
       "fonte": "Conhecimento de empreendimentos por dentro",
       "fonte_id": "outras-buscas/conhecimento-de-empreendimentos-por-dentro",
-      "input": [],
+      "input": [
+        "endereco",
+        "municipio"
+      ],
       "label": "",
-      "output": [],
+      "output": [
+        "endereco",
+        "imovel"
+      ],
       "tipo_fonte": "privado",
       "uf": null,
       "url": "https://www.airbnb.com.br/"
@@ -18572,9 +18608,15 @@
       "descricao": "",
       "fonte": "Conhecimento de empreendimentos por dentro",
       "fonte_id": "outras-buscas/conhecimento-de-empreendimentos-por-dentro",
-      "input": [],
+      "input": [
+        "endereco",
+        "municipio"
+      ],
       "label": "",
-      "output": [],
+      "output": [
+        "endereco",
+        "imovel"
+      ],
       "tipo_fonte": "privado",
       "uf": null,
       "url": "https://www.quintoandar.com.br/"
@@ -18585,9 +18627,15 @@
       "descricao": "",
       "fonte": "Conhecimento de empreendimentos por dentro",
       "fonte_id": "outras-buscas/conhecimento-de-empreendimentos-por-dentro",
-      "input": [],
+      "input": [
+        "endereco",
+        "municipio"
+      ],
       "label": "",
-      "output": [],
+      "output": [
+        "endereco",
+        "imovel"
+      ],
       "tipo_fonte": "privado",
       "uf": null,
       "url": "https://www.trivago.com.br/"
@@ -18598,9 +18646,15 @@
       "descricao": "",
       "fonte": "Conhecimento de empreendimentos por dentro",
       "fonte_id": "outras-buscas/conhecimento-de-empreendimentos-por-dentro",
-      "input": [],
+      "input": [
+        "endereco",
+        "municipio"
+      ],
       "label": "",
-      "output": [],
+      "output": [
+        "endereco",
+        "imovel"
+      ],
       "tipo_fonte": "privado",
       "uf": null,
       "url": "https://www.tripadvisor.com.br/"
@@ -18611,9 +18665,15 @@
       "descricao": "",
       "fonte": "Conhecimento de empreendimentos por dentro",
       "fonte_id": "outras-buscas/conhecimento-de-empreendimentos-por-dentro",
-      "input": [],
+      "input": [
+        "endereco",
+        "municipio"
+      ],
       "label": "",
-      "output": [],
+      "output": [
+        "endereco",
+        "imovel"
+      ],
       "tipo_fonte": "privado",
       "uf": null,
       "url": "https://www.booking.com/index.pt-br.html"

--- a/data/index.json
+++ b/data/index.json
@@ -3382,6 +3382,25 @@
       "url": "https://www.ibge.gov.br/acesso-informacao/institucional/documentos-ibge/1861-novo-portal/institucional/17422-servidores.html"
     },
     {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "descricao": "Pesquisa pública de corretores de seguros habilitados pela Superintendência de Seguros Privados, pessoa natural ou jurídica. Permite filtrar por tipo de pessoa, CNPJ (pessoa jurídica), nome, produto e situação do registro (ativo ou cancelado).",
+      "fonte": "SUSEP - Consulta de Corretores",
+      "fonte_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/susep-consulta-de-corretores",
+      "input": [
+        "cnpj",
+        "nome"
+      ],
+      "label": "",
+      "output": [
+        "dados_cadastrais",
+        "situacao_cadastral"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://www2.susep.gov.br/safe/Corretores/pesquisa"
+    },
+    {
       "categoria": "Estatísticas Segurança Pública",
       "categoria_id": "estatisticas-seguranca-publica",
       "descricao": "Ministério da Justiça e Segurança Pública (MJSP)",
@@ -19168,5 +19187,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1041
+  "total": 1042
 }

--- a/data/index.json
+++ b/data/index.json
@@ -4625,6 +4625,27 @@
     {
       "categoria": "Transparência Pública e Defesa do Consumidor",
       "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "descricao": "Interface REST oficial permitindo consultas automatizadas a despesas, convênios, favorecidos e dados de pessoal.",
+      "fonte": "Portal da Transparência - API de Dados",
+      "fonte_id": "transparencia-publica-e-defesa-do-consumidor/portal-da-transparencia-api-de-dados",
+      "input": [
+        "cnpj",
+        "nome"
+      ],
+      "label": "1. Acesse",
+      "output": [
+        "api_json",
+        "contrato_publico",
+        "licitacao",
+        "sancao"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://portaldatransparencia.gov.br/api-de-dados"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
       "descricao": "Catálogo central de dados abertos do governo federal com mais de 10 mil conjuntos de dados.",
       "fonte": "Dados.gov.br - Portal Brasileiro de Dados Abertos",
       "fonte_id": "transparencia-publica-e-defesa-do-consumidor/dados-gov-br-portal-brasileiro-de-dados-abertos",
@@ -4745,26 +4766,6 @@
       "tipo_fonte": "federal",
       "uf": null,
       "url": "https://pesquisa.apps.tcu.gov.br/"
-    },
-    {
-      "categoria": "Transparência Pública e Defesa do Consumidor",
-      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
-      "descricao": "Busca de decisões do TCU sobre prestação de contas e irregularidades.",
-      "fonte": "TCU - Consulta de Acórdãos",
-      "fonte_id": "transparencia-publica-e-defesa-do-consumidor/tcu-consulta-de-acordaos",
-      "input": [
-        "cnpj",
-        "nome"
-      ],
-      "label": "1. Acesse",
-      "output": [
-        "contrato_publico",
-        "licitacao",
-        "sancao"
-      ],
-      "tipo_fonte": "federal",
-      "uf": null,
-      "url": "https://portaldatransparencia.gov.br/api-de-dados"
     },
     {
       "categoria": "Transparência Pública e Defesa do Consumidor",

--- a/data/index.json
+++ b/data/index.json
@@ -4568,6 +4568,25 @@
     {
       "categoria": "Registros Ambientais",
       "categoria_id": "registros-ambientais",
+      "descricao": "Consulta da regularidade de pessoas físicas e jurídicas no Cadastro Técnico Federal de Atividades Potencialmente Poluidoras. Para consulta é necessário apenas o CPF ou CNPJ.",
+      "fonte": "IBAMA - Certificado de Regularidade (CTF)",
+      "fonte_id": "registros-ambientais/ibama-certificado-de-regularidade-ctf",
+      "input": [
+        "cnpj",
+        "cpf"
+      ],
+      "label": "",
+      "output": [
+        "certidao",
+        "situacao_cadastral"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://servicos.ibama.gov.br/ctf/publico/certificado_regularidade_consulta.php"
+    },
+    {
+      "categoria": "Registros Ambientais",
+      "categoria_id": "registros-ambientais",
       "descricao": "Consulta de licenças ambientais do Estado de São Paulo.",
       "fonte": "CETESB - Licenciamento Ambiental São Paulo",
       "fonte_id": "registros-ambientais/cetesb-licenciamento-ambiental-sao-paulo",
@@ -19608,5 +19627,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1061
+  "total": 1062
 }

--- a/data/index.json
+++ b/data/index.json
@@ -16941,6 +16941,26 @@
     {
       "categoria": "Outras Buscas",
       "categoria_id": "outras-buscas",
+      "descricao": "Busca de organizações da sociedade civil por nome ou CNPJ, com dados cadastrais, projetos e recursos públicos recebidos.",
+      "fonte": "IPEA - Mapa das Organizações da Sociedade Civil",
+      "fonte_id": "outras-buscas/ipea-mapa-das-organizacoes-da-sociedade-civil",
+      "input": [
+        "cnpj",
+        "nome"
+      ],
+      "label": "",
+      "output": [
+        "contrato_publico",
+        "dados_cadastrais",
+        "estatistica"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://mapaosc.ipea.gov.br/"
+    },
+    {
+      "categoria": "Outras Buscas",
+      "categoria_id": "outras-buscas",
       "descricao": "Portal da agência de fomento à inovação com informações sobre editais, financiamentos e projetos.",
       "fonte": "Finep - Financiadora de Estudos e Projetos",
       "fonte_id": "outras-buscas/finep-financiadora-de-estudos-e-projetos",
@@ -19662,5 +19682,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1064
+  "total": 1065
 }

--- a/data/index.json
+++ b/data/index.json
@@ -11720,6 +11720,23 @@
     {
       "categoria": "Datasets / Dados Abertos",
       "categoria_id": "datasets-dados-abertos",
+      "descricao": "Relatórios do Banco Central com dados contábeis e prudenciais das instituições financeiras, por data-base, tipo de instituição e tipo de relatório.",
+      "fonte": "IF.data - Dados Selecionados de Instituições Financeiras",
+      "fonte_id": "datasets-dados-abertos/if-data-dados-selecionados-de-instituicoes-financeiras",
+      "input": [
+        "nenhum"
+      ],
+      "label": "",
+      "output": [
+        "dataset"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://www3.bcb.gov.br/ifdata/"
+    },
+    {
+      "categoria": "Datasets / Dados Abertos",
+      "categoria_id": "datasets-dados-abertos",
       "descricao": "O Plano de Dados Abertos do MTur abrange os setores do turismo e da cultura, e é o documento orientador para as ações de implementação e promoção de abertura de dados produzidos ou que estão sob a responsabilidade do Ministério do Turismo (MTur)",
       "fonte": "Dados MTur - Ministério do Meio Ambiente e Mudança do Clima",
       "fonte_id": "datasets-dados-abertos/dados-mtur-ministerio-do-meio-ambiente-e-mudanca-do-clima",
@@ -19645,5 +19662,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1063
+  "total": 1064
 }

--- a/data/index.json
+++ b/data/index.json
@@ -52,7 +52,7 @@
       ],
       "tipo_fonte": "federal",
       "uf": null,
-      "url": "https://solucoes.receita.fazenda.gov.br/servicos/cnpjreva/cnpjreva_solicitacao.asp"
+      "url": "https://solucoes.receita.fazenda.gov.br/Servicos/cnpjreva/"
     },
     {
       "categoria": "Benefícios sociais (Políticas Públicas)",

--- a/data/index.json
+++ b/data/index.json
@@ -3460,6 +3460,45 @@
       "url": "https://consulta-crf.caixa.gov.br/consultacrf/pages/consultaEmpregador.jsf"
     },
     {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "descricao": "Consulta de instituições reguladas ou supervisionadas pelo Banco Central, por nome, CNPJ (8 primeiros dígitos), UF e município, com opção de incluir agências e instituições em regime especial ou liquidação.",
+      "fonte": "Banco Central - Encontre uma Instituição",
+      "fonte_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/banco-central-encontre-uma-instituicao",
+      "input": [
+        "cnpj",
+        "municipio",
+        "nome",
+        "uf"
+      ],
+      "label": "",
+      "output": [
+        "dados_cadastrais",
+        "situacao_cadastral"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://www.bcb.gov.br/meubc/encontreinstituicao"
+    },
+    {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "descricao": "Consulta gratuita de protestos em cartórios de todo o Brasil. Para consulta é necessário apenas o CPF ou CNPJ.",
+      "fonte": "CENPROT - Consulta de Protestos",
+      "fonte_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/cenprot-consulta-de-protestos",
+      "input": [
+        "cnpj",
+        "cpf"
+      ],
+      "label": "",
+      "output": [
+        "debito"
+      ],
+      "tipo_fonte": "privado",
+      "uf": null,
+      "url": "https://www.pesquisaprotesto.com.br/"
+    },
+    {
       "categoria": "Estatísticas Segurança Pública",
       "categoria_id": "estatisticas-seguranca-publica",
       "descricao": "Ministério da Justiça e Segurança Pública (MJSP)",
@@ -19547,5 +19586,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1058
+  "total": 1060
 }

--- a/data/index.json
+++ b/data/index.json
@@ -3401,6 +3401,65 @@
       "url": "https://www2.susep.gov.br/safe/Corretores/pesquisa"
     },
     {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "descricao": "Consulta pública de devedores inscritos em dívida ativa da União e do FGTS em situação irregular. Pesquisa por CPF, CNPJ, nome ou razão social, com filtros por natureza e valor da dívida e exportação dos resultados.",
+      "fonte": "PGFN - Dívida Aberta",
+      "fonte_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/pgfn-divida-aberta",
+      "input": [
+        "cnpj",
+        "cpf",
+        "nome",
+        "razao_social"
+      ],
+      "label": "",
+      "output": [
+        "dados_cadastrais",
+        "debito"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://www.dividaaberta.pgfn.gov.br/consultar-devedores"
+    },
+    {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "descricao": "Emissão de certidão que informa se a pessoa física ou jurídica consta no Banco Nacional de Devedores Trabalhistas. Para consulta é necessário apenas o CPF ou CNPJ.",
+      "fonte": "TST - Certidão Negativa de Débitos Trabalhistas (CNDT)",
+      "fonte_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/tst-certidao-negativa-de-debitos-trabalhistas-cndt",
+      "input": [
+        "cnpj",
+        "cpf"
+      ],
+      "label": "",
+      "output": [
+        "certidao",
+        "debito"
+      ],
+      "tipo_fonte": "judiciario",
+      "uf": null,
+      "url": "https://cndt-certidao.tst.jus.br/inicio.faces"
+    },
+    {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "descricao": "Consulta do Certificado de Regularidade do FGTS do empregador. Para consulta é necessário o CNPJ ou CEI e a UF.",
+      "fonte": "Caixa - Consulta Regularidade do Empregador (CRF)",
+      "fonte_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/caixa-consulta-regularidade-do-empregador-crf",
+      "input": [
+        "cnpj",
+        "uf"
+      ],
+      "label": "",
+      "output": [
+        "certidao",
+        "situacao_cadastral"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://consulta-crf.caixa.gov.br/consultacrf/pages/consultaEmpregador.jsf"
+    },
+    {
       "categoria": "Estatísticas Segurança Pública",
       "categoria_id": "estatisticas-seguranca-publica",
       "descricao": "Ministério da Justiça e Segurança Pública (MJSP)",
@@ -19388,5 +19447,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1050
+  "total": 1053
 }

--- a/data/index.json
+++ b/data/index.json
@@ -17182,6 +17182,25 @@
     {
       "categoria": "APIs Públicas Brasileiras",
       "categoria_id": "apis-publicas-brasileiras",
+      "descricao": "API pública do Conselho Nacional de Justiça para consulta de metadados e movimentações de processos de todos os tribunais, com documentação, exemplos e modelo de dados na wiki.",
+      "fonte": "CNJ - API Pública DataJud",
+      "fonte_id": "apis-publicas-brasileiras/cnj-api-publica-datajud",
+      "input": [
+        "numero_processo"
+      ],
+      "label": "",
+      "output": [
+        "api_json",
+        "movimentacao",
+        "processo"
+      ],
+      "tipo_fonte": "judiciario",
+      "uf": null,
+      "url": "https://datajud-wiki.cnj.jus.br/api-publica/"
+    },
+    {
+      "categoria": "APIs Públicas Brasileiras",
+      "categoria_id": "apis-publicas-brasileiras",
       "descricao": "API gratuita para consulta de informações cadastrais de empresas brasileiras.",
       "fonte": "ReceitaWS - API CNPJ",
       "fonte_id": "apis-publicas-brasileiras/receitaws-api-cnpj",
@@ -19682,5 +19701,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1065
+  "total": 1066
 }

--- a/data/index.json
+++ b/data/index.json
@@ -4769,6 +4769,206 @@
     {
       "categoria": "Transparência Pública e Defesa do Consumidor",
       "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "descricao": "Emissão de certidões do Tribunal de Contas da União por CPF ou CNPJ (contas julgadas irregulares, inabilitados, licitantes inidôneos e processos) e listas públicas pesquisáveis por nome, CPF/CNPJ, UF e município, com download em CSV. A lista eleitoral cobre as eleições de 2014 a 2026.",
+      "fonte": "TCU - Plataforma de Certidões",
+      "fonte_id": "transparencia-publica-e-defesa-do-consumidor/tcu-plataforma-de-certidoes",
+      "input": [
+        "cnpj",
+        "cpf",
+        "municipio",
+        "nome",
+        "uf"
+      ],
+      "label": "Certidão de contas julgadas irregulares",
+      "output": [
+        "certidao",
+        "dados_cadastrais",
+        "dataset",
+        "processo",
+        "sancao"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://certidoes.apps.tcu.gov.br/emitir-certidao-contas-julgadas-irregulares"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "descricao": "Emissão de certidões do Tribunal de Contas da União por CPF ou CNPJ (contas julgadas irregulares, inabilitados, licitantes inidôneos e processos) e listas públicas pesquisáveis por nome, CPF/CNPJ, UF e município, com download em CSV. A lista eleitoral cobre as eleições de 2014 a 2026.",
+      "fonte": "TCU - Plataforma de Certidões",
+      "fonte_id": "transparencia-publica-e-defesa-do-consumidor/tcu-plataforma-de-certidoes",
+      "input": [
+        "cnpj",
+        "cpf",
+        "municipio",
+        "nome",
+        "uf"
+      ],
+      "label": "Certidão de inabilitados para função pública",
+      "output": [
+        "certidao",
+        "dados_cadastrais",
+        "dataset",
+        "processo",
+        "sancao"
+      ],
+      "tipo_fonte": "federal",
+      "uf": "PA",
+      "url": "https://certidoes.apps.tcu.gov.br/emitir-certidao-inabilitados"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "descricao": "Emissão de certidões do Tribunal de Contas da União por CPF ou CNPJ (contas julgadas irregulares, inabilitados, licitantes inidôneos e processos) e listas públicas pesquisáveis por nome, CPF/CNPJ, UF e município, com download em CSV. A lista eleitoral cobre as eleições de 2014 a 2026.",
+      "fonte": "TCU - Plataforma de Certidões",
+      "fonte_id": "transparencia-publica-e-defesa-do-consumidor/tcu-plataforma-de-certidoes",
+      "input": [
+        "cnpj",
+        "cpf",
+        "municipio",
+        "nome",
+        "uf"
+      ],
+      "label": "Certidão de licitante inidôneo",
+      "output": [
+        "certidao",
+        "dados_cadastrais",
+        "dataset",
+        "processo",
+        "sancao"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://certidoes.apps.tcu.gov.br/emitir-certidao-inidoneos"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "descricao": "Emissão de certidões do Tribunal de Contas da União por CPF ou CNPJ (contas julgadas irregulares, inabilitados, licitantes inidôneos e processos) e listas públicas pesquisáveis por nome, CPF/CNPJ, UF e município, com download em CSV. A lista eleitoral cobre as eleições de 2014 a 2026.",
+      "fonte": "TCU - Plataforma de Certidões",
+      "fonte_id": "transparencia-publica-e-defesa-do-consumidor/tcu-plataforma-de-certidoes",
+      "input": [
+        "cnpj",
+        "cpf",
+        "municipio",
+        "nome",
+        "uf"
+      ],
+      "label": "Certidão de processos",
+      "output": [
+        "certidao",
+        "dados_cadastrais",
+        "dataset",
+        "processo",
+        "sancao"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://certidoes.apps.tcu.gov.br/emitir-certidao-processos"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "descricao": "Emissão de certidões do Tribunal de Contas da União por CPF ou CNPJ (contas julgadas irregulares, inabilitados, licitantes inidôneos e processos) e listas públicas pesquisáveis por nome, CPF/CNPJ, UF e município, com download em CSV. A lista eleitoral cobre as eleições de 2014 a 2026.",
+      "fonte": "TCU - Plataforma de Certidões",
+      "fonte_id": "transparencia-publica-e-defesa-do-consumidor/tcu-plataforma-de-certidoes",
+      "input": [
+        "cnpj",
+        "cpf",
+        "municipio",
+        "nome",
+        "uf"
+      ],
+      "label": "Lista eleitoral de contas julgadas irregulares",
+      "output": [
+        "certidao",
+        "dados_cadastrais",
+        "dataset",
+        "processo",
+        "sancao"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://certidoes.apps.tcu.gov.br/lista-implicacao-eleitoral"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "descricao": "Emissão de certidões do Tribunal de Contas da União por CPF ou CNPJ (contas julgadas irregulares, inabilitados, licitantes inidôneos e processos) e listas públicas pesquisáveis por nome, CPF/CNPJ, UF e município, com download em CSV. A lista eleitoral cobre as eleições de 2014 a 2026.",
+      "fonte": "TCU - Plataforma de Certidões",
+      "fonte_id": "transparencia-publica-e-defesa-do-consumidor/tcu-plataforma-de-certidoes",
+      "input": [
+        "cnpj",
+        "cpf",
+        "municipio",
+        "nome",
+        "uf"
+      ],
+      "label": "Lista de contas julgadas irregulares",
+      "output": [
+        "certidao",
+        "dados_cadastrais",
+        "dataset",
+        "processo",
+        "sancao"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://certidoes.apps.tcu.gov.br/lista-responsaveis"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "descricao": "Emissão de certidões do Tribunal de Contas da União por CPF ou CNPJ (contas julgadas irregulares, inabilitados, licitantes inidôneos e processos) e listas públicas pesquisáveis por nome, CPF/CNPJ, UF e município, com download em CSV. A lista eleitoral cobre as eleições de 2014 a 2026.",
+      "fonte": "TCU - Plataforma de Certidões",
+      "fonte_id": "transparencia-publica-e-defesa-do-consumidor/tcu-plataforma-de-certidoes",
+      "input": [
+        "cnpj",
+        "cpf",
+        "municipio",
+        "nome",
+        "uf"
+      ],
+      "label": "Lista de inabilitados",
+      "output": [
+        "certidao",
+        "dados_cadastrais",
+        "dataset",
+        "processo",
+        "sancao"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://certidoes.apps.tcu.gov.br/lista-inabilitados"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "descricao": "Emissão de certidões do Tribunal de Contas da União por CPF ou CNPJ (contas julgadas irregulares, inabilitados, licitantes inidôneos e processos) e listas públicas pesquisáveis por nome, CPF/CNPJ, UF e município, com download em CSV. A lista eleitoral cobre as eleições de 2014 a 2026.",
+      "fonte": "TCU - Plataforma de Certidões",
+      "fonte_id": "transparencia-publica-e-defesa-do-consumidor/tcu-plataforma-de-certidoes",
+      "input": [
+        "cnpj",
+        "cpf",
+        "municipio",
+        "nome",
+        "uf"
+      ],
+      "label": "Lista de licitantes inidôneos",
+      "output": [
+        "certidao",
+        "dados_cadastrais",
+        "dataset",
+        "processo",
+        "sancao"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://certidoes.apps.tcu.gov.br/lista-inidoneos"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
       "descricao": "Órgão responsável pela defesa do patrimônio público, combate à corrupção, transparência e controle interno do Governo Federal.",
       "fonte": "CGU - Controladoria-Geral da União",
       "fonte_id": "transparencia-publica-e-defesa-do-consumidor/cgu-controladoria-geral-da-uniao",
@@ -19187,5 +19387,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1042
+  "total": 1050
 }

--- a/data/index.json
+++ b/data/index.json
@@ -11738,8 +11738,8 @@
       "categoria": "Datasets / Dados Abertos",
       "categoria_id": "datasets-dados-abertos",
       "descricao": "O Plano de Dados Abertos do MTur abrange os setores do turismo e da cultura, e é o documento orientador para as ações de implementação e promoção de abertura de dados produzidos ou que estão sob a responsabilidade do Ministério do Turismo (MTur)",
-      "fonte": "Dados MTur - Ministério do Meio Ambiente e Mudança do Clima",
-      "fonte_id": "datasets-dados-abertos/dados-mtur-ministerio-do-meio-ambiente-e-mudanca-do-clima",
+      "fonte": "Dados MTur - Ministério do Turismo",
+      "fonte_id": "datasets-dados-abertos/dados-mtur-ministerio-do-turismo",
       "input": [
         "nenhum"
       ],

--- a/data/index.json
+++ b/data/index.json
@@ -3102,6 +3102,27 @@
     {
       "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
       "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "descricao": "Nesta consulta serão exibidas informações (banco, agência e data de restituição) da Restituição do Imposto de Renda. Para consulta é necessário apenas o CPF e data de nascimento.",
+      "fonte": "Consulta Restituição do Imposto de Renda",
+      "fonte_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/consulta-restituicao-do-imposto-de-renda",
+      "input": [
+        "cnpj",
+        "cpf",
+        "nome"
+      ],
+      "label": "",
+      "output": [
+        "dados_cadastrais",
+        "debito",
+        "situacao_cadastral"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://www.restituicao.receita.fazenda.gov.br/"
+    },
+    {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
       "descricao": "Centro de Atendimento Virtual (e-CAC) da Receita Federal permite acesso a serviços digitais.",
       "fonte": "Portal e-CAC Receita Federal",
       "fonte_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/portal-e-cac-receita-federal",
@@ -4126,29 +4147,38 @@
       "url": "https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/declaracao-trabalho-eleitoral"
     },
     {
-      "categoria": "Consultar Zonas Eleitorais por UF",
-      "categoria_id": "consultar-zonas-eleitorais-por-uf",
-      "descricao": "",
+      "categoria": "Registros Eleitorais e Políticos",
+      "categoria_id": "registros-eleitorais-e-politicos",
+      "descricao": "Lista as zonas eleitorais e unidades da Justiça Eleitoral de cada estado.",
       "fonte": "Consultar Zonas Eleitorais por UF",
-      "fonte_id": "consultar-zonas-eleitorais-por-uf/consultar-zonas-eleitorais-por-uf",
-      "input": [],
+      "fonte_id": "registros-eleitorais-e-politicos/consultar-zonas-eleitorais-por-uf",
+      "input": [
+        "cpf",
+        "nome",
+        "titulo_eleitor"
+      ],
       "label": "",
-      "output": [],
+      "output": [
+        "dados_cadastrais"
+      ],
       "tipo_fonte": "judiciario",
       "uf": null,
       "url": "https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/unidades-justica-eleitoral/por-uf"
     },
     {
-      "categoria": "Consultar Zonas Eleitorais por UF",
-      "categoria_id": "consultar-zonas-eleitorais-por-uf",
+      "categoria": "Registros Eleitorais e Políticos",
+      "categoria_id": "registros-eleitorais-e-politicos",
       "descricao": "Dados eleitorais tratados, padronizados e prontos para análise estatística.",
       "fonte": "Base dos Dados - Eleições",
-      "fonte_id": "consultar-zonas-eleitorais-por-uf/base-dos-dados-eleicoes",
+      "fonte_id": "registros-eleitorais-e-politicos/base-dos-dados-eleicoes",
       "input": [
-        "nenhum"
+        "cpf",
+        "nome",
+        "titulo_eleitor"
       ],
       "label": "",
       "output": [
+        "dados_cadastrais",
         "estatistica"
       ],
       "tipo_fonte": "ong",
@@ -19078,5 +19108,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1040
+  "total": 1041
 }

--- a/data/index.json
+++ b/data/index.json
@@ -17746,6 +17746,25 @@
         "nome",
         "registro_profissional"
       ],
+      "label": "Busca por médicos",
+      "output": [
+        "certidao",
+        "dados_cadastrais"
+      ],
+      "tipo_fonte": "ong",
+      "uf": null,
+      "url": "https://portal.cfm.org.br/busca-medicos/"
+    },
+    {
+      "categoria": "Serviços Públicos Estaduais e Conselhos Profissionais",
+      "categoria_id": "servicos-publicos-estaduais-e-conselhos-profissionais",
+      "descricao": "Consultas de registro profissional e certidões em conselhos federais e regionais.",
+      "fonte": "Conselhos Profissionais Nacionais",
+      "fonte_id": "servicos-publicos-estaduais-e-conselhos-profissionais/conselhos-profissionais-nacionais",
+      "input": [
+        "nome",
+        "registro_profissional"
+      ],
       "label": "Portal",
       "output": [
         "certidao",
@@ -19701,5 +19720,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1066
+  "total": 1067
 }

--- a/data/index.json
+++ b/data/index.json
@@ -4967,6 +4967,24 @@
     {
       "categoria": "Transparência Pública e Defesa do Consumidor",
       "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "descricao": "Lista pública do Ministério do Trabalho e Emprego com os empregadores flagrados em fiscalização, em formato PDF.",
+      "fonte": "MTE - Cadastro de Empregadores que Submeteram Trabalhadores a Condições Análogas à Escravidão",
+      "fonte_id": "transparencia-publica-e-defesa-do-consumidor/mte-cadastro-de-empregadores-que-submeteram-trabalhadores-a-condicoes-analogas-a-escravidao",
+      "input": [
+        "nenhum"
+      ],
+      "label": "",
+      "output": [
+        "dataset",
+        "sancao"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://www.gov.br/trabalho-e-emprego/pt-br/assuntos/inspecao-do-trabalho/areas-de-atuacao/cadastro_de_empregadores.pdf"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
       "descricao": "Fiscalização de gastos públicos federais, relatórios de auditoria e decisões.",
       "fonte": "TCU - Tribunal de Contas da União",
       "fonte_id": "transparencia-publica-e-defesa-do-consumidor/tcu-tribunal-de-contas-da-uniao",
@@ -19627,5 +19645,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1062
+  "total": 1063
 }

--- a/data/index.json
+++ b/data/index.json
@@ -4102,6 +4102,87 @@
     {
       "categoria": "Registros Eleitorais e Políticos",
       "categoria_id": "registros-eleitorais-e-politicos",
+      "descricao": "Emissão de certidão que comprova a inexistência de inscrição eleitoral para o cidadão.",
+      "fonte": "Certidão Negativa de Alistamento",
+      "fonte_id": "registros-eleitorais-e-politicos/certidao-negativa-de-alistamento",
+      "input": [
+        "cpf",
+        "nome",
+        "titulo_eleitor"
+      ],
+      "label": "",
+      "output": [
+        "certidao",
+        "dados_cadastrais"
+      ],
+      "tipo_fonte": "judiciario",
+      "uf": null,
+      "url": "https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/certidao-negativa-alistamento"
+    },
+    {
+      "categoria": "Registros Eleitorais e Políticos",
+      "categoria_id": "registros-eleitorais-e-politicos",
+      "descricao": "Emissão de certidão com os dados cadastrais do eleitor e a situação da coleta biométrica.",
+      "fonte": "Certidão Simplificada de Dados e Biometria",
+      "fonte_id": "registros-eleitorais-e-politicos/certidao-simplificada-de-dados-e-biometria",
+      "input": [
+        "cpf",
+        "nome",
+        "titulo_eleitor"
+      ],
+      "label": "",
+      "output": [
+        "certidao",
+        "dados_cadastrais"
+      ],
+      "tipo_fonte": "judiciario",
+      "uf": null,
+      "url": "https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/certidao-simplificada-dados-cadastrais"
+    },
+    {
+      "categoria": "Registros Eleitorais e Políticos",
+      "categoria_id": "registros-eleitorais-e-politicos",
+      "descricao": "Emissão de certidão que comprova a inexistência de débito referente à última eleição.",
+      "fonte": "Certidão de Ausência de Débito da Última Eleição",
+      "fonte_id": "registros-eleitorais-e-politicos/certidao-de-ausencia-de-debito-da-ultima-eleicao",
+      "input": [
+        "cpf",
+        "nome",
+        "titulo_eleitor"
+      ],
+      "label": "",
+      "output": [
+        "certidao",
+        "dados_cadastrais",
+        "debito"
+      ],
+      "tipo_fonte": "judiciario",
+      "uf": null,
+      "url": "https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/certidao-ausencia-debito-ultima-eleicao"
+    },
+    {
+      "categoria": "Registros Eleitorais e Políticos",
+      "categoria_id": "registros-eleitorais-e-politicos",
+      "descricao": "Verifica a autenticidade de certidões e documentos emitidos pela Justiça Eleitoral a partir do código de validação.",
+      "fonte": "Validação de Documento da Justiça Eleitoral",
+      "fonte_id": "registros-eleitorais-e-politicos/validacao-de-documento-da-justica-eleitoral",
+      "input": [
+        "cpf",
+        "nome",
+        "titulo_eleitor"
+      ],
+      "label": "",
+      "output": [
+        "certidao",
+        "dados_cadastrais"
+      ],
+      "tipo_fonte": "judiciario",
+      "uf": null,
+      "url": "https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/validacao"
+    },
+    {
+      "categoria": "Registros Eleitorais e Políticos",
+      "categoria_id": "registros-eleitorais-e-politicos",
       "descricao": "Verifica se o eleitor possui débitos eleitorais pendentes, como multas por ausência nas eleições sem justificativa.",
       "fonte": "Consulta Débitos Eleitorais",
       "fonte_id": "registros-eleitorais-e-politicos/consulta-debitos-eleitorais",
@@ -19447,5 +19528,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1053
+  "total": 1057
 }

--- a/data/index.json
+++ b/data/index.json
@@ -1391,6 +1391,28 @@
     {
       "categoria": "Consulta de Processos",
       "categoria_id": "consulta-de-processos",
+      "descricao": "Pesquisa pública de processos e documentos do Conselho Administrativo de Defesa Econômica por número SEI, texto, interessado, unidade geradora e tipo de processo.",
+      "fonte": "CADE - Pesquisa Pública de Processos",
+      "fonte_id": "consulta-de-processos/cade-pesquisa-publica-de-processos",
+      "input": [
+        "cnpj",
+        "cpf",
+        "nome",
+        "numero_processo"
+      ],
+      "label": "",
+      "output": [
+        "movimentacao",
+        "partes",
+        "processo"
+      ],
+      "tipo_fonte": "federal",
+      "uf": null,
+      "url": "https://sei.cade.gov.br/sei/modulos/pesquisa/md_pesq_processo_pesquisar.php?acao_externa=protocolo_pesquisar&acao_origem_externa=protocolo_pesquisar&id_orgao_acesso_externo=0"
+    },
+    {
+      "categoria": "Consulta de Processos",
+      "categoria_id": "consulta-de-processos",
       "descricao": "Sistema de Gestão de Tabelas Processuais Unificadas - consulta de classes processuais.",
       "fonte": "CNJ - Consulta de Classes Processuais SGT",
       "fonte_id": "consulta-de-processos/cnj-consulta-de-classes-processuais-sgt",
@@ -19586,5 +19608,5 @@
       "url": "https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt"
     }
   ],
-  "total": 1060
+  "total": 1061
 }

--- a/data/overrides.json
+++ b/data/overrides.json
@@ -95,6 +95,10 @@
       "input": ["cpf", "cnpj"],
       "output": ["debito"],
       "observacao": "Consulta gratuita; a certidão é paga."
+    },
+    "registros-ambientais/ibama-certificado-de-regularidade-ctf": {
+      "input": ["cpf", "cnpj"],
+      "output": ["certidao", "situacao_cadastral"]
     }
   }
 }

--- a/data/overrides.json
+++ b/data/overrides.json
@@ -104,6 +104,10 @@
       "input": ["nenhum"],
       "output": ["sancao", "dataset"],
       "observacao": "Lista em PDF, atualizada periodicamente pelo MTE."
+    },
+    "outras-buscas/ipea-mapa-das-organizacoes-da-sociedade-civil": {
+      "input": ["nome", "cnpj"],
+      "output": ["dados_cadastrais", "contrato_publico", "estatistica"]
     }
   }
 }

--- a/data/overrides.json
+++ b/data/overrides.json
@@ -99,6 +99,11 @@
     "registros-ambientais/ibama-certificado-de-regularidade-ctf": {
       "input": ["cpf", "cnpj"],
       "output": ["certidao", "situacao_cadastral"]
+    },
+    "transparencia-publica-e-defesa-do-consumidor/mte-cadastro-de-empregadores-que-submeteram-trabalhadores-a-condicoes-analogas-a-escravidao": {
+      "input": ["nenhum"],
+      "output": ["sancao", "dataset"],
+      "observacao": "Lista em PDF, atualizada periodicamente pelo MTE."
     }
   }
 }

--- a/data/overrides.json
+++ b/data/overrides.json
@@ -60,6 +60,11 @@
       "input": ["nome", "cnpj"],
       "output": ["dados_cadastrais", "situacao_cadastral"],
       "observacao": "Sem cadastro. O campo de documento só aceita CNPJ (pessoa jurídica); corretores pessoa natural são localizados pelo nome."
+    },
+    "transparencia-publica-e-defesa-do-consumidor/tcu-plataforma-de-certidoes": {
+      "input": ["cpf", "cnpj", "nome", "uf", "municipio"],
+      "output": ["certidao", "sancao", "dados_cadastrais", "processo", "dataset"],
+      "observacao": "Sem cadastro. Certidões referem-se aos últimos 20 anos e não incluem decisões sem trânsito em julgado, anuladas ou suspensas. UF e município das listas vêm do domicílio na Receita Federal."
     }
   }
 }

--- a/data/overrides.json
+++ b/data/overrides.json
@@ -15,6 +15,46 @@
       "input": ["dominio"],
       "output": ["api_json", "dados_cadastrais"],
       "observacao": "RDAP para domínios .br."
+    },
+    "outras-buscas/mcti-ministerio-da-ciencia-tecnologia-e-inovacao": {
+      "input": ["nenhum"],
+      "output": ["estatistica", "dataset"],
+      "observacao": "Portal institucional; dados de CT&I ficam em painéis e bases vinculadas ao ministério."
+    },
+    "outras-buscas/embrapii-unidades-de-pesquisa-e-inovacao": {
+      "input": ["nenhum"],
+      "output": ["dados_cadastrais", "endereco"],
+      "observacao": "Lista de unidades credenciadas, com localização e áreas de competência."
+    },
+    "outras-buscas/finep-financiadora-de-estudos-e-projetos": {
+      "input": ["nenhum"],
+      "output": ["contrato_publico", "estatistica"],
+      "observacao": "Editais, chamadas públicas e projetos financiados."
+    },
+    "outras-buscas/suframa-superintendencia-da-zona-franca-de-manaus": {
+      "input": ["nenhum"],
+      "output": ["contrato_publico", "estatistica"],
+      "observacao": "Projetos industriais aprovados e indicadores da Zona Franca de Manaus."
+    },
+    "outras-buscas/sinesp-cidadao-site-a-app": {
+      "input": ["placa", "chassi", "nome"],
+      "output": ["veiculo", "mandado_prisao", "dados_cadastrais"],
+      "observacao": "Exige cadastro gov.br. Consulta veículos, mandados de prisão, desaparecidos e procurados."
+    },
+    "outras-buscas/conhecimento-de-empreendimentos-por-dentro": {
+      "input": ["endereco", "municipio"],
+      "tipo_fonte": "privado",
+      "output": ["imovel", "endereco"],
+      "observacao": "Plataformas de hospedagem e aluguel com fotos internas de imóveis e empreendimentos."
+    },
+    "busca-de-informacoes-via-cpf-cnpj-crm-cna/consulta-restituicao-do-imposto-de-renda": {
+      "input": ["cpf"],
+      "output": ["debito"],
+      "observacao": "Requer CPF e data de nascimento. Retorna banco, agência e data da restituição."
+    },
+    "registros-eleitorais-e-politicos/consultar-zonas-eleitorais-por-uf": {
+      "input": ["uf", "municipio"],
+      "output": ["endereco", "dados_cadastrais"]
     }
   }
 }

--- a/data/overrides.json
+++ b/data/overrides.json
@@ -55,6 +55,11 @@
     "registros-eleitorais-e-politicos/consultar-zonas-eleitorais-por-uf": {
       "input": ["uf", "municipio"],
       "output": ["endereco", "dados_cadastrais"]
+    },
+    "busca-de-informacoes-via-cpf-cnpj-crm-cna/susep-consulta-de-corretores": {
+      "input": ["nome", "cnpj"],
+      "output": ["dados_cadastrais", "situacao_cadastral"],
+      "observacao": "Sem cadastro. O campo de documento só aceita CNPJ (pessoa jurídica); corretores pessoa natural são localizados pelo nome."
     }
   }
 }

--- a/data/overrides.json
+++ b/data/overrides.json
@@ -85,6 +85,16 @@
       "input": ["cnpj", "cpf", "razao_social"],
       "output": ["sancao"],
       "observacao": "Sem cadastro, com hCaptcha."
+    },
+    "busca-de-informacoes-via-cpf-cnpj-crm-cna/banco-central-encontre-uma-instituicao": {
+      "input": ["nome", "cnpj", "uf", "municipio"],
+      "output": ["dados_cadastrais", "situacao_cadastral"],
+      "observacao": "Sem cadastro. Aceita apenas os 8 primeiros dígitos do CNPJ."
+    },
+    "busca-de-informacoes-via-cpf-cnpj-crm-cna/cenprot-consulta-de-protestos": {
+      "input": ["cpf", "cnpj"],
+      "output": ["debito"],
+      "observacao": "Consulta gratuita; a certidão é paga."
     }
   }
 }

--- a/data/overrides.json
+++ b/data/overrides.json
@@ -65,6 +65,21 @@
       "input": ["cpf", "cnpj", "nome", "uf", "municipio"],
       "output": ["certidao", "sancao", "dados_cadastrais", "processo", "dataset"],
       "observacao": "Sem cadastro. Certidões referem-se aos últimos 20 anos e não incluem decisões sem trânsito em julgado, anuladas ou suspensas. UF e município das listas vêm do domicílio na Receita Federal."
+    },
+    "busca-de-informacoes-via-cpf-cnpj-crm-cna/pgfn-divida-aberta": {
+      "input": ["cpf", "cnpj", "nome", "razao_social"],
+      "output": ["debito", "dados_cadastrais"],
+      "observacao": "Sem cadastro. Lista apenas dívidas em situação irregular; permite exportar resultados."
+    },
+    "busca-de-informacoes-via-cpf-cnpj-crm-cna/tst-certidao-negativa-de-debitos-trabalhistas-cndt": {
+      "input": ["cpf", "cnpj"],
+      "output": ["certidao", "debito"],
+      "observacao": "Sem cadastro. Certidão positiva ou negativa emitida na hora."
+    },
+    "busca-de-informacoes-via-cpf-cnpj-crm-cna/caixa-consulta-regularidade-do-empregador-crf": {
+      "input": ["cnpj", "uf"],
+      "output": ["certidao", "situacao_cadastral"],
+      "observacao": "Sem cadastro. Aceita CNPJ ou CEI."
     }
   }
 }

--- a/data/overrides.json
+++ b/data/overrides.json
@@ -108,6 +108,11 @@
     "outras-buscas/ipea-mapa-das-organizacoes-da-sociedade-civil": {
       "input": ["nome", "cnpj"],
       "output": ["dados_cadastrais", "contrato_publico", "estatistica"]
+    },
+    "apis-publicas-brasileiras/cnj-api-publica-datajud": {
+      "input": ["numero_processo"],
+      "output": ["api_json", "processo", "movimentacao"],
+      "observacao": "Chave pública de acesso publicada na própria wiki."
     }
   }
 }

--- a/data/overrides.json
+++ b/data/overrides.json
@@ -80,6 +80,11 @@
       "input": ["cnpj", "uf"],
       "output": ["certidao", "situacao_cadastral"],
       "observacao": "Sem cadastro. Aceita CNPJ ou CEI."
+    },
+    "transparencia-publica-e-defesa-do-consumidor/sicaf-consulta-de-restricao-para-contratar-com-a-administracao-publica": {
+      "input": ["cnpj", "cpf", "razao_social"],
+      "output": ["sancao"],
+      "observacao": "Sem cadastro, com hCaptcha."
     }
   }
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -12333,6 +12333,32 @@
       "categoria": "Outras Buscas",
       "categoria_id": "outras-buscas",
       "classificacao": "override",
+      "descricao": "Busca de organizações da sociedade civil por nome ou CNPJ, com dados cadastrais, projetos e recursos públicos recebidos.",
+      "id": "outras-buscas/ipea-mapa-das-organizacoes-da-sociedade-civil",
+      "input": [
+        "cnpj",
+        "nome"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://mapaosc.ipea.gov.br/"
+        }
+      ],
+      "nome": "IPEA - Mapa das Organizações da Sociedade Civil",
+      "output": [
+        "contrato_publico",
+        "dados_cadastrais",
+        "estatistica"
+      ],
+      "readme_linha": 3422,
+      "tipo_fonte": "federal"
+    },
+    {
+      "categoria": "Outras Buscas",
+      "categoria_id": "outras-buscas",
+      "classificacao": "override",
       "descricao": "Portal da agência de fomento à inovação com informações sobre editais, financiamentos e projetos.",
       "id": "outras-buscas/finep-financiadora-de-estudos-e-projetos",
       "input": [
@@ -12351,7 +12377,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3422,
+      "readme_linha": 3426,
       "tipo_fonte": "federal"
     },
     {
@@ -12374,7 +12400,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3426,
+      "readme_linha": 3430,
       "tipo_fonte": "privado"
     },
     {
@@ -12399,7 +12425,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3430,
+      "readme_linha": 3434,
       "tipo_fonte": "federal"
     },
     {
@@ -12422,7 +12448,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3434,
+      "readme_linha": 3438,
       "tipo_fonte": "federal"
     },
     {
@@ -12443,7 +12469,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3438,
+      "readme_linha": 3442,
       "tipo_fonte": "federal"
     },
     {
@@ -12471,7 +12497,7 @@
         "mandado_prisao",
         "veiculo"
       ],
-      "readme_linha": 3442,
+      "readme_linha": 3446,
       "tipo_fonte": "federal"
     },
     {
@@ -12512,7 +12538,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3451,
+      "readme_linha": 3455,
       "tipo_fonte": "privado"
     },
     {
@@ -12543,7 +12569,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3470,
+      "readme_linha": 3474,
       "tipo_fonte": "privado"
     },
     {
@@ -12572,7 +12598,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3484,
+      "readme_linha": 3488,
       "tipo_fonte": "privado"
     },
     {
@@ -12600,7 +12626,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3511,
+      "readme_linha": 3515,
       "tipo_fonte": "privado"
     },
     {
@@ -12630,7 +12656,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3533,
+      "readme_linha": 3537,
       "tipo_fonte": "privado"
     },
     {
@@ -12657,7 +12683,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3557,
+      "readme_linha": 3561,
       "tipo_fonte": "federal"
     },
     {
@@ -12684,7 +12710,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3580,
+      "readme_linha": 3584,
       "tipo_fonte": "federal"
     },
     {
@@ -12714,7 +12740,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3584,
+      "readme_linha": 3588,
       "tipo_fonte": "ong"
     },
     {
@@ -12740,7 +12766,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3607,
+      "readme_linha": 3611,
       "tipo_fonte": "federal"
     },
     {
@@ -12764,7 +12790,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3611,
+      "readme_linha": 3615,
       "tipo_fonte": "federal"
     },
     {
@@ -12787,7 +12813,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3621,
+      "readme_linha": 3625,
       "tipo_fonte": "federal"
     },
     {
@@ -12810,7 +12836,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3625,
+      "readme_linha": 3629,
       "tipo_fonte": "federal"
     },
     {
@@ -12839,7 +12865,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3629,
+      "readme_linha": 3633,
       "tipo_fonte": "federal"
     },
     {
@@ -12867,7 +12893,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3634,
+      "readme_linha": 3638,
       "tipo_fonte": "federal"
     },
     {
@@ -12890,7 +12916,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3639,
+      "readme_linha": 3643,
       "tipo_fonte": "federal"
     },
     {
@@ -12913,7 +12939,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3643,
+      "readme_linha": 3647,
       "tipo_fonte": "federal"
     },
     {
@@ -12942,7 +12968,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3653,
+      "readme_linha": 3657,
       "tipo_fonte": "federal"
     },
     {
@@ -12966,7 +12992,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3658,
+      "readme_linha": 3662,
       "tipo_fonte": "federal"
     },
     {
@@ -12990,7 +13016,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3662,
+      "readme_linha": 3666,
       "tipo_fonte": "federal"
     },
     {
@@ -13020,7 +13046,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3666,
+      "readme_linha": 3670,
       "tipo_fonte": "ong"
     },
     {
@@ -13050,7 +13076,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3671,
+      "readme_linha": 3675,
       "tipo_fonte": "federal"
     },
     {
@@ -13075,7 +13101,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3676,
+      "readme_linha": 3680,
       "tipo_fonte": "federal"
     },
     {
@@ -13099,7 +13125,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3680,
+      "readme_linha": 3684,
       "tipo_fonte": "federal"
     },
     {
@@ -13123,7 +13149,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3684,
+      "readme_linha": 3688,
       "tipo_fonte": "federal"
     },
     {
@@ -13178,7 +13204,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3694,
+      "readme_linha": 3698,
       "tipo_fonte": "ong"
     },
     {
@@ -13302,7 +13328,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3733,
+      "readme_linha": 3737,
       "tipo_fonte": "estadual"
     },
     {
@@ -13422,7 +13448,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3774,
+      "readme_linha": 3778,
       "tipo_fonte": "ong"
     },
     {
@@ -13456,7 +13482,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3803,
+      "readme_linha": 3807,
       "tipo_fonte": "estadual"
     },
     {
@@ -13482,7 +13508,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3815,
+      "readme_linha": 3819,
       "tipo_fonte": "estadual"
     },
     {
@@ -13508,7 +13534,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3819,
+      "readme_linha": 3823,
       "tipo_fonte": "estadual"
     },
     {
@@ -13532,7 +13558,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3823,
+      "readme_linha": 3827,
       "tipo_fonte": "estadual"
     },
     {
@@ -13555,7 +13581,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3833,
+      "readme_linha": 3837,
       "tipo_fonte": "ong"
     },
     {
@@ -13578,7 +13604,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3837,
+      "readme_linha": 3841,
       "tipo_fonte": "federal"
     },
     {
@@ -13602,7 +13628,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3841,
+      "readme_linha": 3845,
       "tipo_fonte": "ong"
     },
     {
@@ -13625,7 +13651,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3845,
+      "readme_linha": 3849,
       "tipo_fonte": "federal"
     },
     {
@@ -13648,7 +13674,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3849,
+      "readme_linha": 3853,
       "tipo_fonte": "federal"
     },
     {
@@ -13676,7 +13702,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3853,
+      "readme_linha": 3857,
       "tipo_fonte": "privado"
     },
     {
@@ -13764,7 +13790,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3865,
+      "readme_linha": 3869,
       "tipo_fonte": "privado"
     },
     {
@@ -13815,7 +13841,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3887,
+      "readme_linha": 3891,
       "tipo_fonte": "privado"
     },
     {
@@ -13838,7 +13864,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3900,
+      "readme_linha": 3904,
       "tipo_fonte": "estadual"
     },
     {
@@ -13871,7 +13897,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3906,
+      "readme_linha": 3910,
       "tipo_fonte": "privado"
     },
     {
@@ -13895,7 +13921,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3917,
+      "readme_linha": 3921,
       "tipo_fonte": "privado"
     },
     {
@@ -13918,7 +13944,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3921,
+      "readme_linha": 3925,
       "tipo_fonte": "federal"
     },
     {
@@ -13952,7 +13978,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3927,
+      "readme_linha": 3931,
       "tipo_fonte": "privado"
     },
     {
@@ -14038,7 +14064,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3937,
+      "readme_linha": 3941,
       "tipo_fonte": "privado"
     },
     {
@@ -14062,7 +14088,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3986,
+      "readme_linha": 3990,
       "tipo_fonte": "estadual"
     },
     {
@@ -14096,9 +14122,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4149,
+      "readme_linha": 4153,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 448
+  "total": 449
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -3815,6 +3815,31 @@
     {
       "categoria": "Transparência Pública e Defesa do Consumidor",
       "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "classificacao": "override",
+      "descricao": "Lista pública do Ministério do Trabalho e Emprego com os empregadores flagrados em fiscalização, em formato PDF.",
+      "id": "transparencia-publica-e-defesa-do-consumidor/mte-cadastro-de-empregadores-que-submeteram-trabalhadores-a-condicoes-analogas-a-escravidao",
+      "input": [
+        "nenhum"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://www.gov.br/trabalho-e-emprego/pt-br/assuntos/inspecao-do-trabalho/areas-de-atuacao/cadastro_de_empregadores.pdf"
+        }
+      ],
+      "nome": "MTE - Cadastro de Empregadores que Submeteram Trabalhadores a Condições Análogas à Escravidão",
+      "observacao": "Lista em PDF, atualizada periodicamente pelo MTE.",
+      "output": [
+        "dataset",
+        "sancao"
+      ],
+      "readme_linha": 1141,
+      "tipo_fonte": "federal"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
       "classificacao": "heuristica",
       "descricao": "Fiscalização de gastos públicos federais, relatórios de auditoria e decisões.",
       "id": "transparencia-publica-e-defesa-do-consumidor/tcu-tribunal-de-contas-da-uniao",
@@ -3837,7 +3862,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1141,
+      "readme_linha": 1145,
       "tipo_fonte": "federal"
     },
     {
@@ -3863,7 +3888,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1145,
+      "readme_linha": 1149,
       "tipo_fonte": "federal"
     },
     {
@@ -3930,7 +3955,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1149,
+      "readme_linha": 1153,
       "tipo_fonte": "federal"
     },
     {
@@ -3956,7 +3981,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1166,
+      "readme_linha": 1170,
       "tipo_fonte": "federal"
     },
     {
@@ -3982,7 +4007,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1170,
+      "readme_linha": 1174,
       "tipo_fonte": "federal"
     },
     {
@@ -4008,7 +4033,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1174,
+      "readme_linha": 1178,
       "tipo_fonte": "federal"
     },
     {
@@ -4034,7 +4059,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1178,
+      "readme_linha": 1182,
       "tipo_fonte": "federal"
     },
     {
@@ -4060,7 +4085,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1182,
+      "readme_linha": 1186,
       "tipo_fonte": "federal"
     },
     {
@@ -4086,7 +4111,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1186,
+      "readme_linha": 1190,
       "tipo_fonte": "federal"
     },
     {
@@ -4112,7 +4137,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1190,
+      "readme_linha": 1194,
       "tipo_fonte": "federal"
     },
     {
@@ -4139,7 +4164,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1194,
+      "readme_linha": 1198,
       "tipo_fonte": "federal"
     },
     {
@@ -4165,7 +4190,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1198,
+      "readme_linha": 1202,
       "tipo_fonte": "estadual"
     },
     {
@@ -4192,7 +4217,7 @@
         "remuneracao",
         "sancao"
       ],
-      "readme_linha": 1202,
+      "readme_linha": 1206,
       "tipo_fonte": "estadual"
     },
     {
@@ -4218,7 +4243,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1206,
+      "readme_linha": 1210,
       "tipo_fonte": "federal"
     },
     {
@@ -4289,7 +4314,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1210,
+      "readme_linha": 1214,
       "tipo_fonte": "estadual"
     },
     {
@@ -4315,7 +4340,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1254,
+      "readme_linha": 1258,
       "tipo_fonte": "federal"
     },
     {
@@ -4481,7 +4506,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1258,
+      "readme_linha": 1262,
       "tipo_fonte": "estadual"
     },
     {
@@ -4505,7 +4530,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1327,
+      "readme_linha": 1331,
       "tipo_fonte": "federal"
     },
     {
@@ -4529,7 +4554,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1331,
+      "readme_linha": 1335,
       "tipo_fonte": "federal"
     },
     {
@@ -4553,7 +4578,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1335,
+      "readme_linha": 1339,
       "tipo_fonte": "ong"
     },
     {
@@ -4707,7 +4732,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1339,
+      "readme_linha": 1343,
       "tipo_fonte": "estadual"
     },
     {
@@ -4733,7 +4758,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 1404,
+      "readme_linha": 1408,
       "tipo_fonte": "federal"
     },
     {
@@ -4757,7 +4782,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1408,
+      "readme_linha": 1412,
       "tipo_fonte": "federal"
     },
     {
@@ -4781,7 +4806,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1412,
+      "readme_linha": 1416,
       "tipo_fonte": "federal"
     },
     {
@@ -4805,7 +4830,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1416,
+      "readme_linha": 1420,
       "tipo_fonte": "federal"
     },
     {
@@ -4829,7 +4854,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1420,
+      "readme_linha": 1424,
       "tipo_fonte": "federal"
     },
     {
@@ -4853,7 +4878,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1424,
+      "readme_linha": 1428,
       "tipo_fonte": "federal"
     },
     {
@@ -4877,7 +4902,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1428,
+      "readme_linha": 1432,
       "tipo_fonte": "federal"
     },
     {
@@ -4901,7 +4926,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1432,
+      "readme_linha": 1436,
       "tipo_fonte": "federal"
     },
     {
@@ -4925,7 +4950,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1436,
+      "readme_linha": 1440,
       "tipo_fonte": "federal"
     },
     {
@@ -4949,7 +4974,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1440,
+      "readme_linha": 1444,
       "tipo_fonte": "federal"
     },
     {
@@ -4983,7 +5008,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1449,
+      "readme_linha": 1453,
       "tipo_fonte": "privado"
     },
     {
@@ -5011,7 +5036,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1462,
+      "readme_linha": 1466,
       "tipo_fonte": "privado"
     },
     {
@@ -5049,7 +5074,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1467,
+      "readme_linha": 1471,
       "tipo_fonte": "privado"
     },
     {
@@ -5073,7 +5098,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1479,
+      "readme_linha": 1483,
       "tipo_fonte": "privado"
     },
     {
@@ -5137,7 +5162,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1485,
+      "readme_linha": 1489,
       "tipo_fonte": "ong"
     },
     {
@@ -5162,7 +5187,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1503,
+      "readme_linha": 1507,
       "tipo_fonte": "federal"
     },
     {
@@ -5187,7 +5212,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1507,
+      "readme_linha": 1511,
       "tipo_fonte": "federal"
     },
     {
@@ -5211,7 +5236,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1511,
+      "readme_linha": 1515,
       "tipo_fonte": "federal"
     },
     {
@@ -5234,7 +5259,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1515,
+      "readme_linha": 1519,
       "tipo_fonte": "federal"
     },
     {
@@ -5257,7 +5282,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1519,
+      "readme_linha": 1523,
       "tipo_fonte": "federal"
     },
     {
@@ -5286,7 +5311,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1523,
+      "readme_linha": 1527,
       "tipo_fonte": "privado"
     },
     {
@@ -5310,7 +5335,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1528,
+      "readme_linha": 1532,
       "tipo_fonte": "federal"
     },
     {
@@ -5333,7 +5358,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1532,
+      "readme_linha": 1536,
       "tipo_fonte": "federal"
     },
     {
@@ -5358,7 +5383,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1536,
+      "readme_linha": 1540,
       "tipo_fonte": "federal"
     },
     {
@@ -5384,7 +5409,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1544,
+      "readme_linha": 1548,
       "tipo_fonte": "federal"
     },
     {
@@ -5409,7 +5434,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1550,
+      "readme_linha": 1554,
       "tipo_fonte": "federal"
     },
     {
@@ -5434,7 +5459,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1556,
+      "readme_linha": 1560,
       "tipo_fonte": "federal"
     },
     {
@@ -5459,7 +5484,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1562,
+      "readme_linha": 1566,
       "tipo_fonte": "federal"
     },
     {
@@ -5483,7 +5508,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1569,
+      "readme_linha": 1573,
       "tipo_fonte": "federal"
     },
     {
@@ -5506,7 +5531,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1576,
+      "readme_linha": 1580,
       "tipo_fonte": "federal"
     },
     {
@@ -5533,7 +5558,7 @@
         "outorga",
         "radiofrequencia"
       ],
-      "readme_linha": 1583,
+      "readme_linha": 1587,
       "tipo_fonte": "federal"
     },
     {
@@ -5558,7 +5583,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1590,
+      "readme_linha": 1594,
       "tipo_fonte": "federal"
     },
     {
@@ -5581,7 +5606,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1597,
+      "readme_linha": 1601,
       "tipo_fonte": "federal"
     },
     {
@@ -5605,7 +5630,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1604,
+      "readme_linha": 1608,
       "tipo_fonte": "federal"
     },
     {
@@ -5629,7 +5654,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1611,
+      "readme_linha": 1615,
       "tipo_fonte": "federal"
     },
     {
@@ -5653,7 +5678,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1624,
+      "readme_linha": 1628,
       "tipo_fonte": "federal"
     },
     {
@@ -5678,7 +5703,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1630,
+      "readme_linha": 1634,
       "tipo_fonte": "ong"
     },
     {
@@ -5711,7 +5736,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1636,
+      "readme_linha": 1640,
       "tipo_fonte": "privado"
     },
     {
@@ -5739,7 +5764,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1647,
+      "readme_linha": 1651,
       "tipo_fonte": "ong"
     },
     {
@@ -5810,7 +5835,7 @@
         "erb",
         "operadora"
       ],
-      "readme_linha": 1656,
+      "readme_linha": 1660,
       "tipo_fonte": "privado"
     },
     {
@@ -5834,7 +5859,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1682,
+      "readme_linha": 1686,
       "tipo_fonte": "privado"
     },
     {
@@ -5860,7 +5885,7 @@
         "processo",
         "publicacao_academica"
       ],
-      "readme_linha": 1688,
+      "readme_linha": 1692,
       "tipo_fonte": "federal"
     },
     {
@@ -5884,7 +5909,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1694,
+      "readme_linha": 1698,
       "tipo_fonte": "privado"
     },
     {
@@ -5908,7 +5933,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1698,
+      "readme_linha": 1702,
       "tipo_fonte": "academico"
     },
     {
@@ -5932,7 +5957,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1702,
+      "readme_linha": 1706,
       "tipo_fonte": "academico"
     },
     {
@@ -5956,7 +5981,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1706,
+      "readme_linha": 1710,
       "tipo_fonte": "academico"
     },
     {
@@ -5980,7 +6005,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1710,
+      "readme_linha": 1714,
       "tipo_fonte": "academico"
     },
     {
@@ -6004,7 +6029,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1714,
+      "readme_linha": 1718,
       "tipo_fonte": "federal"
     },
     {
@@ -6028,7 +6053,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1718,
+      "readme_linha": 1722,
       "tipo_fonte": "privado"
     },
     {
@@ -6052,7 +6077,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1722,
+      "readme_linha": 1726,
       "tipo_fonte": "federal"
     },
     {
@@ -6076,7 +6101,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1726,
+      "readme_linha": 1730,
       "tipo_fonte": "ong"
     },
     {
@@ -6101,7 +6126,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1730,
+      "readme_linha": 1734,
       "tipo_fonte": "federal"
     },
     {
@@ -6127,7 +6152,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1734,
+      "readme_linha": 1738,
       "tipo_fonte": "federal"
     },
     {
@@ -6152,7 +6177,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 1738,
+      "readme_linha": 1742,
       "tipo_fonte": "federal"
     },
     {
@@ -6176,7 +6201,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1742,
+      "readme_linha": 1746,
       "tipo_fonte": "federal"
     },
     {
@@ -6200,7 +6225,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1746,
+      "readme_linha": 1750,
       "tipo_fonte": "federal"
     },
     {
@@ -6224,7 +6249,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1750,
+      "readme_linha": 1754,
       "tipo_fonte": "federal"
     },
     {
@@ -6364,7 +6389,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1759,
+      "readme_linha": 1763,
       "tipo_fonte": "privado"
     },
     {
@@ -6395,7 +6420,7 @@
         "area_rural",
         "mapa"
       ],
-      "readme_linha": 1793,
+      "readme_linha": 1797,
       "tipo_fonte": "federal"
     },
     {
@@ -6419,7 +6444,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1800,
+      "readme_linha": 1804,
       "tipo_fonte": "federal"
     },
     {
@@ -6448,7 +6473,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1806,
+      "readme_linha": 1810,
       "tipo_fonte": "federal"
     },
     {
@@ -6472,7 +6497,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1813,
+      "readme_linha": 1817,
       "tipo_fonte": "privado"
     },
     {
@@ -6513,7 +6538,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1817,
+      "readme_linha": 1821,
       "tipo_fonte": "internacional"
     },
     {
@@ -6542,7 +6567,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1829,
+      "readme_linha": 1833,
       "tipo_fonte": "federal"
     },
     {
@@ -6567,7 +6592,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1836,
+      "readme_linha": 1840,
       "tipo_fonte": "federal"
     },
     {
@@ -6591,7 +6616,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1842,
+      "readme_linha": 1846,
       "tipo_fonte": "federal"
     },
     {
@@ -6630,7 +6655,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1846,
+      "readme_linha": 1850,
       "tipo_fonte": "federal"
     },
     {
@@ -6654,7 +6679,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1858,
+      "readme_linha": 1862,
       "tipo_fonte": "federal"
     },
     {
@@ -6678,7 +6703,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1862,
+      "readme_linha": 1866,
       "tipo_fonte": "federal"
     },
     {
@@ -6703,7 +6728,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1872,
+      "readme_linha": 1876,
       "tipo_fonte": "federal"
     },
     {
@@ -6728,7 +6753,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1879,
+      "readme_linha": 1883,
       "tipo_fonte": "federal"
     },
     {
@@ -6755,7 +6780,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1886,
+      "readme_linha": 1890,
       "tipo_fonte": "federal"
     },
     {
@@ -6784,7 +6809,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1893,
+      "readme_linha": 1897,
       "tipo_fonte": "federal"
     },
     {
@@ -6810,7 +6835,7 @@
         "mapa",
         "sancao"
       ],
-      "readme_linha": 1900,
+      "readme_linha": 1904,
       "tipo_fonte": "federal"
     },
     {
@@ -6835,7 +6860,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1907,
+      "readme_linha": 1911,
       "tipo_fonte": "federal"
     },
     {
@@ -6862,7 +6887,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1914,
+      "readme_linha": 1918,
       "tipo_fonte": "federal"
     },
     {
@@ -6888,7 +6913,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1921,
+      "readme_linha": 1925,
       "tipo_fonte": "privado"
     },
     {
@@ -6913,7 +6938,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1928,
+      "readme_linha": 1932,
       "tipo_fonte": "federal"
     },
     {
@@ -6940,7 +6965,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1935,
+      "readme_linha": 1939,
       "tipo_fonte": "federal"
     },
     {
@@ -6965,7 +6990,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1942,
+      "readme_linha": 1946,
       "tipo_fonte": "federal"
     },
     {
@@ -6991,7 +7016,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1949,
+      "readme_linha": 1953,
       "tipo_fonte": "federal"
     },
     {
@@ -7017,7 +7042,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1956,
+      "readme_linha": 1960,
       "tipo_fonte": "federal"
     },
     {
@@ -7042,7 +7067,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1963,
+      "readme_linha": 1967,
       "tipo_fonte": "federal"
     },
     {
@@ -7069,7 +7094,7 @@
         "mapa",
         "processo"
       ],
-      "readme_linha": 1970,
+      "readme_linha": 1974,
       "tipo_fonte": "federal"
     },
     {
@@ -7096,7 +7121,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1977,
+      "readme_linha": 1981,
       "tipo_fonte": "federal"
     },
     {
@@ -7120,7 +7145,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1988,
+      "readme_linha": 1992,
       "tipo_fonte": "federal"
     },
     {
@@ -7144,7 +7169,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1994,
+      "readme_linha": 1998,
       "tipo_fonte": "federal"
     },
     {
@@ -7169,7 +7194,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1998,
+      "readme_linha": 2002,
       "tipo_fonte": "federal"
     },
     {
@@ -7193,7 +7218,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2002,
+      "readme_linha": 2006,
       "tipo_fonte": "federal"
     },
     {
@@ -7217,7 +7242,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2006,
+      "readme_linha": 2010,
       "tipo_fonte": "federal"
     },
     {
@@ -7241,7 +7266,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2010,
+      "readme_linha": 2014,
       "tipo_fonte": "federal"
     },
     {
@@ -7270,7 +7295,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2014,
+      "readme_linha": 2018,
       "tipo_fonte": "federal"
     },
     {
@@ -7295,7 +7320,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 2019,
+      "readme_linha": 2023,
       "tipo_fonte": "ong"
     },
     {
@@ -7320,7 +7345,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 2023,
+      "readme_linha": 2027,
       "tipo_fonte": "academico"
     },
     {
@@ -7344,7 +7369,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2027,
+      "readme_linha": 2031,
       "tipo_fonte": "academico"
     },
     {
@@ -7378,7 +7403,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2031,
+      "readme_linha": 2035,
       "tipo_fonte": "federal"
     },
     {
@@ -7416,7 +7441,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2048,
+      "readme_linha": 2052,
       "tipo_fonte": "dork"
     },
     {
@@ -7444,7 +7469,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2061,
+      "readme_linha": 2065,
       "tipo_fonte": "dork"
     },
     {
@@ -7472,7 +7497,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2068,
+      "readme_linha": 2072,
       "tipo_fonte": "dork"
     },
     {
@@ -7505,7 +7530,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2077,
+      "readme_linha": 2081,
       "tipo_fonte": "dork"
     },
     {
@@ -7543,7 +7568,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2088,
+      "readme_linha": 2092,
       "tipo_fonte": "dork"
     },
     {
@@ -7582,7 +7607,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2101,
+      "readme_linha": 2105,
       "tipo_fonte": "dork"
     },
     {
@@ -7621,7 +7646,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2117,
+      "readme_linha": 2121,
       "tipo_fonte": "internacional"
     },
     {
@@ -7655,7 +7680,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2129,
+      "readme_linha": 2133,
       "tipo_fonte": "internacional"
     },
     {
@@ -7683,7 +7708,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2136,
+      "readme_linha": 2140,
       "tipo_fonte": "dork"
     },
     {
@@ -7731,7 +7756,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2143,
+      "readme_linha": 2147,
       "tipo_fonte": "dork"
     },
     {
@@ -7769,7 +7794,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2163,
+      "readme_linha": 2167,
       "tipo_fonte": "dork"
     },
     {
@@ -7808,7 +7833,7 @@
         "dork",
         "video_ao_vivo"
       ],
-      "readme_linha": 2178,
+      "readme_linha": 2182,
       "tipo_fonte": "dork"
     },
     {
@@ -7849,7 +7874,7 @@
         "dork",
         "operadora"
       ],
-      "readme_linha": 2193,
+      "readme_linha": 2197,
       "tipo_fonte": "dork"
     },
     {
@@ -7883,7 +7908,7 @@
         "dork",
         "publicacao_academica"
       ],
-      "readme_linha": 2208,
+      "readme_linha": 2212,
       "tipo_fonte": "dork"
     },
     {
@@ -7916,7 +7941,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2220,
+      "readme_linha": 2224,
       "tipo_fonte": "dork"
     },
     {
@@ -7944,7 +7969,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2232,
+      "readme_linha": 2236,
       "tipo_fonte": "dork"
     },
     {
@@ -7973,7 +7998,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2242,
+      "readme_linha": 2246,
       "tipo_fonte": "internacional"
     },
     {
@@ -8016,7 +8041,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2254,
+      "readme_linha": 2258,
       "tipo_fonte": "dork"
     },
     {
@@ -8041,7 +8066,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2278,
+      "readme_linha": 2282,
       "tipo_fonte": "internacional"
     },
     {
@@ -8076,7 +8101,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2284,
+      "readme_linha": 2288,
       "tipo_fonte": "internacional"
     },
     {
@@ -8106,7 +8131,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2295,
+      "readme_linha": 2299,
       "tipo_fonte": "internacional"
     },
     {
@@ -8131,7 +8156,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2303,
+      "readme_linha": 2307,
       "tipo_fonte": "internacional"
     },
     {
@@ -8157,7 +8182,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2309,
+      "readme_linha": 2313,
       "tipo_fonte": "internacional"
     },
     {
@@ -8183,7 +8208,7 @@
         "estatistica",
         "perfil_social"
       ],
-      "readme_linha": 2315,
+      "readme_linha": 2319,
       "tipo_fonte": "internacional"
     },
     {
@@ -8208,7 +8233,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2321,
+      "readme_linha": 2325,
       "tipo_fonte": "internacional"
     },
     {
@@ -8233,7 +8258,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2327,
+      "readme_linha": 2331,
       "tipo_fonte": "internacional"
     },
     {
@@ -8258,7 +8283,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2331,
+      "readme_linha": 2335,
       "tipo_fonte": "internacional"
     },
     {
@@ -8283,7 +8308,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2335,
+      "readme_linha": 2339,
       "tipo_fonte": "internacional"
     },
     {
@@ -8308,7 +8333,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2339,
+      "readme_linha": 2343,
       "tipo_fonte": "internacional"
     },
     {
@@ -8333,7 +8358,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2343,
+      "readme_linha": 2347,
       "tipo_fonte": "internacional"
     },
     {
@@ -8358,7 +8383,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2347,
+      "readme_linha": 2351,
       "tipo_fonte": "internacional"
     },
     {
@@ -8384,7 +8409,7 @@
         "mandado_prisao",
         "perfil_social"
       ],
-      "readme_linha": 2353,
+      "readme_linha": 2357,
       "tipo_fonte": "privado"
     },
     {
@@ -8414,7 +8439,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2359,
+      "readme_linha": 2363,
       "tipo_fonte": "privado"
     },
     {
@@ -8444,7 +8469,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2366,
+      "readme_linha": 2370,
       "tipo_fonte": "internacional"
     },
     {
@@ -8470,7 +8495,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2372,
+      "readme_linha": 2376,
       "tipo_fonte": "internacional"
     },
     {
@@ -8495,7 +8520,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2379,
+      "readme_linha": 2383,
       "tipo_fonte": "privado"
     },
     {
@@ -8520,7 +8545,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2385,
+      "readme_linha": 2389,
       "tipo_fonte": "internacional"
     },
     {
@@ -8603,7 +8628,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2398,
+      "readme_linha": 2402,
       "tipo_fonte": "privado"
     },
     {
@@ -8666,7 +8691,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2423,
+      "readme_linha": 2427,
       "tipo_fonte": "privado"
     },
     {
@@ -8689,7 +8714,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2450,
+      "readme_linha": 2454,
       "tipo_fonte": "federal"
     },
     {
@@ -8712,7 +8737,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2456,
+      "readme_linha": 2460,
       "tipo_fonte": "privado"
     },
     {
@@ -8735,7 +8760,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2462,
+      "readme_linha": 2466,
       "tipo_fonte": "federal"
     },
     {
@@ -8758,7 +8783,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2468,
+      "readme_linha": 2472,
       "tipo_fonte": "privado"
     },
     {
@@ -8781,7 +8806,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2474,
+      "readme_linha": 2478,
       "tipo_fonte": "federal"
     },
     {
@@ -8804,7 +8829,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2480,
+      "readme_linha": 2484,
       "tipo_fonte": "federal"
     },
     {
@@ -8827,7 +8852,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2486,
+      "readme_linha": 2490,
       "tipo_fonte": "federal"
     },
     {
@@ -8851,7 +8876,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2492,
+      "readme_linha": 2496,
       "tipo_fonte": "federal"
     },
     {
@@ -8880,7 +8905,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 2496,
+      "readme_linha": 2500,
       "tipo_fonte": "federal"
     },
     {
@@ -8903,7 +8928,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2503,
+      "readme_linha": 2507,
       "tipo_fonte": "federal"
     },
     {
@@ -8926,7 +8951,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2507,
+      "readme_linha": 2511,
       "tipo_fonte": "federal"
     },
     {
@@ -8950,7 +8975,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2513,
+      "readme_linha": 2517,
       "tipo_fonte": "federal"
     },
     {
@@ -8973,7 +8998,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2519,
+      "readme_linha": 2523,
       "tipo_fonte": "estadual"
     },
     {
@@ -8997,7 +9022,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2525,
+      "readme_linha": 2529,
       "tipo_fonte": "estadual"
     },
     {
@@ -9021,7 +9046,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2531,
+      "readme_linha": 2535,
       "tipo_fonte": "federal"
     },
     {
@@ -9044,7 +9069,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2537,
+      "readme_linha": 2541,
       "tipo_fonte": "federal"
     },
     {
@@ -9067,7 +9092,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2543,
+      "readme_linha": 2547,
       "tipo_fonte": "estadual"
     },
     {
@@ -9091,7 +9116,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2549,
+      "readme_linha": 2553,
       "tipo_fonte": "federal"
     },
     {
@@ -9114,7 +9139,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2555,
+      "readme_linha": 2559,
       "tipo_fonte": "estadual"
     },
     {
@@ -9137,7 +9162,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2561,
+      "readme_linha": 2565,
       "tipo_fonte": "estadual"
     },
     {
@@ -9160,7 +9185,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2567,
+      "readme_linha": 2571,
       "tipo_fonte": "federal"
     },
     {
@@ -9183,7 +9208,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2573,
+      "readme_linha": 2577,
       "tipo_fonte": "estadual"
     },
     {
@@ -9206,7 +9231,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2579,
+      "readme_linha": 2583,
       "tipo_fonte": "estadual"
     },
     {
@@ -9229,7 +9254,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2583,
+      "readme_linha": 2587,
       "tipo_fonte": "federal"
     },
     {
@@ -9252,7 +9277,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2589,
+      "readme_linha": 2593,
       "tipo_fonte": "federal"
     },
     {
@@ -9275,7 +9300,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2595,
+      "readme_linha": 2599,
       "tipo_fonte": "estadual"
     },
     {
@@ -9298,7 +9323,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2601,
+      "readme_linha": 2605,
       "tipo_fonte": "federal"
     },
     {
@@ -9326,7 +9351,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2607,
+      "readme_linha": 2611,
       "tipo_fonte": "federal"
     },
     {
@@ -9351,7 +9376,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2614,
+      "readme_linha": 2618,
       "tipo_fonte": "estadual"
     },
     {
@@ -9374,7 +9399,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2618,
+      "readme_linha": 2622,
       "tipo_fonte": "federal"
     },
     {
@@ -9398,7 +9423,7 @@
         "dataset",
         "diario_oficial"
       ],
-      "readme_linha": 2622,
+      "readme_linha": 2626,
       "tipo_fonte": "ong"
     },
     {
@@ -9421,7 +9446,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2628,
+      "readme_linha": 2632,
       "tipo_fonte": "ong"
     },
     {
@@ -9444,7 +9469,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2632,
+      "readme_linha": 2636,
       "tipo_fonte": "federal"
     },
     {
@@ -9467,7 +9492,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2636,
+      "readme_linha": 2640,
       "tipo_fonte": "federal"
     },
     {
@@ -9490,7 +9515,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2640,
+      "readme_linha": 2644,
       "tipo_fonte": "privado"
     },
     {
@@ -9513,7 +9538,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2644,
+      "readme_linha": 2648,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9536,7 +9561,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2648,
+      "readme_linha": 2652,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9560,7 +9585,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2652,
+      "readme_linha": 2656,
       "tipo_fonte": "federal"
     },
     {
@@ -9583,7 +9608,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2656,
+      "readme_linha": 2660,
       "tipo_fonte": "federal"
     },
     {
@@ -9607,7 +9632,7 @@
         "dataset",
         "endereco"
       ],
-      "readme_linha": 2660,
+      "readme_linha": 2664,
       "tipo_fonte": "privado"
     },
     {
@@ -9632,7 +9657,7 @@
         "beneficio",
         "remuneracao"
       ],
-      "readme_linha": 2670,
+      "readme_linha": 2674,
       "tipo_fonte": "ong"
     },
     {
@@ -9656,7 +9681,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2678,
+      "readme_linha": 2682,
       "tipo_fonte": "estadual"
     },
     {
@@ -9680,7 +9705,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2682,
+      "readme_linha": 2686,
       "tipo_fonte": "estadual"
     },
     {
@@ -9779,7 +9804,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2688,
+      "readme_linha": 2692,
       "tipo_fonte": "privado"
     },
     {
@@ -9838,7 +9863,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2711,
+      "readme_linha": 2715,
       "tipo_fonte": "ong"
     },
     {
@@ -9867,7 +9892,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2726,
+      "readme_linha": 2730,
       "tipo_fonte": "privado"
     },
     {
@@ -9891,7 +9916,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2733,
+      "readme_linha": 2737,
       "tipo_fonte": "privado"
     },
     {
@@ -9915,7 +9940,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2739,
+      "readme_linha": 2743,
       "tipo_fonte": "federal"
     },
     {
@@ -9939,7 +9964,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2745,
+      "readme_linha": 2749,
       "tipo_fonte": "federal"
     },
     {
@@ -9964,7 +9989,7 @@
         "veiculo",
         "video_ao_vivo"
       ],
-      "readme_linha": 2751,
+      "readme_linha": 2755,
       "tipo_fonte": "internacional"
     },
     {
@@ -9988,7 +10013,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2755,
+      "readme_linha": 2759,
       "tipo_fonte": "internacional"
     },
     {
@@ -10013,7 +10038,7 @@
         "multa",
         "veiculo"
       ],
-      "readme_linha": 2759,
+      "readme_linha": 2763,
       "tipo_fonte": "federal"
     },
     {
@@ -10039,7 +10064,7 @@
         "dados_cadastrais",
         "veiculo"
       ],
-      "readme_linha": 2763,
+      "readme_linha": 2767,
       "tipo_fonte": "federal"
     },
     {
@@ -10063,7 +10088,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2767,
+      "readme_linha": 2771,
       "tipo_fonte": "federal"
     },
     {
@@ -10087,7 +10112,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2771,
+      "readme_linha": 2775,
       "tipo_fonte": "privado"
     },
     {
@@ -10111,7 +10136,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2777,
+      "readme_linha": 2781,
       "tipo_fonte": "federal"
     },
     {
@@ -10135,7 +10160,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2783,
+      "readme_linha": 2787,
       "tipo_fonte": "federal"
     },
     {
@@ -10160,7 +10185,7 @@
         "dataset",
         "veiculo"
       ],
-      "readme_linha": 2789,
+      "readme_linha": 2793,
       "tipo_fonte": "federal"
     },
     {
@@ -10189,7 +10214,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2795,
+      "readme_linha": 2799,
       "tipo_fonte": "estadual"
     },
     {
@@ -10218,7 +10243,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2802,
+      "readme_linha": 2806,
       "tipo_fonte": "estadual"
     },
     {
@@ -10387,7 +10412,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2809,
+      "readme_linha": 2813,
       "tipo_fonte": "estadual"
     },
     {
@@ -10411,7 +10436,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 2879,
+      "readme_linha": 2883,
       "tipo_fonte": "privado"
     },
     {
@@ -10434,7 +10459,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2885,
+      "readme_linha": 2889,
       "tipo_fonte": "privado"
     },
     {
@@ -10477,7 +10502,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2891,
+      "readme_linha": 2895,
       "tipo_fonte": "estadual"
     },
     {
@@ -10500,7 +10525,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2911,
+      "readme_linha": 2915,
       "tipo_fonte": "privado"
     },
     {
@@ -10523,7 +10548,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2917,
+      "readme_linha": 2921,
       "tipo_fonte": "privado"
     },
     {
@@ -10546,7 +10571,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2923,
+      "readme_linha": 2927,
       "tipo_fonte": "privado"
     },
     {
@@ -10571,7 +10596,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 2935,
+      "readme_linha": 2939,
       "tipo_fonte": "federal"
     },
     {
@@ -10597,7 +10622,7 @@
         "estatistica",
         "multa"
       ],
-      "readme_linha": 2939,
+      "readme_linha": 2943,
       "tipo_fonte": "privado"
     },
     {
@@ -10620,7 +10645,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2943,
+      "readme_linha": 2947,
       "tipo_fonte": "federal"
     },
     {
@@ -10643,7 +10668,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2947,
+      "readme_linha": 2951,
       "tipo_fonte": "federal"
     },
     {
@@ -10666,7 +10691,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2951,
+      "readme_linha": 2955,
       "tipo_fonte": "federal"
     },
     {
@@ -10689,7 +10714,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2955,
+      "readme_linha": 2959,
       "tipo_fonte": "federal"
     },
     {
@@ -10717,7 +10742,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2959,
+      "readme_linha": 2963,
       "tipo_fonte": "internacional"
     },
     {
@@ -10740,7 +10765,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2964,
+      "readme_linha": 2968,
       "tipo_fonte": "privado"
     },
     {
@@ -10763,7 +10788,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2968,
+      "readme_linha": 2972,
       "tipo_fonte": "privado"
     },
     {
@@ -10786,7 +10811,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2972,
+      "readme_linha": 2976,
       "tipo_fonte": "privado"
     },
     {
@@ -10809,7 +10834,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2982,
+      "readme_linha": 2986,
       "tipo_fonte": "federal"
     },
     {
@@ -10835,7 +10860,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 2988,
+      "readme_linha": 2992,
       "tipo_fonte": "privado"
     },
     {
@@ -10858,7 +10883,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2994,
+      "readme_linha": 2998,
       "tipo_fonte": "federal"
     },
     {
@@ -10883,7 +10908,7 @@
         "dados_cadastrais",
         "multa"
       ],
-      "readme_linha": 3000,
+      "readme_linha": 3004,
       "tipo_fonte": "federal"
     },
     {
@@ -10961,7 +10986,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3004,
+      "readme_linha": 3008,
       "tipo_fonte": "federal"
     },
     {
@@ -10984,7 +11009,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3032,
+      "readme_linha": 3036,
       "tipo_fonte": "estadual"
     },
     {
@@ -11007,7 +11032,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3038,
+      "readme_linha": 3042,
       "tipo_fonte": "privado"
     },
     {
@@ -11030,7 +11055,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3042,
+      "readme_linha": 3046,
       "tipo_fonte": "estadual"
     },
     {
@@ -11053,7 +11078,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3046,
+      "readme_linha": 3050,
       "tipo_fonte": "internacional"
     },
     {
@@ -11096,7 +11121,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3050,
+      "readme_linha": 3054,
       "tipo_fonte": "privado"
     },
     {
@@ -11144,7 +11169,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3065,
+      "readme_linha": 3069,
       "tipo_fonte": "privado"
     },
     {
@@ -11247,7 +11272,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3079,
+      "readme_linha": 3083,
       "tipo_fonte": "privado"
     },
     {
@@ -11270,7 +11295,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3120,
+      "readme_linha": 3124,
       "tipo_fonte": "privado"
     },
     {
@@ -11318,7 +11343,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3124,
+      "readme_linha": 3128,
       "tipo_fonte": "estadual"
     },
     {
@@ -11641,7 +11666,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3138,
+      "readme_linha": 3142,
       "tipo_fonte": "privado"
     },
     {
@@ -11664,7 +11689,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3213,
+      "readme_linha": 3217,
       "tipo_fonte": "privado"
     },
     {
@@ -11687,7 +11712,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3217,
+      "readme_linha": 3221,
       "tipo_fonte": "privado"
     },
     {
@@ -11710,7 +11735,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3221,
+      "readme_linha": 3225,
       "tipo_fonte": "estadual"
     },
     {
@@ -11733,7 +11758,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3225,
+      "readme_linha": 3229,
       "tipo_fonte": "federal"
     },
     {
@@ -11762,7 +11787,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3229,
+      "readme_linha": 3233,
       "tipo_fonte": "internacional"
     },
     {
@@ -11786,7 +11811,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3234,
+      "readme_linha": 3238,
       "tipo_fonte": "internacional"
     },
     {
@@ -11810,7 +11835,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3238,
+      "readme_linha": 3242,
       "tipo_fonte": "internacional"
     },
     {
@@ -11834,7 +11859,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3242,
+      "readme_linha": 3246,
       "tipo_fonte": "internacional"
     },
     {
@@ -11858,7 +11883,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3246,
+      "readme_linha": 3250,
       "tipo_fonte": "internacional"
     },
     {
@@ -11882,7 +11907,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3250,
+      "readme_linha": 3254,
       "tipo_fonte": "internacional"
     },
     {
@@ -11906,7 +11931,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3254,
+      "readme_linha": 3258,
       "tipo_fonte": "internacional"
     },
     {
@@ -11930,7 +11955,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3258,
+      "readme_linha": 3262,
       "tipo_fonte": "internacional"
     },
     {
@@ -11953,7 +11978,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3262,
+      "readme_linha": 3266,
       "tipo_fonte": "estadual"
     },
     {
@@ -12027,7 +12052,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3272,
+      "readme_linha": 3276,
       "tipo_fonte": "ministerio_publico"
     },
     {
@@ -12087,7 +12112,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3313,
+      "readme_linha": 3317,
       "tipo_fonte": "defensoria"
     },
     {
@@ -12121,7 +12146,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3345,
+      "readme_linha": 3349,
       "tipo_fonte": "ong"
     },
     {
@@ -12150,7 +12175,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3362,
+      "readme_linha": 3366,
       "tipo_fonte": "estadual"
     },
     {
@@ -12179,7 +12204,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3382,
+      "readme_linha": 3386,
       "tipo_fonte": "privado"
     },
     {
@@ -12228,7 +12253,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3387,
+      "readme_linha": 3391,
       "tipo_fonte": "estadual"
     },
     {
@@ -12253,7 +12278,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 3406,
+      "readme_linha": 3410,
       "tipo_fonte": "federal"
     },
     {
@@ -12278,7 +12303,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3410,
+      "readme_linha": 3414,
       "tipo_fonte": "ong"
     },
     {
@@ -12303,7 +12328,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3414,
+      "readme_linha": 3418,
       "tipo_fonte": "federal"
     },
     {
@@ -12326,7 +12351,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3418,
+      "readme_linha": 3422,
       "tipo_fonte": "privado"
     },
     {
@@ -12351,7 +12376,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3422,
+      "readme_linha": 3426,
       "tipo_fonte": "federal"
     },
     {
@@ -12374,7 +12399,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3426,
+      "readme_linha": 3430,
       "tipo_fonte": "federal"
     },
     {
@@ -12395,7 +12420,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3430,
+      "readme_linha": 3434,
       "tipo_fonte": "federal"
     },
     {
@@ -12423,7 +12448,7 @@
         "mandado_prisao",
         "veiculo"
       ],
-      "readme_linha": 3434,
+      "readme_linha": 3438,
       "tipo_fonte": "federal"
     },
     {
@@ -12464,7 +12489,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3443,
+      "readme_linha": 3447,
       "tipo_fonte": "privado"
     },
     {
@@ -12495,7 +12520,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3462,
+      "readme_linha": 3466,
       "tipo_fonte": "privado"
     },
     {
@@ -12524,7 +12549,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3476,
+      "readme_linha": 3480,
       "tipo_fonte": "privado"
     },
     {
@@ -12552,7 +12577,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3503,
+      "readme_linha": 3507,
       "tipo_fonte": "privado"
     },
     {
@@ -12582,7 +12607,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3525,
+      "readme_linha": 3529,
       "tipo_fonte": "privado"
     },
     {
@@ -12609,7 +12634,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3549,
+      "readme_linha": 3553,
       "tipo_fonte": "federal"
     },
     {
@@ -12636,7 +12661,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3572,
+      "readme_linha": 3576,
       "tipo_fonte": "federal"
     },
     {
@@ -12666,7 +12691,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3576,
+      "readme_linha": 3580,
       "tipo_fonte": "ong"
     },
     {
@@ -12692,7 +12717,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3599,
+      "readme_linha": 3603,
       "tipo_fonte": "federal"
     },
     {
@@ -12716,7 +12741,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3603,
+      "readme_linha": 3607,
       "tipo_fonte": "federal"
     },
     {
@@ -12739,7 +12764,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3613,
+      "readme_linha": 3617,
       "tipo_fonte": "federal"
     },
     {
@@ -12762,7 +12787,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3617,
+      "readme_linha": 3621,
       "tipo_fonte": "federal"
     },
     {
@@ -12791,7 +12816,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3621,
+      "readme_linha": 3625,
       "tipo_fonte": "federal"
     },
     {
@@ -12819,7 +12844,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3626,
+      "readme_linha": 3630,
       "tipo_fonte": "federal"
     },
     {
@@ -12842,7 +12867,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3631,
+      "readme_linha": 3635,
       "tipo_fonte": "federal"
     },
     {
@@ -12865,7 +12890,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3635,
+      "readme_linha": 3639,
       "tipo_fonte": "federal"
     },
     {
@@ -12894,7 +12919,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3645,
+      "readme_linha": 3649,
       "tipo_fonte": "federal"
     },
     {
@@ -12918,7 +12943,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3650,
+      "readme_linha": 3654,
       "tipo_fonte": "federal"
     },
     {
@@ -12942,7 +12967,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3654,
+      "readme_linha": 3658,
       "tipo_fonte": "federal"
     },
     {
@@ -12972,7 +12997,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3658,
+      "readme_linha": 3662,
       "tipo_fonte": "ong"
     },
     {
@@ -13002,7 +13027,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3663,
+      "readme_linha": 3667,
       "tipo_fonte": "federal"
     },
     {
@@ -13027,7 +13052,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3668,
+      "readme_linha": 3672,
       "tipo_fonte": "federal"
     },
     {
@@ -13051,7 +13076,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3672,
+      "readme_linha": 3676,
       "tipo_fonte": "federal"
     },
     {
@@ -13075,7 +13100,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3676,
+      "readme_linha": 3680,
       "tipo_fonte": "federal"
     },
     {
@@ -13130,7 +13155,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3686,
+      "readme_linha": 3690,
       "tipo_fonte": "ong"
     },
     {
@@ -13254,7 +13279,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3725,
+      "readme_linha": 3729,
       "tipo_fonte": "estadual"
     },
     {
@@ -13374,7 +13399,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3766,
+      "readme_linha": 3770,
       "tipo_fonte": "ong"
     },
     {
@@ -13408,7 +13433,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3795,
+      "readme_linha": 3799,
       "tipo_fonte": "estadual"
     },
     {
@@ -13434,7 +13459,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3807,
+      "readme_linha": 3811,
       "tipo_fonte": "estadual"
     },
     {
@@ -13460,7 +13485,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3811,
+      "readme_linha": 3815,
       "tipo_fonte": "estadual"
     },
     {
@@ -13484,7 +13509,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3815,
+      "readme_linha": 3819,
       "tipo_fonte": "estadual"
     },
     {
@@ -13507,7 +13532,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3825,
+      "readme_linha": 3829,
       "tipo_fonte": "ong"
     },
     {
@@ -13530,7 +13555,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3829,
+      "readme_linha": 3833,
       "tipo_fonte": "federal"
     },
     {
@@ -13554,7 +13579,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3833,
+      "readme_linha": 3837,
       "tipo_fonte": "ong"
     },
     {
@@ -13577,7 +13602,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3837,
+      "readme_linha": 3841,
       "tipo_fonte": "federal"
     },
     {
@@ -13600,7 +13625,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3841,
+      "readme_linha": 3845,
       "tipo_fonte": "federal"
     },
     {
@@ -13628,7 +13653,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3845,
+      "readme_linha": 3849,
       "tipo_fonte": "privado"
     },
     {
@@ -13716,7 +13741,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3857,
+      "readme_linha": 3861,
       "tipo_fonte": "privado"
     },
     {
@@ -13767,7 +13792,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3879,
+      "readme_linha": 3883,
       "tipo_fonte": "privado"
     },
     {
@@ -13790,7 +13815,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3892,
+      "readme_linha": 3896,
       "tipo_fonte": "estadual"
     },
     {
@@ -13823,7 +13848,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3898,
+      "readme_linha": 3902,
       "tipo_fonte": "privado"
     },
     {
@@ -13847,7 +13872,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3909,
+      "readme_linha": 3913,
       "tipo_fonte": "privado"
     },
     {
@@ -13870,7 +13895,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3913,
+      "readme_linha": 3917,
       "tipo_fonte": "federal"
     },
     {
@@ -13904,7 +13929,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3919,
+      "readme_linha": 3923,
       "tipo_fonte": "privado"
     },
     {
@@ -13990,7 +14015,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3929,
+      "readme_linha": 3933,
       "tipo_fonte": "privado"
     },
     {
@@ -14014,7 +14039,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3978,
+      "readme_linha": 3982,
       "tipo_fonte": "estadual"
     },
     {
@@ -14048,9 +14073,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4141,
+      "readme_linha": 4145,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 446
+  "total": 447
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -3372,6 +3372,11 @@
           "label": "",
           "uf": null,
           "url": "https://portaldatransparencia.gov.br/api-de-dados"
+        },
+        {
+          "label": "1. Acesse",
+          "uf": null,
+          "url": "https://portaldatransparencia.gov.br/api-de-dados"
         }
       ],
       "nome": "Portal da Transparência - API de Dados",
@@ -3408,7 +3413,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1040,
+      "readme_linha": 1077,
       "tipo_fonte": "federal"
     },
     {
@@ -3435,7 +3440,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1044,
+      "readme_linha": 1081,
       "tipo_fonte": "federal"
     },
     {
@@ -3461,7 +3466,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1048,
+      "readme_linha": 1085,
       "tipo_fonte": "federal"
     },
     {
@@ -3487,7 +3492,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1052,
+      "readme_linha": 1089,
       "tipo_fonte": "federal"
     },
     {
@@ -3515,7 +3520,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1056,
+      "readme_linha": 1093,
       "tipo_fonte": "federal"
     },
     {
@@ -3533,11 +3538,6 @@
           "label": "",
           "uf": null,
           "url": "https://pesquisa.apps.tcu.gov.br/"
-        },
-        {
-          "label": "1. Acesse",
-          "uf": null,
-          "url": "https://portaldatransparencia.gov.br/api-de-dados"
         }
       ],
       "nome": "TCU - Consulta de Acórdãos",
@@ -3546,7 +3546,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1060,
+      "readme_linha": 1097,
       "tipo_fonte": "federal"
     },
     {

--- a/data/sources.json
+++ b/data/sources.json
@@ -8813,6 +8813,29 @@
       "categoria": "Datasets / Dados Abertos",
       "categoria_id": "datasets-dados-abertos",
       "classificacao": "heuristica",
+      "descricao": "Relatórios do Banco Central com dados contábeis e prudenciais das instituições financeiras, por data-base, tipo de instituição e tipo de relatório.",
+      "id": "datasets-dados-abertos/if-data-dados-selecionados-de-instituicoes-financeiras",
+      "input": [
+        "nenhum"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://www3.bcb.gov.br/ifdata/"
+        }
+      ],
+      "nome": "IF.data - Dados Selecionados de Instituições Financeiras",
+      "output": [
+        "dataset"
+      ],
+      "readme_linha": 2484,
+      "tipo_fonte": "federal"
+    },
+    {
+      "categoria": "Datasets / Dados Abertos",
+      "categoria_id": "datasets-dados-abertos",
+      "classificacao": "heuristica",
       "descricao": "O Plano de Dados Abertos do MTur abrange os setores do turismo e da cultura, e é o documento orientador para as ações de implementação e promoção de abertura de dados produzidos ou que estão sob a responsabilidade do Ministério do Turismo (MTur)",
       "id": "datasets-dados-abertos/dados-mtur-ministerio-do-meio-ambiente-e-mudanca-do-clima",
       "input": [
@@ -8829,7 +8852,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2484,
+      "readme_linha": 2488,
       "tipo_fonte": "federal"
     },
     {
@@ -8852,7 +8875,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2490,
+      "readme_linha": 2494,
       "tipo_fonte": "federal"
     },
     {
@@ -8876,7 +8899,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2496,
+      "readme_linha": 2500,
       "tipo_fonte": "federal"
     },
     {
@@ -8905,7 +8928,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 2500,
+      "readme_linha": 2504,
       "tipo_fonte": "federal"
     },
     {
@@ -8928,7 +8951,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2507,
+      "readme_linha": 2511,
       "tipo_fonte": "federal"
     },
     {
@@ -8951,7 +8974,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2511,
+      "readme_linha": 2515,
       "tipo_fonte": "federal"
     },
     {
@@ -8975,7 +8998,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2517,
+      "readme_linha": 2521,
       "tipo_fonte": "federal"
     },
     {
@@ -8998,7 +9021,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2523,
+      "readme_linha": 2527,
       "tipo_fonte": "estadual"
     },
     {
@@ -9022,7 +9045,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2529,
+      "readme_linha": 2533,
       "tipo_fonte": "estadual"
     },
     {
@@ -9046,7 +9069,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2535,
+      "readme_linha": 2539,
       "tipo_fonte": "federal"
     },
     {
@@ -9069,7 +9092,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2541,
+      "readme_linha": 2545,
       "tipo_fonte": "federal"
     },
     {
@@ -9092,7 +9115,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2547,
+      "readme_linha": 2551,
       "tipo_fonte": "estadual"
     },
     {
@@ -9116,7 +9139,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2553,
+      "readme_linha": 2557,
       "tipo_fonte": "federal"
     },
     {
@@ -9139,7 +9162,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2559,
+      "readme_linha": 2563,
       "tipo_fonte": "estadual"
     },
     {
@@ -9162,7 +9185,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2565,
+      "readme_linha": 2569,
       "tipo_fonte": "estadual"
     },
     {
@@ -9185,7 +9208,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2571,
+      "readme_linha": 2575,
       "tipo_fonte": "federal"
     },
     {
@@ -9208,7 +9231,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2577,
+      "readme_linha": 2581,
       "tipo_fonte": "estadual"
     },
     {
@@ -9231,7 +9254,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2583,
+      "readme_linha": 2587,
       "tipo_fonte": "estadual"
     },
     {
@@ -9254,7 +9277,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2587,
+      "readme_linha": 2591,
       "tipo_fonte": "federal"
     },
     {
@@ -9277,7 +9300,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2593,
+      "readme_linha": 2597,
       "tipo_fonte": "federal"
     },
     {
@@ -9300,7 +9323,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2599,
+      "readme_linha": 2603,
       "tipo_fonte": "estadual"
     },
     {
@@ -9323,7 +9346,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2605,
+      "readme_linha": 2609,
       "tipo_fonte": "federal"
     },
     {
@@ -9351,7 +9374,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2611,
+      "readme_linha": 2615,
       "tipo_fonte": "federal"
     },
     {
@@ -9376,7 +9399,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2618,
+      "readme_linha": 2622,
       "tipo_fonte": "estadual"
     },
     {
@@ -9399,7 +9422,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2622,
+      "readme_linha": 2626,
       "tipo_fonte": "federal"
     },
     {
@@ -9423,7 +9446,7 @@
         "dataset",
         "diario_oficial"
       ],
-      "readme_linha": 2626,
+      "readme_linha": 2630,
       "tipo_fonte": "ong"
     },
     {
@@ -9446,7 +9469,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2632,
+      "readme_linha": 2636,
       "tipo_fonte": "ong"
     },
     {
@@ -9469,7 +9492,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2636,
+      "readme_linha": 2640,
       "tipo_fonte": "federal"
     },
     {
@@ -9492,7 +9515,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2640,
+      "readme_linha": 2644,
       "tipo_fonte": "federal"
     },
     {
@@ -9515,7 +9538,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2644,
+      "readme_linha": 2648,
       "tipo_fonte": "privado"
     },
     {
@@ -9538,7 +9561,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2648,
+      "readme_linha": 2652,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9561,7 +9584,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2652,
+      "readme_linha": 2656,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9585,7 +9608,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2656,
+      "readme_linha": 2660,
       "tipo_fonte": "federal"
     },
     {
@@ -9608,7 +9631,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2660,
+      "readme_linha": 2664,
       "tipo_fonte": "federal"
     },
     {
@@ -9632,7 +9655,7 @@
         "dataset",
         "endereco"
       ],
-      "readme_linha": 2664,
+      "readme_linha": 2668,
       "tipo_fonte": "privado"
     },
     {
@@ -9657,7 +9680,7 @@
         "beneficio",
         "remuneracao"
       ],
-      "readme_linha": 2674,
+      "readme_linha": 2678,
       "tipo_fonte": "ong"
     },
     {
@@ -9681,7 +9704,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2682,
+      "readme_linha": 2686,
       "tipo_fonte": "estadual"
     },
     {
@@ -9705,7 +9728,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2686,
+      "readme_linha": 2690,
       "tipo_fonte": "estadual"
     },
     {
@@ -9804,7 +9827,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2692,
+      "readme_linha": 2696,
       "tipo_fonte": "privado"
     },
     {
@@ -9863,7 +9886,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2715,
+      "readme_linha": 2719,
       "tipo_fonte": "ong"
     },
     {
@@ -9892,7 +9915,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2730,
+      "readme_linha": 2734,
       "tipo_fonte": "privado"
     },
     {
@@ -9916,7 +9939,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2737,
+      "readme_linha": 2741,
       "tipo_fonte": "privado"
     },
     {
@@ -9940,7 +9963,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2743,
+      "readme_linha": 2747,
       "tipo_fonte": "federal"
     },
     {
@@ -9964,7 +9987,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2749,
+      "readme_linha": 2753,
       "tipo_fonte": "federal"
     },
     {
@@ -9989,7 +10012,7 @@
         "veiculo",
         "video_ao_vivo"
       ],
-      "readme_linha": 2755,
+      "readme_linha": 2759,
       "tipo_fonte": "internacional"
     },
     {
@@ -10013,7 +10036,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2759,
+      "readme_linha": 2763,
       "tipo_fonte": "internacional"
     },
     {
@@ -10038,7 +10061,7 @@
         "multa",
         "veiculo"
       ],
-      "readme_linha": 2763,
+      "readme_linha": 2767,
       "tipo_fonte": "federal"
     },
     {
@@ -10064,7 +10087,7 @@
         "dados_cadastrais",
         "veiculo"
       ],
-      "readme_linha": 2767,
+      "readme_linha": 2771,
       "tipo_fonte": "federal"
     },
     {
@@ -10088,7 +10111,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2771,
+      "readme_linha": 2775,
       "tipo_fonte": "federal"
     },
     {
@@ -10112,7 +10135,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2775,
+      "readme_linha": 2779,
       "tipo_fonte": "privado"
     },
     {
@@ -10136,7 +10159,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2781,
+      "readme_linha": 2785,
       "tipo_fonte": "federal"
     },
     {
@@ -10160,7 +10183,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2787,
+      "readme_linha": 2791,
       "tipo_fonte": "federal"
     },
     {
@@ -10185,7 +10208,7 @@
         "dataset",
         "veiculo"
       ],
-      "readme_linha": 2793,
+      "readme_linha": 2797,
       "tipo_fonte": "federal"
     },
     {
@@ -10214,7 +10237,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2799,
+      "readme_linha": 2803,
       "tipo_fonte": "estadual"
     },
     {
@@ -10243,7 +10266,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2806,
+      "readme_linha": 2810,
       "tipo_fonte": "estadual"
     },
     {
@@ -10412,7 +10435,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2813,
+      "readme_linha": 2817,
       "tipo_fonte": "estadual"
     },
     {
@@ -10436,7 +10459,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 2883,
+      "readme_linha": 2887,
       "tipo_fonte": "privado"
     },
     {
@@ -10459,7 +10482,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2889,
+      "readme_linha": 2893,
       "tipo_fonte": "privado"
     },
     {
@@ -10502,7 +10525,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2895,
+      "readme_linha": 2899,
       "tipo_fonte": "estadual"
     },
     {
@@ -10525,7 +10548,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2915,
+      "readme_linha": 2919,
       "tipo_fonte": "privado"
     },
     {
@@ -10548,7 +10571,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2921,
+      "readme_linha": 2925,
       "tipo_fonte": "privado"
     },
     {
@@ -10571,7 +10594,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2927,
+      "readme_linha": 2931,
       "tipo_fonte": "privado"
     },
     {
@@ -10596,7 +10619,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 2939,
+      "readme_linha": 2943,
       "tipo_fonte": "federal"
     },
     {
@@ -10622,7 +10645,7 @@
         "estatistica",
         "multa"
       ],
-      "readme_linha": 2943,
+      "readme_linha": 2947,
       "tipo_fonte": "privado"
     },
     {
@@ -10645,7 +10668,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2947,
+      "readme_linha": 2951,
       "tipo_fonte": "federal"
     },
     {
@@ -10668,7 +10691,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2951,
+      "readme_linha": 2955,
       "tipo_fonte": "federal"
     },
     {
@@ -10691,7 +10714,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2955,
+      "readme_linha": 2959,
       "tipo_fonte": "federal"
     },
     {
@@ -10714,7 +10737,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2959,
+      "readme_linha": 2963,
       "tipo_fonte": "federal"
     },
     {
@@ -10742,7 +10765,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2963,
+      "readme_linha": 2967,
       "tipo_fonte": "internacional"
     },
     {
@@ -10765,7 +10788,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2968,
+      "readme_linha": 2972,
       "tipo_fonte": "privado"
     },
     {
@@ -10788,7 +10811,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2972,
+      "readme_linha": 2976,
       "tipo_fonte": "privado"
     },
     {
@@ -10811,7 +10834,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2976,
+      "readme_linha": 2980,
       "tipo_fonte": "privado"
     },
     {
@@ -10834,7 +10857,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2986,
+      "readme_linha": 2990,
       "tipo_fonte": "federal"
     },
     {
@@ -10860,7 +10883,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 2992,
+      "readme_linha": 2996,
       "tipo_fonte": "privado"
     },
     {
@@ -10883,7 +10906,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2998,
+      "readme_linha": 3002,
       "tipo_fonte": "federal"
     },
     {
@@ -10908,7 +10931,7 @@
         "dados_cadastrais",
         "multa"
       ],
-      "readme_linha": 3004,
+      "readme_linha": 3008,
       "tipo_fonte": "federal"
     },
     {
@@ -10986,7 +11009,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3008,
+      "readme_linha": 3012,
       "tipo_fonte": "federal"
     },
     {
@@ -11009,7 +11032,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3036,
+      "readme_linha": 3040,
       "tipo_fonte": "estadual"
     },
     {
@@ -11032,7 +11055,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3042,
+      "readme_linha": 3046,
       "tipo_fonte": "privado"
     },
     {
@@ -11055,7 +11078,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3046,
+      "readme_linha": 3050,
       "tipo_fonte": "estadual"
     },
     {
@@ -11078,7 +11101,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3050,
+      "readme_linha": 3054,
       "tipo_fonte": "internacional"
     },
     {
@@ -11121,7 +11144,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3054,
+      "readme_linha": 3058,
       "tipo_fonte": "privado"
     },
     {
@@ -11169,7 +11192,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3069,
+      "readme_linha": 3073,
       "tipo_fonte": "privado"
     },
     {
@@ -11272,7 +11295,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3083,
+      "readme_linha": 3087,
       "tipo_fonte": "privado"
     },
     {
@@ -11295,7 +11318,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3124,
+      "readme_linha": 3128,
       "tipo_fonte": "privado"
     },
     {
@@ -11343,7 +11366,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3128,
+      "readme_linha": 3132,
       "tipo_fonte": "estadual"
     },
     {
@@ -11666,7 +11689,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3142,
+      "readme_linha": 3146,
       "tipo_fonte": "privado"
     },
     {
@@ -11689,7 +11712,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3217,
+      "readme_linha": 3221,
       "tipo_fonte": "privado"
     },
     {
@@ -11712,7 +11735,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3221,
+      "readme_linha": 3225,
       "tipo_fonte": "privado"
     },
     {
@@ -11735,7 +11758,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3225,
+      "readme_linha": 3229,
       "tipo_fonte": "estadual"
     },
     {
@@ -11758,7 +11781,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3229,
+      "readme_linha": 3233,
       "tipo_fonte": "federal"
     },
     {
@@ -11787,7 +11810,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3233,
+      "readme_linha": 3237,
       "tipo_fonte": "internacional"
     },
     {
@@ -11811,7 +11834,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3238,
+      "readme_linha": 3242,
       "tipo_fonte": "internacional"
     },
     {
@@ -11835,7 +11858,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3242,
+      "readme_linha": 3246,
       "tipo_fonte": "internacional"
     },
     {
@@ -11859,7 +11882,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3246,
+      "readme_linha": 3250,
       "tipo_fonte": "internacional"
     },
     {
@@ -11883,7 +11906,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3250,
+      "readme_linha": 3254,
       "tipo_fonte": "internacional"
     },
     {
@@ -11907,7 +11930,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3254,
+      "readme_linha": 3258,
       "tipo_fonte": "internacional"
     },
     {
@@ -11931,7 +11954,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3258,
+      "readme_linha": 3262,
       "tipo_fonte": "internacional"
     },
     {
@@ -11955,7 +11978,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3262,
+      "readme_linha": 3266,
       "tipo_fonte": "internacional"
     },
     {
@@ -11978,7 +12001,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3266,
+      "readme_linha": 3270,
       "tipo_fonte": "estadual"
     },
     {
@@ -12052,7 +12075,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3276,
+      "readme_linha": 3280,
       "tipo_fonte": "ministerio_publico"
     },
     {
@@ -12112,7 +12135,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3317,
+      "readme_linha": 3321,
       "tipo_fonte": "defensoria"
     },
     {
@@ -12146,7 +12169,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3349,
+      "readme_linha": 3353,
       "tipo_fonte": "ong"
     },
     {
@@ -12175,7 +12198,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3366,
+      "readme_linha": 3370,
       "tipo_fonte": "estadual"
     },
     {
@@ -12204,7 +12227,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3386,
+      "readme_linha": 3390,
       "tipo_fonte": "privado"
     },
     {
@@ -12253,7 +12276,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3391,
+      "readme_linha": 3395,
       "tipo_fonte": "estadual"
     },
     {
@@ -12278,7 +12301,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 3410,
+      "readme_linha": 3414,
       "tipo_fonte": "federal"
     },
     {
@@ -12303,7 +12326,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3414,
+      "readme_linha": 3418,
       "tipo_fonte": "ong"
     },
     {
@@ -12328,7 +12351,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3418,
+      "readme_linha": 3422,
       "tipo_fonte": "federal"
     },
     {
@@ -12351,7 +12374,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3422,
+      "readme_linha": 3426,
       "tipo_fonte": "privado"
     },
     {
@@ -12376,7 +12399,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3426,
+      "readme_linha": 3430,
       "tipo_fonte": "federal"
     },
     {
@@ -12399,7 +12422,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3430,
+      "readme_linha": 3434,
       "tipo_fonte": "federal"
     },
     {
@@ -12420,7 +12443,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3434,
+      "readme_linha": 3438,
       "tipo_fonte": "federal"
     },
     {
@@ -12448,7 +12471,7 @@
         "mandado_prisao",
         "veiculo"
       ],
-      "readme_linha": 3438,
+      "readme_linha": 3442,
       "tipo_fonte": "federal"
     },
     {
@@ -12489,7 +12512,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3447,
+      "readme_linha": 3451,
       "tipo_fonte": "privado"
     },
     {
@@ -12520,7 +12543,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3466,
+      "readme_linha": 3470,
       "tipo_fonte": "privado"
     },
     {
@@ -12549,7 +12572,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3480,
+      "readme_linha": 3484,
       "tipo_fonte": "privado"
     },
     {
@@ -12577,7 +12600,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3507,
+      "readme_linha": 3511,
       "tipo_fonte": "privado"
     },
     {
@@ -12607,7 +12630,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3529,
+      "readme_linha": 3533,
       "tipo_fonte": "privado"
     },
     {
@@ -12634,7 +12657,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3553,
+      "readme_linha": 3557,
       "tipo_fonte": "federal"
     },
     {
@@ -12661,7 +12684,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3576,
+      "readme_linha": 3580,
       "tipo_fonte": "federal"
     },
     {
@@ -12691,7 +12714,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3580,
+      "readme_linha": 3584,
       "tipo_fonte": "ong"
     },
     {
@@ -12717,7 +12740,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3603,
+      "readme_linha": 3607,
       "tipo_fonte": "federal"
     },
     {
@@ -12741,7 +12764,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3607,
+      "readme_linha": 3611,
       "tipo_fonte": "federal"
     },
     {
@@ -12764,7 +12787,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3617,
+      "readme_linha": 3621,
       "tipo_fonte": "federal"
     },
     {
@@ -12787,7 +12810,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3621,
+      "readme_linha": 3625,
       "tipo_fonte": "federal"
     },
     {
@@ -12816,7 +12839,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3625,
+      "readme_linha": 3629,
       "tipo_fonte": "federal"
     },
     {
@@ -12844,7 +12867,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3630,
+      "readme_linha": 3634,
       "tipo_fonte": "federal"
     },
     {
@@ -12867,7 +12890,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3635,
+      "readme_linha": 3639,
       "tipo_fonte": "federal"
     },
     {
@@ -12890,7 +12913,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3639,
+      "readme_linha": 3643,
       "tipo_fonte": "federal"
     },
     {
@@ -12919,7 +12942,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3649,
+      "readme_linha": 3653,
       "tipo_fonte": "federal"
     },
     {
@@ -12943,7 +12966,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3654,
+      "readme_linha": 3658,
       "tipo_fonte": "federal"
     },
     {
@@ -12967,7 +12990,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3658,
+      "readme_linha": 3662,
       "tipo_fonte": "federal"
     },
     {
@@ -12997,7 +13020,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3662,
+      "readme_linha": 3666,
       "tipo_fonte": "ong"
     },
     {
@@ -13027,7 +13050,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3667,
+      "readme_linha": 3671,
       "tipo_fonte": "federal"
     },
     {
@@ -13052,7 +13075,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3672,
+      "readme_linha": 3676,
       "tipo_fonte": "federal"
     },
     {
@@ -13076,7 +13099,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3676,
+      "readme_linha": 3680,
       "tipo_fonte": "federal"
     },
     {
@@ -13100,7 +13123,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3680,
+      "readme_linha": 3684,
       "tipo_fonte": "federal"
     },
     {
@@ -13155,7 +13178,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3690,
+      "readme_linha": 3694,
       "tipo_fonte": "ong"
     },
     {
@@ -13279,7 +13302,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3729,
+      "readme_linha": 3733,
       "tipo_fonte": "estadual"
     },
     {
@@ -13399,7 +13422,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3770,
+      "readme_linha": 3774,
       "tipo_fonte": "ong"
     },
     {
@@ -13433,7 +13456,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3799,
+      "readme_linha": 3803,
       "tipo_fonte": "estadual"
     },
     {
@@ -13459,7 +13482,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3811,
+      "readme_linha": 3815,
       "tipo_fonte": "estadual"
     },
     {
@@ -13485,7 +13508,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3815,
+      "readme_linha": 3819,
       "tipo_fonte": "estadual"
     },
     {
@@ -13509,7 +13532,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3819,
+      "readme_linha": 3823,
       "tipo_fonte": "estadual"
     },
     {
@@ -13532,7 +13555,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3829,
+      "readme_linha": 3833,
       "tipo_fonte": "ong"
     },
     {
@@ -13555,7 +13578,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3833,
+      "readme_linha": 3837,
       "tipo_fonte": "federal"
     },
     {
@@ -13579,7 +13602,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3837,
+      "readme_linha": 3841,
       "tipo_fonte": "ong"
     },
     {
@@ -13602,7 +13625,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3841,
+      "readme_linha": 3845,
       "tipo_fonte": "federal"
     },
     {
@@ -13625,7 +13648,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3845,
+      "readme_linha": 3849,
       "tipo_fonte": "federal"
     },
     {
@@ -13653,7 +13676,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3849,
+      "readme_linha": 3853,
       "tipo_fonte": "privado"
     },
     {
@@ -13741,7 +13764,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3861,
+      "readme_linha": 3865,
       "tipo_fonte": "privado"
     },
     {
@@ -13792,7 +13815,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3883,
+      "readme_linha": 3887,
       "tipo_fonte": "privado"
     },
     {
@@ -13815,7 +13838,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3896,
+      "readme_linha": 3900,
       "tipo_fonte": "estadual"
     },
     {
@@ -13848,7 +13871,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3902,
+      "readme_linha": 3906,
       "tipo_fonte": "privado"
     },
     {
@@ -13872,7 +13895,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3913,
+      "readme_linha": 3917,
       "tipo_fonte": "privado"
     },
     {
@@ -13895,7 +13918,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3917,
+      "readme_linha": 3921,
       "tipo_fonte": "federal"
     },
     {
@@ -13929,7 +13952,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3923,
+      "readme_linha": 3927,
       "tipo_fonte": "privado"
     },
     {
@@ -14015,7 +14038,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3933,
+      "readme_linha": 3937,
       "tipo_fonte": "privado"
     },
     {
@@ -14039,7 +14062,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3982,
+      "readme_linha": 3986,
       "tipo_fonte": "estadual"
     },
     {
@@ -14073,9 +14096,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4145,
+      "readme_linha": 4149,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 447
+  "total": 448
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -3552,6 +3552,73 @@
     {
       "categoria": "Transparência Pública e Defesa do Consumidor",
       "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "classificacao": "override",
+      "descricao": "Emissão de certidões do Tribunal de Contas da União por CPF ou CNPJ (contas julgadas irregulares, inabilitados, licitantes inidôneos e processos) e listas públicas pesquisáveis por nome, CPF/CNPJ, UF e município, com download em CSV. A lista eleitoral cobre as eleições de 2014 a 2026.",
+      "id": "transparencia-publica-e-defesa-do-consumidor/tcu-plataforma-de-certidoes",
+      "input": [
+        "cnpj",
+        "cpf",
+        "municipio",
+        "nome",
+        "uf"
+      ],
+      "links": [
+        {
+          "label": "Certidão de contas julgadas irregulares",
+          "uf": null,
+          "url": "https://certidoes.apps.tcu.gov.br/emitir-certidao-contas-julgadas-irregulares"
+        },
+        {
+          "label": "Certidão de inabilitados para função pública",
+          "uf": "PA",
+          "url": "https://certidoes.apps.tcu.gov.br/emitir-certidao-inabilitados"
+        },
+        {
+          "label": "Certidão de licitante inidôneo",
+          "uf": null,
+          "url": "https://certidoes.apps.tcu.gov.br/emitir-certidao-inidoneos"
+        },
+        {
+          "label": "Certidão de processos",
+          "uf": null,
+          "url": "https://certidoes.apps.tcu.gov.br/emitir-certidao-processos"
+        },
+        {
+          "label": "Lista eleitoral de contas julgadas irregulares",
+          "uf": null,
+          "url": "https://certidoes.apps.tcu.gov.br/lista-implicacao-eleitoral"
+        },
+        {
+          "label": "Lista de contas julgadas irregulares",
+          "uf": null,
+          "url": "https://certidoes.apps.tcu.gov.br/lista-responsaveis"
+        },
+        {
+          "label": "Lista de inabilitados",
+          "uf": null,
+          "url": "https://certidoes.apps.tcu.gov.br/lista-inabilitados"
+        },
+        {
+          "label": "Lista de licitantes inidôneos",
+          "uf": null,
+          "url": "https://certidoes.apps.tcu.gov.br/lista-inidoneos"
+        }
+      ],
+      "nome": "TCU - Plataforma de Certidões",
+      "observacao": "Sem cadastro. Certidões referem-se aos últimos 20 anos e não incluem decisões sem trânsito em julgado, anuladas ou suspensas. UF e município das listas vêm do domicílio na Receita Federal.",
+      "output": [
+        "certidao",
+        "dados_cadastrais",
+        "dataset",
+        "processo",
+        "sancao"
+      ],
+      "readme_linha": 1101,
+      "tipo_fonte": "federal"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
       "classificacao": "heuristica",
       "descricao": "Órgão responsável pela defesa do patrimônio público, combate à corrupção, transparência e controle interno do Governo Federal.",
       "id": "transparencia-publica-e-defesa-do-consumidor/cgu-controladoria-geral-da-uniao",
@@ -3572,7 +3639,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1101,
+      "readme_linha": 1118,
       "tipo_fonte": "federal"
     },
     {
@@ -3598,7 +3665,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1105,
+      "readme_linha": 1122,
       "tipo_fonte": "federal"
     },
     {
@@ -3624,7 +3691,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1109,
+      "readme_linha": 1126,
       "tipo_fonte": "federal"
     },
     {
@@ -3650,7 +3717,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1113,
+      "readme_linha": 1130,
       "tipo_fonte": "federal"
     },
     {
@@ -3676,7 +3743,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1117,
+      "readme_linha": 1134,
       "tipo_fonte": "federal"
     },
     {
@@ -3702,7 +3769,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1121,
+      "readme_linha": 1138,
       "tipo_fonte": "federal"
     },
     {
@@ -3728,7 +3795,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1125,
+      "readme_linha": 1142,
       "tipo_fonte": "federal"
     },
     {
@@ -3755,7 +3822,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1129,
+      "readme_linha": 1146,
       "tipo_fonte": "federal"
     },
     {
@@ -3781,7 +3848,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1133,
+      "readme_linha": 1150,
       "tipo_fonte": "estadual"
     },
     {
@@ -3808,7 +3875,7 @@
         "remuneracao",
         "sancao"
       ],
-      "readme_linha": 1137,
+      "readme_linha": 1154,
       "tipo_fonte": "estadual"
     },
     {
@@ -3834,7 +3901,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1141,
+      "readme_linha": 1158,
       "tipo_fonte": "federal"
     },
     {
@@ -3905,7 +3972,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1145,
+      "readme_linha": 1162,
       "tipo_fonte": "estadual"
     },
     {
@@ -3931,7 +3998,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1189,
+      "readme_linha": 1206,
       "tipo_fonte": "federal"
     },
     {
@@ -4097,7 +4164,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1193,
+      "readme_linha": 1210,
       "tipo_fonte": "estadual"
     },
     {
@@ -4121,7 +4188,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1262,
+      "readme_linha": 1279,
       "tipo_fonte": "federal"
     },
     {
@@ -4145,7 +4212,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1266,
+      "readme_linha": 1283,
       "tipo_fonte": "federal"
     },
     {
@@ -4169,7 +4236,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1270,
+      "readme_linha": 1287,
       "tipo_fonte": "ong"
     },
     {
@@ -4323,7 +4390,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1274,
+      "readme_linha": 1291,
       "tipo_fonte": "estadual"
     },
     {
@@ -4349,7 +4416,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 1339,
+      "readme_linha": 1356,
       "tipo_fonte": "federal"
     },
     {
@@ -4373,7 +4440,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1343,
+      "readme_linha": 1360,
       "tipo_fonte": "federal"
     },
     {
@@ -4397,7 +4464,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1347,
+      "readme_linha": 1364,
       "tipo_fonte": "federal"
     },
     {
@@ -4421,7 +4488,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1351,
+      "readme_linha": 1368,
       "tipo_fonte": "federal"
     },
     {
@@ -4445,7 +4512,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1355,
+      "readme_linha": 1372,
       "tipo_fonte": "federal"
     },
     {
@@ -4469,7 +4536,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1359,
+      "readme_linha": 1376,
       "tipo_fonte": "federal"
     },
     {
@@ -4493,7 +4560,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1363,
+      "readme_linha": 1380,
       "tipo_fonte": "federal"
     },
     {
@@ -4517,7 +4584,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1367,
+      "readme_linha": 1384,
       "tipo_fonte": "federal"
     },
     {
@@ -4541,7 +4608,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1371,
+      "readme_linha": 1388,
       "tipo_fonte": "federal"
     },
     {
@@ -4565,7 +4632,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1375,
+      "readme_linha": 1392,
       "tipo_fonte": "federal"
     },
     {
@@ -4599,7 +4666,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1384,
+      "readme_linha": 1401,
       "tipo_fonte": "privado"
     },
     {
@@ -4627,7 +4694,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1397,
+      "readme_linha": 1414,
       "tipo_fonte": "privado"
     },
     {
@@ -4665,7 +4732,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1402,
+      "readme_linha": 1419,
       "tipo_fonte": "privado"
     },
     {
@@ -4689,7 +4756,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1414,
+      "readme_linha": 1431,
       "tipo_fonte": "privado"
     },
     {
@@ -4753,7 +4820,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1420,
+      "readme_linha": 1437,
       "tipo_fonte": "ong"
     },
     {
@@ -4778,7 +4845,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1438,
+      "readme_linha": 1455,
       "tipo_fonte": "federal"
     },
     {
@@ -4803,7 +4870,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1442,
+      "readme_linha": 1459,
       "tipo_fonte": "federal"
     },
     {
@@ -4827,7 +4894,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1446,
+      "readme_linha": 1463,
       "tipo_fonte": "federal"
     },
     {
@@ -4850,7 +4917,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1450,
+      "readme_linha": 1467,
       "tipo_fonte": "federal"
     },
     {
@@ -4873,7 +4940,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1454,
+      "readme_linha": 1471,
       "tipo_fonte": "federal"
     },
     {
@@ -4902,7 +4969,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1458,
+      "readme_linha": 1475,
       "tipo_fonte": "privado"
     },
     {
@@ -4926,7 +4993,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1463,
+      "readme_linha": 1480,
       "tipo_fonte": "federal"
     },
     {
@@ -4949,7 +5016,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1467,
+      "readme_linha": 1484,
       "tipo_fonte": "federal"
     },
     {
@@ -4974,7 +5041,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1471,
+      "readme_linha": 1488,
       "tipo_fonte": "federal"
     },
     {
@@ -5000,7 +5067,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1479,
+      "readme_linha": 1496,
       "tipo_fonte": "federal"
     },
     {
@@ -5025,7 +5092,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1485,
+      "readme_linha": 1502,
       "tipo_fonte": "federal"
     },
     {
@@ -5050,7 +5117,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1491,
+      "readme_linha": 1508,
       "tipo_fonte": "federal"
     },
     {
@@ -5075,7 +5142,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1497,
+      "readme_linha": 1514,
       "tipo_fonte": "federal"
     },
     {
@@ -5099,7 +5166,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1504,
+      "readme_linha": 1521,
       "tipo_fonte": "federal"
     },
     {
@@ -5122,7 +5189,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1511,
+      "readme_linha": 1528,
       "tipo_fonte": "federal"
     },
     {
@@ -5149,7 +5216,7 @@
         "outorga",
         "radiofrequencia"
       ],
-      "readme_linha": 1518,
+      "readme_linha": 1535,
       "tipo_fonte": "federal"
     },
     {
@@ -5174,7 +5241,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1525,
+      "readme_linha": 1542,
       "tipo_fonte": "federal"
     },
     {
@@ -5197,7 +5264,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1532,
+      "readme_linha": 1549,
       "tipo_fonte": "federal"
     },
     {
@@ -5221,7 +5288,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1539,
+      "readme_linha": 1556,
       "tipo_fonte": "federal"
     },
     {
@@ -5245,7 +5312,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1546,
+      "readme_linha": 1563,
       "tipo_fonte": "federal"
     },
     {
@@ -5269,7 +5336,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1559,
+      "readme_linha": 1576,
       "tipo_fonte": "federal"
     },
     {
@@ -5294,7 +5361,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1565,
+      "readme_linha": 1582,
       "tipo_fonte": "ong"
     },
     {
@@ -5327,7 +5394,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1571,
+      "readme_linha": 1588,
       "tipo_fonte": "privado"
     },
     {
@@ -5355,7 +5422,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1582,
+      "readme_linha": 1599,
       "tipo_fonte": "ong"
     },
     {
@@ -5426,7 +5493,7 @@
         "erb",
         "operadora"
       ],
-      "readme_linha": 1591,
+      "readme_linha": 1608,
       "tipo_fonte": "privado"
     },
     {
@@ -5450,7 +5517,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1617,
+      "readme_linha": 1634,
       "tipo_fonte": "privado"
     },
     {
@@ -5476,7 +5543,7 @@
         "processo",
         "publicacao_academica"
       ],
-      "readme_linha": 1623,
+      "readme_linha": 1640,
       "tipo_fonte": "federal"
     },
     {
@@ -5500,7 +5567,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1629,
+      "readme_linha": 1646,
       "tipo_fonte": "privado"
     },
     {
@@ -5524,7 +5591,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1633,
+      "readme_linha": 1650,
       "tipo_fonte": "academico"
     },
     {
@@ -5548,7 +5615,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1637,
+      "readme_linha": 1654,
       "tipo_fonte": "academico"
     },
     {
@@ -5572,7 +5639,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1641,
+      "readme_linha": 1658,
       "tipo_fonte": "academico"
     },
     {
@@ -5596,7 +5663,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1645,
+      "readme_linha": 1662,
       "tipo_fonte": "academico"
     },
     {
@@ -5620,7 +5687,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1649,
+      "readme_linha": 1666,
       "tipo_fonte": "federal"
     },
     {
@@ -5644,7 +5711,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1653,
+      "readme_linha": 1670,
       "tipo_fonte": "privado"
     },
     {
@@ -5668,7 +5735,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1657,
+      "readme_linha": 1674,
       "tipo_fonte": "federal"
     },
     {
@@ -5692,7 +5759,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1661,
+      "readme_linha": 1678,
       "tipo_fonte": "ong"
     },
     {
@@ -5717,7 +5784,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1665,
+      "readme_linha": 1682,
       "tipo_fonte": "federal"
     },
     {
@@ -5743,7 +5810,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1669,
+      "readme_linha": 1686,
       "tipo_fonte": "federal"
     },
     {
@@ -5768,7 +5835,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 1673,
+      "readme_linha": 1690,
       "tipo_fonte": "federal"
     },
     {
@@ -5792,7 +5859,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1677,
+      "readme_linha": 1694,
       "tipo_fonte": "federal"
     },
     {
@@ -5816,7 +5883,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1681,
+      "readme_linha": 1698,
       "tipo_fonte": "federal"
     },
     {
@@ -5840,7 +5907,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1685,
+      "readme_linha": 1702,
       "tipo_fonte": "federal"
     },
     {
@@ -5980,7 +6047,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1694,
+      "readme_linha": 1711,
       "tipo_fonte": "privado"
     },
     {
@@ -6011,7 +6078,7 @@
         "area_rural",
         "mapa"
       ],
-      "readme_linha": 1728,
+      "readme_linha": 1745,
       "tipo_fonte": "federal"
     },
     {
@@ -6035,7 +6102,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1735,
+      "readme_linha": 1752,
       "tipo_fonte": "federal"
     },
     {
@@ -6064,7 +6131,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1741,
+      "readme_linha": 1758,
       "tipo_fonte": "federal"
     },
     {
@@ -6088,7 +6155,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1748,
+      "readme_linha": 1765,
       "tipo_fonte": "privado"
     },
     {
@@ -6129,7 +6196,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1752,
+      "readme_linha": 1769,
       "tipo_fonte": "internacional"
     },
     {
@@ -6158,7 +6225,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1764,
+      "readme_linha": 1781,
       "tipo_fonte": "federal"
     },
     {
@@ -6183,7 +6250,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1771,
+      "readme_linha": 1788,
       "tipo_fonte": "federal"
     },
     {
@@ -6207,7 +6274,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1777,
+      "readme_linha": 1794,
       "tipo_fonte": "federal"
     },
     {
@@ -6246,7 +6313,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1781,
+      "readme_linha": 1798,
       "tipo_fonte": "federal"
     },
     {
@@ -6270,7 +6337,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1793,
+      "readme_linha": 1810,
       "tipo_fonte": "federal"
     },
     {
@@ -6294,7 +6361,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1797,
+      "readme_linha": 1814,
       "tipo_fonte": "federal"
     },
     {
@@ -6319,7 +6386,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1807,
+      "readme_linha": 1824,
       "tipo_fonte": "federal"
     },
     {
@@ -6344,7 +6411,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1814,
+      "readme_linha": 1831,
       "tipo_fonte": "federal"
     },
     {
@@ -6371,7 +6438,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1821,
+      "readme_linha": 1838,
       "tipo_fonte": "federal"
     },
     {
@@ -6400,7 +6467,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1828,
+      "readme_linha": 1845,
       "tipo_fonte": "federal"
     },
     {
@@ -6426,7 +6493,7 @@
         "mapa",
         "sancao"
       ],
-      "readme_linha": 1835,
+      "readme_linha": 1852,
       "tipo_fonte": "federal"
     },
     {
@@ -6451,7 +6518,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1842,
+      "readme_linha": 1859,
       "tipo_fonte": "federal"
     },
     {
@@ -6478,7 +6545,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1849,
+      "readme_linha": 1866,
       "tipo_fonte": "federal"
     },
     {
@@ -6504,7 +6571,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1856,
+      "readme_linha": 1873,
       "tipo_fonte": "privado"
     },
     {
@@ -6529,7 +6596,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1863,
+      "readme_linha": 1880,
       "tipo_fonte": "federal"
     },
     {
@@ -6556,7 +6623,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1870,
+      "readme_linha": 1887,
       "tipo_fonte": "federal"
     },
     {
@@ -6581,7 +6648,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1877,
+      "readme_linha": 1894,
       "tipo_fonte": "federal"
     },
     {
@@ -6607,7 +6674,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1884,
+      "readme_linha": 1901,
       "tipo_fonte": "federal"
     },
     {
@@ -6633,7 +6700,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1891,
+      "readme_linha": 1908,
       "tipo_fonte": "federal"
     },
     {
@@ -6658,7 +6725,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1898,
+      "readme_linha": 1915,
       "tipo_fonte": "federal"
     },
     {
@@ -6685,7 +6752,7 @@
         "mapa",
         "processo"
       ],
-      "readme_linha": 1905,
+      "readme_linha": 1922,
       "tipo_fonte": "federal"
     },
     {
@@ -6712,7 +6779,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1912,
+      "readme_linha": 1929,
       "tipo_fonte": "federal"
     },
     {
@@ -6736,7 +6803,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1923,
+      "readme_linha": 1940,
       "tipo_fonte": "federal"
     },
     {
@@ -6760,7 +6827,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1929,
+      "readme_linha": 1946,
       "tipo_fonte": "federal"
     },
     {
@@ -6785,7 +6852,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1933,
+      "readme_linha": 1950,
       "tipo_fonte": "federal"
     },
     {
@@ -6809,7 +6876,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1937,
+      "readme_linha": 1954,
       "tipo_fonte": "federal"
     },
     {
@@ -6833,7 +6900,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1941,
+      "readme_linha": 1958,
       "tipo_fonte": "federal"
     },
     {
@@ -6857,7 +6924,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1945,
+      "readme_linha": 1962,
       "tipo_fonte": "federal"
     },
     {
@@ -6886,7 +6953,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1949,
+      "readme_linha": 1966,
       "tipo_fonte": "federal"
     },
     {
@@ -6911,7 +6978,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1954,
+      "readme_linha": 1971,
       "tipo_fonte": "ong"
     },
     {
@@ -6936,7 +7003,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1958,
+      "readme_linha": 1975,
       "tipo_fonte": "academico"
     },
     {
@@ -6960,7 +7027,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1962,
+      "readme_linha": 1979,
       "tipo_fonte": "academico"
     },
     {
@@ -6994,7 +7061,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1966,
+      "readme_linha": 1983,
       "tipo_fonte": "federal"
     },
     {
@@ -7032,7 +7099,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 1983,
+      "readme_linha": 2000,
       "tipo_fonte": "dork"
     },
     {
@@ -7060,7 +7127,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 1996,
+      "readme_linha": 2013,
       "tipo_fonte": "dork"
     },
     {
@@ -7088,7 +7155,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2003,
+      "readme_linha": 2020,
       "tipo_fonte": "dork"
     },
     {
@@ -7121,7 +7188,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2012,
+      "readme_linha": 2029,
       "tipo_fonte": "dork"
     },
     {
@@ -7159,7 +7226,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2023,
+      "readme_linha": 2040,
       "tipo_fonte": "dork"
     },
     {
@@ -7198,7 +7265,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2036,
+      "readme_linha": 2053,
       "tipo_fonte": "dork"
     },
     {
@@ -7237,7 +7304,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2052,
+      "readme_linha": 2069,
       "tipo_fonte": "internacional"
     },
     {
@@ -7271,7 +7338,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2064,
+      "readme_linha": 2081,
       "tipo_fonte": "internacional"
     },
     {
@@ -7299,7 +7366,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2071,
+      "readme_linha": 2088,
       "tipo_fonte": "dork"
     },
     {
@@ -7347,7 +7414,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2078,
+      "readme_linha": 2095,
       "tipo_fonte": "dork"
     },
     {
@@ -7385,7 +7452,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2098,
+      "readme_linha": 2115,
       "tipo_fonte": "dork"
     },
     {
@@ -7424,7 +7491,7 @@
         "dork",
         "video_ao_vivo"
       ],
-      "readme_linha": 2113,
+      "readme_linha": 2130,
       "tipo_fonte": "dork"
     },
     {
@@ -7465,7 +7532,7 @@
         "dork",
         "operadora"
       ],
-      "readme_linha": 2128,
+      "readme_linha": 2145,
       "tipo_fonte": "dork"
     },
     {
@@ -7499,7 +7566,7 @@
         "dork",
         "publicacao_academica"
       ],
-      "readme_linha": 2143,
+      "readme_linha": 2160,
       "tipo_fonte": "dork"
     },
     {
@@ -7532,7 +7599,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2155,
+      "readme_linha": 2172,
       "tipo_fonte": "dork"
     },
     {
@@ -7560,7 +7627,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2167,
+      "readme_linha": 2184,
       "tipo_fonte": "dork"
     },
     {
@@ -7589,7 +7656,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2177,
+      "readme_linha": 2194,
       "tipo_fonte": "internacional"
     },
     {
@@ -7632,7 +7699,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2189,
+      "readme_linha": 2206,
       "tipo_fonte": "dork"
     },
     {
@@ -7657,7 +7724,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2213,
+      "readme_linha": 2230,
       "tipo_fonte": "internacional"
     },
     {
@@ -7692,7 +7759,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2219,
+      "readme_linha": 2236,
       "tipo_fonte": "internacional"
     },
     {
@@ -7722,7 +7789,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2230,
+      "readme_linha": 2247,
       "tipo_fonte": "internacional"
     },
     {
@@ -7747,7 +7814,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2238,
+      "readme_linha": 2255,
       "tipo_fonte": "internacional"
     },
     {
@@ -7773,7 +7840,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2244,
+      "readme_linha": 2261,
       "tipo_fonte": "internacional"
     },
     {
@@ -7799,7 +7866,7 @@
         "estatistica",
         "perfil_social"
       ],
-      "readme_linha": 2250,
+      "readme_linha": 2267,
       "tipo_fonte": "internacional"
     },
     {
@@ -7824,7 +7891,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2256,
+      "readme_linha": 2273,
       "tipo_fonte": "internacional"
     },
     {
@@ -7849,7 +7916,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2262,
+      "readme_linha": 2279,
       "tipo_fonte": "internacional"
     },
     {
@@ -7874,7 +7941,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2266,
+      "readme_linha": 2283,
       "tipo_fonte": "internacional"
     },
     {
@@ -7899,7 +7966,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2270,
+      "readme_linha": 2287,
       "tipo_fonte": "internacional"
     },
     {
@@ -7924,7 +7991,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2274,
+      "readme_linha": 2291,
       "tipo_fonte": "internacional"
     },
     {
@@ -7949,7 +8016,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2278,
+      "readme_linha": 2295,
       "tipo_fonte": "internacional"
     },
     {
@@ -7974,7 +8041,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2282,
+      "readme_linha": 2299,
       "tipo_fonte": "internacional"
     },
     {
@@ -8000,7 +8067,7 @@
         "mandado_prisao",
         "perfil_social"
       ],
-      "readme_linha": 2288,
+      "readme_linha": 2305,
       "tipo_fonte": "privado"
     },
     {
@@ -8030,7 +8097,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2294,
+      "readme_linha": 2311,
       "tipo_fonte": "privado"
     },
     {
@@ -8060,7 +8127,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2301,
+      "readme_linha": 2318,
       "tipo_fonte": "internacional"
     },
     {
@@ -8086,7 +8153,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2307,
+      "readme_linha": 2324,
       "tipo_fonte": "internacional"
     },
     {
@@ -8111,7 +8178,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2314,
+      "readme_linha": 2331,
       "tipo_fonte": "privado"
     },
     {
@@ -8136,7 +8203,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2320,
+      "readme_linha": 2337,
       "tipo_fonte": "internacional"
     },
     {
@@ -8219,7 +8286,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2333,
+      "readme_linha": 2350,
       "tipo_fonte": "privado"
     },
     {
@@ -8282,7 +8349,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2358,
+      "readme_linha": 2375,
       "tipo_fonte": "privado"
     },
     {
@@ -8305,7 +8372,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2385,
+      "readme_linha": 2402,
       "tipo_fonte": "federal"
     },
     {
@@ -8328,7 +8395,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2391,
+      "readme_linha": 2408,
       "tipo_fonte": "privado"
     },
     {
@@ -8351,7 +8418,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2397,
+      "readme_linha": 2414,
       "tipo_fonte": "federal"
     },
     {
@@ -8374,7 +8441,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2403,
+      "readme_linha": 2420,
       "tipo_fonte": "privado"
     },
     {
@@ -8397,7 +8464,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2409,
+      "readme_linha": 2426,
       "tipo_fonte": "federal"
     },
     {
@@ -8420,7 +8487,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2415,
+      "readme_linha": 2432,
       "tipo_fonte": "federal"
     },
     {
@@ -8443,7 +8510,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2421,
+      "readme_linha": 2438,
       "tipo_fonte": "federal"
     },
     {
@@ -8467,7 +8534,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2427,
+      "readme_linha": 2444,
       "tipo_fonte": "federal"
     },
     {
@@ -8496,7 +8563,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 2431,
+      "readme_linha": 2448,
       "tipo_fonte": "federal"
     },
     {
@@ -8519,7 +8586,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2438,
+      "readme_linha": 2455,
       "tipo_fonte": "federal"
     },
     {
@@ -8542,7 +8609,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2442,
+      "readme_linha": 2459,
       "tipo_fonte": "federal"
     },
     {
@@ -8566,7 +8633,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2448,
+      "readme_linha": 2465,
       "tipo_fonte": "federal"
     },
     {
@@ -8589,7 +8656,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2454,
+      "readme_linha": 2471,
       "tipo_fonte": "estadual"
     },
     {
@@ -8613,7 +8680,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2460,
+      "readme_linha": 2477,
       "tipo_fonte": "estadual"
     },
     {
@@ -8637,7 +8704,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2466,
+      "readme_linha": 2483,
       "tipo_fonte": "federal"
     },
     {
@@ -8660,7 +8727,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2472,
+      "readme_linha": 2489,
       "tipo_fonte": "federal"
     },
     {
@@ -8683,7 +8750,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2478,
+      "readme_linha": 2495,
       "tipo_fonte": "estadual"
     },
     {
@@ -8707,7 +8774,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2484,
+      "readme_linha": 2501,
       "tipo_fonte": "federal"
     },
     {
@@ -8730,7 +8797,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2490,
+      "readme_linha": 2507,
       "tipo_fonte": "estadual"
     },
     {
@@ -8753,7 +8820,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2496,
+      "readme_linha": 2513,
       "tipo_fonte": "estadual"
     },
     {
@@ -8776,7 +8843,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2502,
+      "readme_linha": 2519,
       "tipo_fonte": "federal"
     },
     {
@@ -8799,7 +8866,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2508,
+      "readme_linha": 2525,
       "tipo_fonte": "estadual"
     },
     {
@@ -8822,7 +8889,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2514,
+      "readme_linha": 2531,
       "tipo_fonte": "estadual"
     },
     {
@@ -8845,7 +8912,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2518,
+      "readme_linha": 2535,
       "tipo_fonte": "federal"
     },
     {
@@ -8868,7 +8935,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2524,
+      "readme_linha": 2541,
       "tipo_fonte": "federal"
     },
     {
@@ -8891,7 +8958,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2530,
+      "readme_linha": 2547,
       "tipo_fonte": "estadual"
     },
     {
@@ -8914,7 +8981,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2536,
+      "readme_linha": 2553,
       "tipo_fonte": "federal"
     },
     {
@@ -8942,7 +9009,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2542,
+      "readme_linha": 2559,
       "tipo_fonte": "federal"
     },
     {
@@ -8967,7 +9034,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2549,
+      "readme_linha": 2566,
       "tipo_fonte": "estadual"
     },
     {
@@ -8990,7 +9057,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2553,
+      "readme_linha": 2570,
       "tipo_fonte": "federal"
     },
     {
@@ -9014,7 +9081,7 @@
         "dataset",
         "diario_oficial"
       ],
-      "readme_linha": 2557,
+      "readme_linha": 2574,
       "tipo_fonte": "ong"
     },
     {
@@ -9037,7 +9104,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2563,
+      "readme_linha": 2580,
       "tipo_fonte": "ong"
     },
     {
@@ -9060,7 +9127,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2567,
+      "readme_linha": 2584,
       "tipo_fonte": "federal"
     },
     {
@@ -9083,7 +9150,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2571,
+      "readme_linha": 2588,
       "tipo_fonte": "federal"
     },
     {
@@ -9106,7 +9173,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2575,
+      "readme_linha": 2592,
       "tipo_fonte": "privado"
     },
     {
@@ -9129,7 +9196,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2579,
+      "readme_linha": 2596,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9152,7 +9219,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2583,
+      "readme_linha": 2600,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9176,7 +9243,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2587,
+      "readme_linha": 2604,
       "tipo_fonte": "federal"
     },
     {
@@ -9199,7 +9266,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2591,
+      "readme_linha": 2608,
       "tipo_fonte": "federal"
     },
     {
@@ -9223,7 +9290,7 @@
         "dataset",
         "endereco"
       ],
-      "readme_linha": 2595,
+      "readme_linha": 2612,
       "tipo_fonte": "privado"
     },
     {
@@ -9248,7 +9315,7 @@
         "beneficio",
         "remuneracao"
       ],
-      "readme_linha": 2605,
+      "readme_linha": 2622,
       "tipo_fonte": "ong"
     },
     {
@@ -9272,7 +9339,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2613,
+      "readme_linha": 2630,
       "tipo_fonte": "estadual"
     },
     {
@@ -9296,7 +9363,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2617,
+      "readme_linha": 2634,
       "tipo_fonte": "estadual"
     },
     {
@@ -9395,7 +9462,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2623,
+      "readme_linha": 2640,
       "tipo_fonte": "privado"
     },
     {
@@ -9454,7 +9521,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2646,
+      "readme_linha": 2663,
       "tipo_fonte": "ong"
     },
     {
@@ -9483,7 +9550,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2661,
+      "readme_linha": 2678,
       "tipo_fonte": "privado"
     },
     {
@@ -9507,7 +9574,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2668,
+      "readme_linha": 2685,
       "tipo_fonte": "privado"
     },
     {
@@ -9531,7 +9598,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2674,
+      "readme_linha": 2691,
       "tipo_fonte": "federal"
     },
     {
@@ -9555,7 +9622,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2680,
+      "readme_linha": 2697,
       "tipo_fonte": "federal"
     },
     {
@@ -9580,7 +9647,7 @@
         "veiculo",
         "video_ao_vivo"
       ],
-      "readme_linha": 2686,
+      "readme_linha": 2703,
       "tipo_fonte": "internacional"
     },
     {
@@ -9604,7 +9671,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2690,
+      "readme_linha": 2707,
       "tipo_fonte": "internacional"
     },
     {
@@ -9629,7 +9696,7 @@
         "multa",
         "veiculo"
       ],
-      "readme_linha": 2694,
+      "readme_linha": 2711,
       "tipo_fonte": "federal"
     },
     {
@@ -9655,7 +9722,7 @@
         "dados_cadastrais",
         "veiculo"
       ],
-      "readme_linha": 2698,
+      "readme_linha": 2715,
       "tipo_fonte": "federal"
     },
     {
@@ -9679,7 +9746,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2702,
+      "readme_linha": 2719,
       "tipo_fonte": "federal"
     },
     {
@@ -9703,7 +9770,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2706,
+      "readme_linha": 2723,
       "tipo_fonte": "privado"
     },
     {
@@ -9727,7 +9794,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2712,
+      "readme_linha": 2729,
       "tipo_fonte": "federal"
     },
     {
@@ -9751,7 +9818,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2718,
+      "readme_linha": 2735,
       "tipo_fonte": "federal"
     },
     {
@@ -9776,7 +9843,7 @@
         "dataset",
         "veiculo"
       ],
-      "readme_linha": 2724,
+      "readme_linha": 2741,
       "tipo_fonte": "federal"
     },
     {
@@ -9805,7 +9872,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2730,
+      "readme_linha": 2747,
       "tipo_fonte": "estadual"
     },
     {
@@ -9834,7 +9901,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2737,
+      "readme_linha": 2754,
       "tipo_fonte": "estadual"
     },
     {
@@ -10003,7 +10070,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2744,
+      "readme_linha": 2761,
       "tipo_fonte": "estadual"
     },
     {
@@ -10027,7 +10094,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 2814,
+      "readme_linha": 2831,
       "tipo_fonte": "privado"
     },
     {
@@ -10050,7 +10117,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2820,
+      "readme_linha": 2837,
       "tipo_fonte": "privado"
     },
     {
@@ -10093,7 +10160,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2826,
+      "readme_linha": 2843,
       "tipo_fonte": "estadual"
     },
     {
@@ -10116,7 +10183,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2846,
+      "readme_linha": 2863,
       "tipo_fonte": "privado"
     },
     {
@@ -10139,7 +10206,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2852,
+      "readme_linha": 2869,
       "tipo_fonte": "privado"
     },
     {
@@ -10162,7 +10229,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2858,
+      "readme_linha": 2875,
       "tipo_fonte": "privado"
     },
     {
@@ -10187,7 +10254,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 2870,
+      "readme_linha": 2887,
       "tipo_fonte": "federal"
     },
     {
@@ -10213,7 +10280,7 @@
         "estatistica",
         "multa"
       ],
-      "readme_linha": 2874,
+      "readme_linha": 2891,
       "tipo_fonte": "privado"
     },
     {
@@ -10236,7 +10303,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2878,
+      "readme_linha": 2895,
       "tipo_fonte": "federal"
     },
     {
@@ -10259,7 +10326,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2882,
+      "readme_linha": 2899,
       "tipo_fonte": "federal"
     },
     {
@@ -10282,7 +10349,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2886,
+      "readme_linha": 2903,
       "tipo_fonte": "federal"
     },
     {
@@ -10305,7 +10372,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2890,
+      "readme_linha": 2907,
       "tipo_fonte": "federal"
     },
     {
@@ -10333,7 +10400,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2894,
+      "readme_linha": 2911,
       "tipo_fonte": "internacional"
     },
     {
@@ -10356,7 +10423,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2899,
+      "readme_linha": 2916,
       "tipo_fonte": "privado"
     },
     {
@@ -10379,7 +10446,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2903,
+      "readme_linha": 2920,
       "tipo_fonte": "privado"
     },
     {
@@ -10402,7 +10469,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2907,
+      "readme_linha": 2924,
       "tipo_fonte": "privado"
     },
     {
@@ -10425,7 +10492,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2917,
+      "readme_linha": 2934,
       "tipo_fonte": "federal"
     },
     {
@@ -10451,7 +10518,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 2923,
+      "readme_linha": 2940,
       "tipo_fonte": "privado"
     },
     {
@@ -10474,7 +10541,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2929,
+      "readme_linha": 2946,
       "tipo_fonte": "federal"
     },
     {
@@ -10499,7 +10566,7 @@
         "dados_cadastrais",
         "multa"
       ],
-      "readme_linha": 2935,
+      "readme_linha": 2952,
       "tipo_fonte": "federal"
     },
     {
@@ -10577,7 +10644,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2939,
+      "readme_linha": 2956,
       "tipo_fonte": "federal"
     },
     {
@@ -10600,7 +10667,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2967,
+      "readme_linha": 2984,
       "tipo_fonte": "estadual"
     },
     {
@@ -10623,7 +10690,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2973,
+      "readme_linha": 2990,
       "tipo_fonte": "privado"
     },
     {
@@ -10646,7 +10713,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2977,
+      "readme_linha": 2994,
       "tipo_fonte": "estadual"
     },
     {
@@ -10669,7 +10736,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2981,
+      "readme_linha": 2998,
       "tipo_fonte": "internacional"
     },
     {
@@ -10712,7 +10779,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2985,
+      "readme_linha": 3002,
       "tipo_fonte": "privado"
     },
     {
@@ -10760,7 +10827,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3000,
+      "readme_linha": 3017,
       "tipo_fonte": "privado"
     },
     {
@@ -10863,7 +10930,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3014,
+      "readme_linha": 3031,
       "tipo_fonte": "privado"
     },
     {
@@ -10886,7 +10953,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3055,
+      "readme_linha": 3072,
       "tipo_fonte": "privado"
     },
     {
@@ -10934,7 +11001,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3059,
+      "readme_linha": 3076,
       "tipo_fonte": "estadual"
     },
     {
@@ -11257,7 +11324,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3073,
+      "readme_linha": 3090,
       "tipo_fonte": "privado"
     },
     {
@@ -11280,7 +11347,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3148,
+      "readme_linha": 3165,
       "tipo_fonte": "privado"
     },
     {
@@ -11303,7 +11370,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3152,
+      "readme_linha": 3169,
       "tipo_fonte": "privado"
     },
     {
@@ -11326,7 +11393,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3156,
+      "readme_linha": 3173,
       "tipo_fonte": "estadual"
     },
     {
@@ -11349,7 +11416,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3160,
+      "readme_linha": 3177,
       "tipo_fonte": "federal"
     },
     {
@@ -11378,7 +11445,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3164,
+      "readme_linha": 3181,
       "tipo_fonte": "internacional"
     },
     {
@@ -11402,7 +11469,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3169,
+      "readme_linha": 3186,
       "tipo_fonte": "internacional"
     },
     {
@@ -11426,7 +11493,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3173,
+      "readme_linha": 3190,
       "tipo_fonte": "internacional"
     },
     {
@@ -11450,7 +11517,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3177,
+      "readme_linha": 3194,
       "tipo_fonte": "internacional"
     },
     {
@@ -11474,7 +11541,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3181,
+      "readme_linha": 3198,
       "tipo_fonte": "internacional"
     },
     {
@@ -11498,7 +11565,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3185,
+      "readme_linha": 3202,
       "tipo_fonte": "internacional"
     },
     {
@@ -11522,7 +11589,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3189,
+      "readme_linha": 3206,
       "tipo_fonte": "internacional"
     },
     {
@@ -11546,7 +11613,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3193,
+      "readme_linha": 3210,
       "tipo_fonte": "internacional"
     },
     {
@@ -11569,7 +11636,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3197,
+      "readme_linha": 3214,
       "tipo_fonte": "estadual"
     },
     {
@@ -11643,7 +11710,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3207,
+      "readme_linha": 3224,
       "tipo_fonte": "ministerio_publico"
     },
     {
@@ -11703,7 +11770,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3248,
+      "readme_linha": 3265,
       "tipo_fonte": "defensoria"
     },
     {
@@ -11737,7 +11804,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3280,
+      "readme_linha": 3297,
       "tipo_fonte": "ong"
     },
     {
@@ -11766,7 +11833,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3297,
+      "readme_linha": 3314,
       "tipo_fonte": "estadual"
     },
     {
@@ -11795,7 +11862,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3317,
+      "readme_linha": 3334,
       "tipo_fonte": "privado"
     },
     {
@@ -11844,7 +11911,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3322,
+      "readme_linha": 3339,
       "tipo_fonte": "estadual"
     },
     {
@@ -11869,7 +11936,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 3341,
+      "readme_linha": 3358,
       "tipo_fonte": "federal"
     },
     {
@@ -11894,7 +11961,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3345,
+      "readme_linha": 3362,
       "tipo_fonte": "ong"
     },
     {
@@ -11919,7 +11986,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3349,
+      "readme_linha": 3366,
       "tipo_fonte": "federal"
     },
     {
@@ -11942,7 +12009,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3353,
+      "readme_linha": 3370,
       "tipo_fonte": "privado"
     },
     {
@@ -11967,7 +12034,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3357,
+      "readme_linha": 3374,
       "tipo_fonte": "federal"
     },
     {
@@ -11990,7 +12057,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3361,
+      "readme_linha": 3378,
       "tipo_fonte": "federal"
     },
     {
@@ -12011,7 +12078,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3365,
+      "readme_linha": 3382,
       "tipo_fonte": "federal"
     },
     {
@@ -12039,7 +12106,7 @@
         "mandado_prisao",
         "veiculo"
       ],
-      "readme_linha": 3369,
+      "readme_linha": 3386,
       "tipo_fonte": "federal"
     },
     {
@@ -12080,7 +12147,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3378,
+      "readme_linha": 3395,
       "tipo_fonte": "privado"
     },
     {
@@ -12111,7 +12178,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3397,
+      "readme_linha": 3414,
       "tipo_fonte": "privado"
     },
     {
@@ -12140,7 +12207,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3411,
+      "readme_linha": 3428,
       "tipo_fonte": "privado"
     },
     {
@@ -12168,7 +12235,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3438,
+      "readme_linha": 3455,
       "tipo_fonte": "privado"
     },
     {
@@ -12198,7 +12265,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3460,
+      "readme_linha": 3477,
       "tipo_fonte": "privado"
     },
     {
@@ -12225,7 +12292,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3484,
+      "readme_linha": 3501,
       "tipo_fonte": "federal"
     },
     {
@@ -12252,7 +12319,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3507,
+      "readme_linha": 3524,
       "tipo_fonte": "federal"
     },
     {
@@ -12282,7 +12349,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3511,
+      "readme_linha": 3528,
       "tipo_fonte": "ong"
     },
     {
@@ -12308,7 +12375,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3534,
+      "readme_linha": 3551,
       "tipo_fonte": "federal"
     },
     {
@@ -12332,7 +12399,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3538,
+      "readme_linha": 3555,
       "tipo_fonte": "federal"
     },
     {
@@ -12355,7 +12422,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3548,
+      "readme_linha": 3565,
       "tipo_fonte": "federal"
     },
     {
@@ -12378,7 +12445,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3552,
+      "readme_linha": 3569,
       "tipo_fonte": "federal"
     },
     {
@@ -12407,7 +12474,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3556,
+      "readme_linha": 3573,
       "tipo_fonte": "federal"
     },
     {
@@ -12435,7 +12502,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3561,
+      "readme_linha": 3578,
       "tipo_fonte": "federal"
     },
     {
@@ -12458,7 +12525,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3566,
+      "readme_linha": 3583,
       "tipo_fonte": "federal"
     },
     {
@@ -12481,7 +12548,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3570,
+      "readme_linha": 3587,
       "tipo_fonte": "federal"
     },
     {
@@ -12510,7 +12577,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3580,
+      "readme_linha": 3597,
       "tipo_fonte": "federal"
     },
     {
@@ -12534,7 +12601,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3585,
+      "readme_linha": 3602,
       "tipo_fonte": "federal"
     },
     {
@@ -12558,7 +12625,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3589,
+      "readme_linha": 3606,
       "tipo_fonte": "federal"
     },
     {
@@ -12588,7 +12655,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3593,
+      "readme_linha": 3610,
       "tipo_fonte": "ong"
     },
     {
@@ -12618,7 +12685,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3598,
+      "readme_linha": 3615,
       "tipo_fonte": "federal"
     },
     {
@@ -12643,7 +12710,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3603,
+      "readme_linha": 3620,
       "tipo_fonte": "federal"
     },
     {
@@ -12667,7 +12734,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3607,
+      "readme_linha": 3624,
       "tipo_fonte": "federal"
     },
     {
@@ -12691,7 +12758,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3611,
+      "readme_linha": 3628,
       "tipo_fonte": "federal"
     },
     {
@@ -12746,7 +12813,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3621,
+      "readme_linha": 3638,
       "tipo_fonte": "ong"
     },
     {
@@ -12870,7 +12937,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3660,
+      "readme_linha": 3677,
       "tipo_fonte": "estadual"
     },
     {
@@ -12990,7 +13057,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3701,
+      "readme_linha": 3718,
       "tipo_fonte": "ong"
     },
     {
@@ -13024,7 +13091,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3730,
+      "readme_linha": 3747,
       "tipo_fonte": "estadual"
     },
     {
@@ -13050,7 +13117,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3742,
+      "readme_linha": 3759,
       "tipo_fonte": "estadual"
     },
     {
@@ -13076,7 +13143,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3746,
+      "readme_linha": 3763,
       "tipo_fonte": "estadual"
     },
     {
@@ -13100,7 +13167,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3750,
+      "readme_linha": 3767,
       "tipo_fonte": "estadual"
     },
     {
@@ -13123,7 +13190,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3760,
+      "readme_linha": 3777,
       "tipo_fonte": "ong"
     },
     {
@@ -13146,7 +13213,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3764,
+      "readme_linha": 3781,
       "tipo_fonte": "federal"
     },
     {
@@ -13170,7 +13237,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3768,
+      "readme_linha": 3785,
       "tipo_fonte": "ong"
     },
     {
@@ -13193,7 +13260,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3772,
+      "readme_linha": 3789,
       "tipo_fonte": "federal"
     },
     {
@@ -13216,7 +13283,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3776,
+      "readme_linha": 3793,
       "tipo_fonte": "federal"
     },
     {
@@ -13244,7 +13311,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3780,
+      "readme_linha": 3797,
       "tipo_fonte": "privado"
     },
     {
@@ -13332,7 +13399,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3792,
+      "readme_linha": 3809,
       "tipo_fonte": "privado"
     },
     {
@@ -13383,7 +13450,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3814,
+      "readme_linha": 3831,
       "tipo_fonte": "privado"
     },
     {
@@ -13406,7 +13473,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3827,
+      "readme_linha": 3844,
       "tipo_fonte": "estadual"
     },
     {
@@ -13439,7 +13506,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3833,
+      "readme_linha": 3850,
       "tipo_fonte": "privado"
     },
     {
@@ -13463,7 +13530,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3844,
+      "readme_linha": 3861,
       "tipo_fonte": "privado"
     },
     {
@@ -13486,7 +13553,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3848,
+      "readme_linha": 3865,
       "tipo_fonte": "federal"
     },
     {
@@ -13520,7 +13587,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3854,
+      "readme_linha": 3871,
       "tipo_fonte": "privado"
     },
     {
@@ -13606,7 +13673,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3864,
+      "readme_linha": 3881,
       "tipo_fonte": "privado"
     },
     {
@@ -13630,7 +13697,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3913,
+      "readme_linha": 3930,
       "tipo_fonte": "estadual"
     },
     {
@@ -13664,9 +13731,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4076,
+      "readme_linha": 4093,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 433
+  "total": 434
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -2183,6 +2183,59 @@
       "tipo_fonte": "federal"
     },
     {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "classificacao": "override",
+      "descricao": "Consulta de instituições reguladas ou supervisionadas pelo Banco Central, por nome, CNPJ (8 primeiros dígitos), UF e município, com opção de incluir agências e instituições em regime especial ou liquidação.",
+      "id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/banco-central-encontre-uma-instituicao",
+      "input": [
+        "cnpj",
+        "municipio",
+        "nome",
+        "uf"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://www.bcb.gov.br/meubc/encontreinstituicao"
+        }
+      ],
+      "nome": "Banco Central - Encontre uma Instituição",
+      "observacao": "Sem cadastro. Aceita apenas os 8 primeiros dígitos do CNPJ.",
+      "output": [
+        "dados_cadastrais",
+        "situacao_cadastral"
+      ],
+      "readme_linha": 748,
+      "tipo_fonte": "federal"
+    },
+    {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "classificacao": "override",
+      "descricao": "Consulta gratuita de protestos em cartórios de todo o Brasil. Para consulta é necessário apenas o CPF ou CNPJ.",
+      "id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/cenprot-consulta-de-protestos",
+      "input": [
+        "cnpj",
+        "cpf"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://www.pesquisaprotesto.com.br/"
+        }
+      ],
+      "nome": "CENPROT - Consulta de Protestos",
+      "observacao": "Consulta gratuita; a certidão é paga.",
+      "output": [
+        "debito"
+      ],
+      "readme_linha": 752,
+      "tipo_fonte": "privado"
+    },
+    {
       "categoria": "Estatísticas Segurança Pública",
       "categoria_id": "estatisticas-seguranca-publica",
       "classificacao": "heuristica",
@@ -2207,7 +2260,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 757,
+      "readme_linha": 765,
       "tipo_fonte": "federal"
     },
     {
@@ -2315,7 +2368,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 769,
+      "readme_linha": 777,
       "tipo_fonte": "estadual"
     },
     {
@@ -2343,7 +2396,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 830,
+      "readme_linha": 838,
       "tipo_fonte": "ong"
     },
     {
@@ -2366,7 +2419,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 835,
+      "readme_linha": 843,
       "tipo_fonte": "privado"
     },
     {
@@ -2389,7 +2442,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 839,
+      "readme_linha": 847,
       "tipo_fonte": "ong"
     },
     {
@@ -2413,7 +2466,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 843,
+      "readme_linha": 851,
       "tipo_fonte": "privado"
     },
     {
@@ -2438,7 +2491,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 853,
+      "readme_linha": 861,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2463,7 +2516,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 857,
+      "readme_linha": 865,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2488,7 +2541,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 861,
+      "readme_linha": 869,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2513,7 +2566,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 865,
+      "readme_linha": 873,
       "tipo_fonte": "legislativo"
     },
     {
@@ -2538,7 +2591,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 869,
+      "readme_linha": 877,
       "tipo_fonte": "legislativo"
     },
     {
@@ -2564,7 +2617,7 @@
         "dados_cadastrais",
         "dataset"
       ],
-      "readme_linha": 873,
+      "readme_linha": 881,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2590,7 +2643,7 @@
         "dados_cadastrais",
         "dataset"
       ],
-      "readme_linha": 877,
+      "readme_linha": 885,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2616,7 +2669,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 881,
+      "readme_linha": 889,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2641,7 +2694,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 885,
+      "readme_linha": 893,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2667,7 +2720,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 889,
+      "readme_linha": 897,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2693,7 +2746,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 893,
+      "readme_linha": 901,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2719,7 +2772,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 897,
+      "readme_linha": 905,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2745,7 +2798,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 901,
+      "readme_linha": 909,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2772,7 +2825,7 @@
         "dados_cadastrais",
         "debito"
       ],
-      "readme_linha": 905,
+      "readme_linha": 913,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2798,7 +2851,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 909,
+      "readme_linha": 917,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2826,7 +2879,7 @@
         "debito",
         "multa"
       ],
-      "readme_linha": 913,
+      "readme_linha": 921,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2851,7 +2904,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 917,
+      "readme_linha": 925,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2877,7 +2930,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 921,
+      "readme_linha": 929,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2902,7 +2955,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 925,
+      "readme_linha": 933,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2930,7 +2983,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 929,
+      "readme_linha": 937,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2955,7 +3008,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 933,
+      "readme_linha": 941,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2980,7 +3033,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 938,
+      "readme_linha": 946,
       "tipo_fonte": "judiciario"
     },
     {
@@ -3006,7 +3059,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 942,
+      "readme_linha": 950,
       "tipo_fonte": "ong"
     },
     {
@@ -3030,7 +3083,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 952,
+      "readme_linha": 960,
       "tipo_fonte": "ong"
     },
     {
@@ -3054,7 +3107,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 956,
+      "readme_linha": 964,
       "tipo_fonte": "estadual"
     },
     {
@@ -3078,7 +3131,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 960,
+      "readme_linha": 968,
       "tipo_fonte": "municipal"
     },
     {
@@ -3102,7 +3155,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 964,
+      "readme_linha": 972,
       "tipo_fonte": "federal"
     },
     {
@@ -3126,7 +3179,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 968,
+      "readme_linha": 976,
       "tipo_fonte": "federal"
     },
     {
@@ -3152,7 +3205,7 @@
         "certidao",
         "imovel"
       ],
-      "readme_linha": 972,
+      "readme_linha": 980,
       "tipo_fonte": "ong"
     },
     {
@@ -3176,7 +3229,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 982,
+      "readme_linha": 990,
       "tipo_fonte": "federal"
     },
     {
@@ -3200,7 +3253,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 986,
+      "readme_linha": 994,
       "tipo_fonte": "federal"
     },
     {
@@ -3224,7 +3277,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 990,
+      "readme_linha": 998,
       "tipo_fonte": "federal"
     },
     {
@@ -3248,7 +3301,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 994,
+      "readme_linha": 1002,
       "tipo_fonte": "estadual"
     },
     {
@@ -3273,7 +3326,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 998,
+      "readme_linha": 1006,
       "tipo_fonte": "ong"
     },
     {
@@ -3298,7 +3351,7 @@
         "estatistica",
         "licenca_ambiental"
       ],
-      "readme_linha": 1002,
+      "readme_linha": 1010,
       "tipo_fonte": "ong"
     },
     {
@@ -3323,7 +3376,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 1006,
+      "readme_linha": 1014,
       "tipo_fonte": "ong"
     },
     {
@@ -3346,7 +3399,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1016,
+      "readme_linha": 1024,
       "tipo_fonte": "federal"
     },
     {
@@ -3369,7 +3422,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1020,
+      "readme_linha": 1028,
       "tipo_fonte": "federal"
     },
     {
@@ -3392,7 +3445,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1024,
+      "readme_linha": 1032,
       "tipo_fonte": "federal"
     },
     {
@@ -3415,7 +3468,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1028,
+      "readme_linha": 1036,
       "tipo_fonte": "federal"
     },
     {
@@ -3439,7 +3492,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1038,
+      "readme_linha": 1046,
       "tipo_fonte": "federal"
     },
     {
@@ -3463,7 +3516,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1042,
+      "readme_linha": 1050,
       "tipo_fonte": "federal"
     },
     {
@@ -3487,7 +3540,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1046,
+      "readme_linha": 1054,
       "tipo_fonte": "federal"
     },
     {
@@ -3513,7 +3566,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1056,
+      "readme_linha": 1064,
       "tipo_fonte": "federal"
     },
     {
@@ -3539,7 +3592,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1060,
+      "readme_linha": 1068,
       "tipo_fonte": "federal"
     },
     {
@@ -3571,7 +3624,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1064,
+      "readme_linha": 1072,
       "tipo_fonte": "federal"
     },
     {
@@ -3598,7 +3651,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1105,
+      "readme_linha": 1113,
       "tipo_fonte": "federal"
     },
     {
@@ -3625,7 +3678,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1109,
+      "readme_linha": 1117,
       "tipo_fonte": "federal"
     },
     {
@@ -3651,7 +3704,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1113,
+      "readme_linha": 1121,
       "tipo_fonte": "federal"
     },
     {
@@ -3677,7 +3730,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1117,
+      "readme_linha": 1125,
       "tipo_fonte": "federal"
     },
     {
@@ -3703,7 +3756,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 1121,
+      "readme_linha": 1129,
       "tipo_fonte": "federal"
     },
     {
@@ -3731,7 +3784,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1125,
+      "readme_linha": 1133,
       "tipo_fonte": "federal"
     },
     {
@@ -3757,7 +3810,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1129,
+      "readme_linha": 1137,
       "tipo_fonte": "federal"
     },
     {
@@ -3824,7 +3877,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1133,
+      "readme_linha": 1141,
       "tipo_fonte": "federal"
     },
     {
@@ -3850,7 +3903,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1150,
+      "readme_linha": 1158,
       "tipo_fonte": "federal"
     },
     {
@@ -3876,7 +3929,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1154,
+      "readme_linha": 1162,
       "tipo_fonte": "federal"
     },
     {
@@ -3902,7 +3955,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1158,
+      "readme_linha": 1166,
       "tipo_fonte": "federal"
     },
     {
@@ -3928,7 +3981,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1162,
+      "readme_linha": 1170,
       "tipo_fonte": "federal"
     },
     {
@@ -3954,7 +4007,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1166,
+      "readme_linha": 1174,
       "tipo_fonte": "federal"
     },
     {
@@ -3980,7 +4033,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1170,
+      "readme_linha": 1178,
       "tipo_fonte": "federal"
     },
     {
@@ -4006,7 +4059,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1174,
+      "readme_linha": 1182,
       "tipo_fonte": "federal"
     },
     {
@@ -4033,7 +4086,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1178,
+      "readme_linha": 1186,
       "tipo_fonte": "federal"
     },
     {
@@ -4059,7 +4112,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1182,
+      "readme_linha": 1190,
       "tipo_fonte": "estadual"
     },
     {
@@ -4086,7 +4139,7 @@
         "remuneracao",
         "sancao"
       ],
-      "readme_linha": 1186,
+      "readme_linha": 1194,
       "tipo_fonte": "estadual"
     },
     {
@@ -4112,7 +4165,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1190,
+      "readme_linha": 1198,
       "tipo_fonte": "federal"
     },
     {
@@ -4183,7 +4236,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1194,
+      "readme_linha": 1202,
       "tipo_fonte": "estadual"
     },
     {
@@ -4209,7 +4262,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1238,
+      "readme_linha": 1246,
       "tipo_fonte": "federal"
     },
     {
@@ -4375,7 +4428,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1242,
+      "readme_linha": 1250,
       "tipo_fonte": "estadual"
     },
     {
@@ -4399,7 +4452,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1311,
+      "readme_linha": 1319,
       "tipo_fonte": "federal"
     },
     {
@@ -4423,7 +4476,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1315,
+      "readme_linha": 1323,
       "tipo_fonte": "federal"
     },
     {
@@ -4447,7 +4500,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1319,
+      "readme_linha": 1327,
       "tipo_fonte": "ong"
     },
     {
@@ -4601,7 +4654,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1323,
+      "readme_linha": 1331,
       "tipo_fonte": "estadual"
     },
     {
@@ -4627,7 +4680,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 1388,
+      "readme_linha": 1396,
       "tipo_fonte": "federal"
     },
     {
@@ -4651,7 +4704,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1392,
+      "readme_linha": 1400,
       "tipo_fonte": "federal"
     },
     {
@@ -4675,7 +4728,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1396,
+      "readme_linha": 1404,
       "tipo_fonte": "federal"
     },
     {
@@ -4699,7 +4752,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1400,
+      "readme_linha": 1408,
       "tipo_fonte": "federal"
     },
     {
@@ -4723,7 +4776,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1404,
+      "readme_linha": 1412,
       "tipo_fonte": "federal"
     },
     {
@@ -4747,7 +4800,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1408,
+      "readme_linha": 1416,
       "tipo_fonte": "federal"
     },
     {
@@ -4771,7 +4824,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1412,
+      "readme_linha": 1420,
       "tipo_fonte": "federal"
     },
     {
@@ -4795,7 +4848,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1416,
+      "readme_linha": 1424,
       "tipo_fonte": "federal"
     },
     {
@@ -4819,7 +4872,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1420,
+      "readme_linha": 1428,
       "tipo_fonte": "federal"
     },
     {
@@ -4843,7 +4896,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1424,
+      "readme_linha": 1432,
       "tipo_fonte": "federal"
     },
     {
@@ -4877,7 +4930,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1433,
+      "readme_linha": 1441,
       "tipo_fonte": "privado"
     },
     {
@@ -4905,7 +4958,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1446,
+      "readme_linha": 1454,
       "tipo_fonte": "privado"
     },
     {
@@ -4943,7 +4996,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1451,
+      "readme_linha": 1459,
       "tipo_fonte": "privado"
     },
     {
@@ -4967,7 +5020,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1463,
+      "readme_linha": 1471,
       "tipo_fonte": "privado"
     },
     {
@@ -5031,7 +5084,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1469,
+      "readme_linha": 1477,
       "tipo_fonte": "ong"
     },
     {
@@ -5056,7 +5109,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1487,
+      "readme_linha": 1495,
       "tipo_fonte": "federal"
     },
     {
@@ -5081,7 +5134,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1491,
+      "readme_linha": 1499,
       "tipo_fonte": "federal"
     },
     {
@@ -5105,7 +5158,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1495,
+      "readme_linha": 1503,
       "tipo_fonte": "federal"
     },
     {
@@ -5128,7 +5181,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1499,
+      "readme_linha": 1507,
       "tipo_fonte": "federal"
     },
     {
@@ -5151,7 +5204,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1503,
+      "readme_linha": 1511,
       "tipo_fonte": "federal"
     },
     {
@@ -5180,7 +5233,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1507,
+      "readme_linha": 1515,
       "tipo_fonte": "privado"
     },
     {
@@ -5204,7 +5257,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1512,
+      "readme_linha": 1520,
       "tipo_fonte": "federal"
     },
     {
@@ -5227,7 +5280,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1516,
+      "readme_linha": 1524,
       "tipo_fonte": "federal"
     },
     {
@@ -5252,7 +5305,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1520,
+      "readme_linha": 1528,
       "tipo_fonte": "federal"
     },
     {
@@ -5278,7 +5331,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1528,
+      "readme_linha": 1536,
       "tipo_fonte": "federal"
     },
     {
@@ -5303,7 +5356,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1534,
+      "readme_linha": 1542,
       "tipo_fonte": "federal"
     },
     {
@@ -5328,7 +5381,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1540,
+      "readme_linha": 1548,
       "tipo_fonte": "federal"
     },
     {
@@ -5353,7 +5406,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1546,
+      "readme_linha": 1554,
       "tipo_fonte": "federal"
     },
     {
@@ -5377,7 +5430,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1553,
+      "readme_linha": 1561,
       "tipo_fonte": "federal"
     },
     {
@@ -5400,7 +5453,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1560,
+      "readme_linha": 1568,
       "tipo_fonte": "federal"
     },
     {
@@ -5427,7 +5480,7 @@
         "outorga",
         "radiofrequencia"
       ],
-      "readme_linha": 1567,
+      "readme_linha": 1575,
       "tipo_fonte": "federal"
     },
     {
@@ -5452,7 +5505,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1574,
+      "readme_linha": 1582,
       "tipo_fonte": "federal"
     },
     {
@@ -5475,7 +5528,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1581,
+      "readme_linha": 1589,
       "tipo_fonte": "federal"
     },
     {
@@ -5499,7 +5552,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1588,
+      "readme_linha": 1596,
       "tipo_fonte": "federal"
     },
     {
@@ -5523,7 +5576,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1595,
+      "readme_linha": 1603,
       "tipo_fonte": "federal"
     },
     {
@@ -5547,7 +5600,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1608,
+      "readme_linha": 1616,
       "tipo_fonte": "federal"
     },
     {
@@ -5572,7 +5625,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1614,
+      "readme_linha": 1622,
       "tipo_fonte": "ong"
     },
     {
@@ -5605,7 +5658,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1620,
+      "readme_linha": 1628,
       "tipo_fonte": "privado"
     },
     {
@@ -5633,7 +5686,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1631,
+      "readme_linha": 1639,
       "tipo_fonte": "ong"
     },
     {
@@ -5704,7 +5757,7 @@
         "erb",
         "operadora"
       ],
-      "readme_linha": 1640,
+      "readme_linha": 1648,
       "tipo_fonte": "privado"
     },
     {
@@ -5728,7 +5781,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1666,
+      "readme_linha": 1674,
       "tipo_fonte": "privado"
     },
     {
@@ -5754,7 +5807,7 @@
         "processo",
         "publicacao_academica"
       ],
-      "readme_linha": 1672,
+      "readme_linha": 1680,
       "tipo_fonte": "federal"
     },
     {
@@ -5778,7 +5831,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1678,
+      "readme_linha": 1686,
       "tipo_fonte": "privado"
     },
     {
@@ -5802,7 +5855,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1682,
+      "readme_linha": 1690,
       "tipo_fonte": "academico"
     },
     {
@@ -5826,7 +5879,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1686,
+      "readme_linha": 1694,
       "tipo_fonte": "academico"
     },
     {
@@ -5850,7 +5903,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1690,
+      "readme_linha": 1698,
       "tipo_fonte": "academico"
     },
     {
@@ -5874,7 +5927,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1694,
+      "readme_linha": 1702,
       "tipo_fonte": "academico"
     },
     {
@@ -5898,7 +5951,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1698,
+      "readme_linha": 1706,
       "tipo_fonte": "federal"
     },
     {
@@ -5922,7 +5975,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1702,
+      "readme_linha": 1710,
       "tipo_fonte": "privado"
     },
     {
@@ -5946,7 +5999,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1706,
+      "readme_linha": 1714,
       "tipo_fonte": "federal"
     },
     {
@@ -5970,7 +6023,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1710,
+      "readme_linha": 1718,
       "tipo_fonte": "ong"
     },
     {
@@ -5995,7 +6048,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1714,
+      "readme_linha": 1722,
       "tipo_fonte": "federal"
     },
     {
@@ -6021,7 +6074,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1718,
+      "readme_linha": 1726,
       "tipo_fonte": "federal"
     },
     {
@@ -6046,7 +6099,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 1722,
+      "readme_linha": 1730,
       "tipo_fonte": "federal"
     },
     {
@@ -6070,7 +6123,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1726,
+      "readme_linha": 1734,
       "tipo_fonte": "federal"
     },
     {
@@ -6094,7 +6147,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1730,
+      "readme_linha": 1738,
       "tipo_fonte": "federal"
     },
     {
@@ -6118,7 +6171,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1734,
+      "readme_linha": 1742,
       "tipo_fonte": "federal"
     },
     {
@@ -6258,7 +6311,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1743,
+      "readme_linha": 1751,
       "tipo_fonte": "privado"
     },
     {
@@ -6289,7 +6342,7 @@
         "area_rural",
         "mapa"
       ],
-      "readme_linha": 1777,
+      "readme_linha": 1785,
       "tipo_fonte": "federal"
     },
     {
@@ -6313,7 +6366,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1784,
+      "readme_linha": 1792,
       "tipo_fonte": "federal"
     },
     {
@@ -6342,7 +6395,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1790,
+      "readme_linha": 1798,
       "tipo_fonte": "federal"
     },
     {
@@ -6366,7 +6419,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1797,
+      "readme_linha": 1805,
       "tipo_fonte": "privado"
     },
     {
@@ -6407,7 +6460,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1801,
+      "readme_linha": 1809,
       "tipo_fonte": "internacional"
     },
     {
@@ -6436,7 +6489,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1813,
+      "readme_linha": 1821,
       "tipo_fonte": "federal"
     },
     {
@@ -6461,7 +6514,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1820,
+      "readme_linha": 1828,
       "tipo_fonte": "federal"
     },
     {
@@ -6485,7 +6538,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1826,
+      "readme_linha": 1834,
       "tipo_fonte": "federal"
     },
     {
@@ -6524,7 +6577,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1830,
+      "readme_linha": 1838,
       "tipo_fonte": "federal"
     },
     {
@@ -6548,7 +6601,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1842,
+      "readme_linha": 1850,
       "tipo_fonte": "federal"
     },
     {
@@ -6572,7 +6625,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1846,
+      "readme_linha": 1854,
       "tipo_fonte": "federal"
     },
     {
@@ -6597,7 +6650,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1856,
+      "readme_linha": 1864,
       "tipo_fonte": "federal"
     },
     {
@@ -6622,7 +6675,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1863,
+      "readme_linha": 1871,
       "tipo_fonte": "federal"
     },
     {
@@ -6649,7 +6702,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1870,
+      "readme_linha": 1878,
       "tipo_fonte": "federal"
     },
     {
@@ -6678,7 +6731,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1877,
+      "readme_linha": 1885,
       "tipo_fonte": "federal"
     },
     {
@@ -6704,7 +6757,7 @@
         "mapa",
         "sancao"
       ],
-      "readme_linha": 1884,
+      "readme_linha": 1892,
       "tipo_fonte": "federal"
     },
     {
@@ -6729,7 +6782,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1891,
+      "readme_linha": 1899,
       "tipo_fonte": "federal"
     },
     {
@@ -6756,7 +6809,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1898,
+      "readme_linha": 1906,
       "tipo_fonte": "federal"
     },
     {
@@ -6782,7 +6835,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1905,
+      "readme_linha": 1913,
       "tipo_fonte": "privado"
     },
     {
@@ -6807,7 +6860,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1912,
+      "readme_linha": 1920,
       "tipo_fonte": "federal"
     },
     {
@@ -6834,7 +6887,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1919,
+      "readme_linha": 1927,
       "tipo_fonte": "federal"
     },
     {
@@ -6859,7 +6912,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1926,
+      "readme_linha": 1934,
       "tipo_fonte": "federal"
     },
     {
@@ -6885,7 +6938,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1933,
+      "readme_linha": 1941,
       "tipo_fonte": "federal"
     },
     {
@@ -6911,7 +6964,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1940,
+      "readme_linha": 1948,
       "tipo_fonte": "federal"
     },
     {
@@ -6936,7 +6989,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1947,
+      "readme_linha": 1955,
       "tipo_fonte": "federal"
     },
     {
@@ -6963,7 +7016,7 @@
         "mapa",
         "processo"
       ],
-      "readme_linha": 1954,
+      "readme_linha": 1962,
       "tipo_fonte": "federal"
     },
     {
@@ -6990,7 +7043,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1961,
+      "readme_linha": 1969,
       "tipo_fonte": "federal"
     },
     {
@@ -7014,7 +7067,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1972,
+      "readme_linha": 1980,
       "tipo_fonte": "federal"
     },
     {
@@ -7038,7 +7091,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1978,
+      "readme_linha": 1986,
       "tipo_fonte": "federal"
     },
     {
@@ -7063,7 +7116,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1982,
+      "readme_linha": 1990,
       "tipo_fonte": "federal"
     },
     {
@@ -7087,7 +7140,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1986,
+      "readme_linha": 1994,
       "tipo_fonte": "federal"
     },
     {
@@ -7111,7 +7164,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1990,
+      "readme_linha": 1998,
       "tipo_fonte": "federal"
     },
     {
@@ -7135,7 +7188,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1994,
+      "readme_linha": 2002,
       "tipo_fonte": "federal"
     },
     {
@@ -7164,7 +7217,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1998,
+      "readme_linha": 2006,
       "tipo_fonte": "federal"
     },
     {
@@ -7189,7 +7242,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 2003,
+      "readme_linha": 2011,
       "tipo_fonte": "ong"
     },
     {
@@ -7214,7 +7267,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 2007,
+      "readme_linha": 2015,
       "tipo_fonte": "academico"
     },
     {
@@ -7238,7 +7291,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2011,
+      "readme_linha": 2019,
       "tipo_fonte": "academico"
     },
     {
@@ -7272,7 +7325,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2015,
+      "readme_linha": 2023,
       "tipo_fonte": "federal"
     },
     {
@@ -7310,7 +7363,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2032,
+      "readme_linha": 2040,
       "tipo_fonte": "dork"
     },
     {
@@ -7338,7 +7391,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2045,
+      "readme_linha": 2053,
       "tipo_fonte": "dork"
     },
     {
@@ -7366,7 +7419,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2052,
+      "readme_linha": 2060,
       "tipo_fonte": "dork"
     },
     {
@@ -7399,7 +7452,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2061,
+      "readme_linha": 2069,
       "tipo_fonte": "dork"
     },
     {
@@ -7437,7 +7490,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2072,
+      "readme_linha": 2080,
       "tipo_fonte": "dork"
     },
     {
@@ -7476,7 +7529,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2085,
+      "readme_linha": 2093,
       "tipo_fonte": "dork"
     },
     {
@@ -7515,7 +7568,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2101,
+      "readme_linha": 2109,
       "tipo_fonte": "internacional"
     },
     {
@@ -7549,7 +7602,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2113,
+      "readme_linha": 2121,
       "tipo_fonte": "internacional"
     },
     {
@@ -7577,7 +7630,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2120,
+      "readme_linha": 2128,
       "tipo_fonte": "dork"
     },
     {
@@ -7625,7 +7678,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2127,
+      "readme_linha": 2135,
       "tipo_fonte": "dork"
     },
     {
@@ -7663,7 +7716,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2147,
+      "readme_linha": 2155,
       "tipo_fonte": "dork"
     },
     {
@@ -7702,7 +7755,7 @@
         "dork",
         "video_ao_vivo"
       ],
-      "readme_linha": 2162,
+      "readme_linha": 2170,
       "tipo_fonte": "dork"
     },
     {
@@ -7743,7 +7796,7 @@
         "dork",
         "operadora"
       ],
-      "readme_linha": 2177,
+      "readme_linha": 2185,
       "tipo_fonte": "dork"
     },
     {
@@ -7777,7 +7830,7 @@
         "dork",
         "publicacao_academica"
       ],
-      "readme_linha": 2192,
+      "readme_linha": 2200,
       "tipo_fonte": "dork"
     },
     {
@@ -7810,7 +7863,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2204,
+      "readme_linha": 2212,
       "tipo_fonte": "dork"
     },
     {
@@ -7838,7 +7891,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2216,
+      "readme_linha": 2224,
       "tipo_fonte": "dork"
     },
     {
@@ -7867,7 +7920,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2226,
+      "readme_linha": 2234,
       "tipo_fonte": "internacional"
     },
     {
@@ -7910,7 +7963,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2238,
+      "readme_linha": 2246,
       "tipo_fonte": "dork"
     },
     {
@@ -7935,7 +7988,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2262,
+      "readme_linha": 2270,
       "tipo_fonte": "internacional"
     },
     {
@@ -7970,7 +8023,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2268,
+      "readme_linha": 2276,
       "tipo_fonte": "internacional"
     },
     {
@@ -8000,7 +8053,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2279,
+      "readme_linha": 2287,
       "tipo_fonte": "internacional"
     },
     {
@@ -8025,7 +8078,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2287,
+      "readme_linha": 2295,
       "tipo_fonte": "internacional"
     },
     {
@@ -8051,7 +8104,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2293,
+      "readme_linha": 2301,
       "tipo_fonte": "internacional"
     },
     {
@@ -8077,7 +8130,7 @@
         "estatistica",
         "perfil_social"
       ],
-      "readme_linha": 2299,
+      "readme_linha": 2307,
       "tipo_fonte": "internacional"
     },
     {
@@ -8102,7 +8155,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2305,
+      "readme_linha": 2313,
       "tipo_fonte": "internacional"
     },
     {
@@ -8127,7 +8180,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2311,
+      "readme_linha": 2319,
       "tipo_fonte": "internacional"
     },
     {
@@ -8152,7 +8205,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2315,
+      "readme_linha": 2323,
       "tipo_fonte": "internacional"
     },
     {
@@ -8177,7 +8230,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2319,
+      "readme_linha": 2327,
       "tipo_fonte": "internacional"
     },
     {
@@ -8202,7 +8255,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2323,
+      "readme_linha": 2331,
       "tipo_fonte": "internacional"
     },
     {
@@ -8227,7 +8280,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2327,
+      "readme_linha": 2335,
       "tipo_fonte": "internacional"
     },
     {
@@ -8252,7 +8305,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2331,
+      "readme_linha": 2339,
       "tipo_fonte": "internacional"
     },
     {
@@ -8278,7 +8331,7 @@
         "mandado_prisao",
         "perfil_social"
       ],
-      "readme_linha": 2337,
+      "readme_linha": 2345,
       "tipo_fonte": "privado"
     },
     {
@@ -8308,7 +8361,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2343,
+      "readme_linha": 2351,
       "tipo_fonte": "privado"
     },
     {
@@ -8338,7 +8391,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2350,
+      "readme_linha": 2358,
       "tipo_fonte": "internacional"
     },
     {
@@ -8364,7 +8417,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2356,
+      "readme_linha": 2364,
       "tipo_fonte": "internacional"
     },
     {
@@ -8389,7 +8442,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2363,
+      "readme_linha": 2371,
       "tipo_fonte": "privado"
     },
     {
@@ -8414,7 +8467,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2369,
+      "readme_linha": 2377,
       "tipo_fonte": "internacional"
     },
     {
@@ -8497,7 +8550,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2382,
+      "readme_linha": 2390,
       "tipo_fonte": "privado"
     },
     {
@@ -8560,7 +8613,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2407,
+      "readme_linha": 2415,
       "tipo_fonte": "privado"
     },
     {
@@ -8583,7 +8636,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2434,
+      "readme_linha": 2442,
       "tipo_fonte": "federal"
     },
     {
@@ -8606,7 +8659,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2440,
+      "readme_linha": 2448,
       "tipo_fonte": "privado"
     },
     {
@@ -8629,7 +8682,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2446,
+      "readme_linha": 2454,
       "tipo_fonte": "federal"
     },
     {
@@ -8652,7 +8705,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2452,
+      "readme_linha": 2460,
       "tipo_fonte": "privado"
     },
     {
@@ -8675,7 +8728,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2458,
+      "readme_linha": 2466,
       "tipo_fonte": "federal"
     },
     {
@@ -8698,7 +8751,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2464,
+      "readme_linha": 2472,
       "tipo_fonte": "federal"
     },
     {
@@ -8721,7 +8774,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2470,
+      "readme_linha": 2478,
       "tipo_fonte": "federal"
     },
     {
@@ -8745,7 +8798,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2476,
+      "readme_linha": 2484,
       "tipo_fonte": "federal"
     },
     {
@@ -8774,7 +8827,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 2480,
+      "readme_linha": 2488,
       "tipo_fonte": "federal"
     },
     {
@@ -8797,7 +8850,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2487,
+      "readme_linha": 2495,
       "tipo_fonte": "federal"
     },
     {
@@ -8820,7 +8873,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2491,
+      "readme_linha": 2499,
       "tipo_fonte": "federal"
     },
     {
@@ -8844,7 +8897,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2497,
+      "readme_linha": 2505,
       "tipo_fonte": "federal"
     },
     {
@@ -8867,7 +8920,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2503,
+      "readme_linha": 2511,
       "tipo_fonte": "estadual"
     },
     {
@@ -8891,7 +8944,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2509,
+      "readme_linha": 2517,
       "tipo_fonte": "estadual"
     },
     {
@@ -8915,7 +8968,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2515,
+      "readme_linha": 2523,
       "tipo_fonte": "federal"
     },
     {
@@ -8938,7 +8991,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2521,
+      "readme_linha": 2529,
       "tipo_fonte": "federal"
     },
     {
@@ -8961,7 +9014,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2527,
+      "readme_linha": 2535,
       "tipo_fonte": "estadual"
     },
     {
@@ -8985,7 +9038,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2533,
+      "readme_linha": 2541,
       "tipo_fonte": "federal"
     },
     {
@@ -9008,7 +9061,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2539,
+      "readme_linha": 2547,
       "tipo_fonte": "estadual"
     },
     {
@@ -9031,7 +9084,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2545,
+      "readme_linha": 2553,
       "tipo_fonte": "estadual"
     },
     {
@@ -9054,7 +9107,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2551,
+      "readme_linha": 2559,
       "tipo_fonte": "federal"
     },
     {
@@ -9077,7 +9130,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2557,
+      "readme_linha": 2565,
       "tipo_fonte": "estadual"
     },
     {
@@ -9100,7 +9153,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2563,
+      "readme_linha": 2571,
       "tipo_fonte": "estadual"
     },
     {
@@ -9123,7 +9176,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2567,
+      "readme_linha": 2575,
       "tipo_fonte": "federal"
     },
     {
@@ -9146,7 +9199,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2573,
+      "readme_linha": 2581,
       "tipo_fonte": "federal"
     },
     {
@@ -9169,7 +9222,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2579,
+      "readme_linha": 2587,
       "tipo_fonte": "estadual"
     },
     {
@@ -9192,7 +9245,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2585,
+      "readme_linha": 2593,
       "tipo_fonte": "federal"
     },
     {
@@ -9220,7 +9273,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2591,
+      "readme_linha": 2599,
       "tipo_fonte": "federal"
     },
     {
@@ -9245,7 +9298,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2598,
+      "readme_linha": 2606,
       "tipo_fonte": "estadual"
     },
     {
@@ -9268,7 +9321,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2602,
+      "readme_linha": 2610,
       "tipo_fonte": "federal"
     },
     {
@@ -9292,7 +9345,7 @@
         "dataset",
         "diario_oficial"
       ],
-      "readme_linha": 2606,
+      "readme_linha": 2614,
       "tipo_fonte": "ong"
     },
     {
@@ -9315,7 +9368,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2612,
+      "readme_linha": 2620,
       "tipo_fonte": "ong"
     },
     {
@@ -9338,7 +9391,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2616,
+      "readme_linha": 2624,
       "tipo_fonte": "federal"
     },
     {
@@ -9361,7 +9414,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2620,
+      "readme_linha": 2628,
       "tipo_fonte": "federal"
     },
     {
@@ -9384,7 +9437,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2624,
+      "readme_linha": 2632,
       "tipo_fonte": "privado"
     },
     {
@@ -9407,7 +9460,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2628,
+      "readme_linha": 2636,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9430,7 +9483,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2632,
+      "readme_linha": 2640,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9454,7 +9507,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2636,
+      "readme_linha": 2644,
       "tipo_fonte": "federal"
     },
     {
@@ -9477,7 +9530,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2640,
+      "readme_linha": 2648,
       "tipo_fonte": "federal"
     },
     {
@@ -9501,7 +9554,7 @@
         "dataset",
         "endereco"
       ],
-      "readme_linha": 2644,
+      "readme_linha": 2652,
       "tipo_fonte": "privado"
     },
     {
@@ -9526,7 +9579,7 @@
         "beneficio",
         "remuneracao"
       ],
-      "readme_linha": 2654,
+      "readme_linha": 2662,
       "tipo_fonte": "ong"
     },
     {
@@ -9550,7 +9603,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2662,
+      "readme_linha": 2670,
       "tipo_fonte": "estadual"
     },
     {
@@ -9574,7 +9627,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2666,
+      "readme_linha": 2674,
       "tipo_fonte": "estadual"
     },
     {
@@ -9673,7 +9726,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2672,
+      "readme_linha": 2680,
       "tipo_fonte": "privado"
     },
     {
@@ -9732,7 +9785,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2695,
+      "readme_linha": 2703,
       "tipo_fonte": "ong"
     },
     {
@@ -9761,7 +9814,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2710,
+      "readme_linha": 2718,
       "tipo_fonte": "privado"
     },
     {
@@ -9785,7 +9838,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2717,
+      "readme_linha": 2725,
       "tipo_fonte": "privado"
     },
     {
@@ -9809,7 +9862,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2723,
+      "readme_linha": 2731,
       "tipo_fonte": "federal"
     },
     {
@@ -9833,7 +9886,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2729,
+      "readme_linha": 2737,
       "tipo_fonte": "federal"
     },
     {
@@ -9858,7 +9911,7 @@
         "veiculo",
         "video_ao_vivo"
       ],
-      "readme_linha": 2735,
+      "readme_linha": 2743,
       "tipo_fonte": "internacional"
     },
     {
@@ -9882,7 +9935,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2739,
+      "readme_linha": 2747,
       "tipo_fonte": "internacional"
     },
     {
@@ -9907,7 +9960,7 @@
         "multa",
         "veiculo"
       ],
-      "readme_linha": 2743,
+      "readme_linha": 2751,
       "tipo_fonte": "federal"
     },
     {
@@ -9933,7 +9986,7 @@
         "dados_cadastrais",
         "veiculo"
       ],
-      "readme_linha": 2747,
+      "readme_linha": 2755,
       "tipo_fonte": "federal"
     },
     {
@@ -9957,7 +10010,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2751,
+      "readme_linha": 2759,
       "tipo_fonte": "federal"
     },
     {
@@ -9981,7 +10034,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2755,
+      "readme_linha": 2763,
       "tipo_fonte": "privado"
     },
     {
@@ -10005,7 +10058,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2761,
+      "readme_linha": 2769,
       "tipo_fonte": "federal"
     },
     {
@@ -10029,7 +10082,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2767,
+      "readme_linha": 2775,
       "tipo_fonte": "federal"
     },
     {
@@ -10054,7 +10107,7 @@
         "dataset",
         "veiculo"
       ],
-      "readme_linha": 2773,
+      "readme_linha": 2781,
       "tipo_fonte": "federal"
     },
     {
@@ -10083,7 +10136,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2779,
+      "readme_linha": 2787,
       "tipo_fonte": "estadual"
     },
     {
@@ -10112,7 +10165,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2786,
+      "readme_linha": 2794,
       "tipo_fonte": "estadual"
     },
     {
@@ -10281,7 +10334,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2793,
+      "readme_linha": 2801,
       "tipo_fonte": "estadual"
     },
     {
@@ -10305,7 +10358,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 2863,
+      "readme_linha": 2871,
       "tipo_fonte": "privado"
     },
     {
@@ -10328,7 +10381,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2869,
+      "readme_linha": 2877,
       "tipo_fonte": "privado"
     },
     {
@@ -10371,7 +10424,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2875,
+      "readme_linha": 2883,
       "tipo_fonte": "estadual"
     },
     {
@@ -10394,7 +10447,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2895,
+      "readme_linha": 2903,
       "tipo_fonte": "privado"
     },
     {
@@ -10417,7 +10470,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2901,
+      "readme_linha": 2909,
       "tipo_fonte": "privado"
     },
     {
@@ -10440,7 +10493,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2907,
+      "readme_linha": 2915,
       "tipo_fonte": "privado"
     },
     {
@@ -10465,7 +10518,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 2919,
+      "readme_linha": 2927,
       "tipo_fonte": "federal"
     },
     {
@@ -10491,7 +10544,7 @@
         "estatistica",
         "multa"
       ],
-      "readme_linha": 2923,
+      "readme_linha": 2931,
       "tipo_fonte": "privado"
     },
     {
@@ -10514,7 +10567,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2927,
+      "readme_linha": 2935,
       "tipo_fonte": "federal"
     },
     {
@@ -10537,7 +10590,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2931,
+      "readme_linha": 2939,
       "tipo_fonte": "federal"
     },
     {
@@ -10560,7 +10613,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2935,
+      "readme_linha": 2943,
       "tipo_fonte": "federal"
     },
     {
@@ -10583,7 +10636,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2939,
+      "readme_linha": 2947,
       "tipo_fonte": "federal"
     },
     {
@@ -10611,7 +10664,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2943,
+      "readme_linha": 2951,
       "tipo_fonte": "internacional"
     },
     {
@@ -10634,7 +10687,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2948,
+      "readme_linha": 2956,
       "tipo_fonte": "privado"
     },
     {
@@ -10657,7 +10710,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2952,
+      "readme_linha": 2960,
       "tipo_fonte": "privado"
     },
     {
@@ -10680,7 +10733,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2956,
+      "readme_linha": 2964,
       "tipo_fonte": "privado"
     },
     {
@@ -10703,7 +10756,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2966,
+      "readme_linha": 2974,
       "tipo_fonte": "federal"
     },
     {
@@ -10729,7 +10782,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 2972,
+      "readme_linha": 2980,
       "tipo_fonte": "privado"
     },
     {
@@ -10752,7 +10805,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2978,
+      "readme_linha": 2986,
       "tipo_fonte": "federal"
     },
     {
@@ -10777,7 +10830,7 @@
         "dados_cadastrais",
         "multa"
       ],
-      "readme_linha": 2984,
+      "readme_linha": 2992,
       "tipo_fonte": "federal"
     },
     {
@@ -10855,7 +10908,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2988,
+      "readme_linha": 2996,
       "tipo_fonte": "federal"
     },
     {
@@ -10878,7 +10931,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3016,
+      "readme_linha": 3024,
       "tipo_fonte": "estadual"
     },
     {
@@ -10901,7 +10954,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3022,
+      "readme_linha": 3030,
       "tipo_fonte": "privado"
     },
     {
@@ -10924,7 +10977,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3026,
+      "readme_linha": 3034,
       "tipo_fonte": "estadual"
     },
     {
@@ -10947,7 +11000,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3030,
+      "readme_linha": 3038,
       "tipo_fonte": "internacional"
     },
     {
@@ -10990,7 +11043,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3034,
+      "readme_linha": 3042,
       "tipo_fonte": "privado"
     },
     {
@@ -11038,7 +11091,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3049,
+      "readme_linha": 3057,
       "tipo_fonte": "privado"
     },
     {
@@ -11141,7 +11194,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3063,
+      "readme_linha": 3071,
       "tipo_fonte": "privado"
     },
     {
@@ -11164,7 +11217,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3104,
+      "readme_linha": 3112,
       "tipo_fonte": "privado"
     },
     {
@@ -11212,7 +11265,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3108,
+      "readme_linha": 3116,
       "tipo_fonte": "estadual"
     },
     {
@@ -11535,7 +11588,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3122,
+      "readme_linha": 3130,
       "tipo_fonte": "privado"
     },
     {
@@ -11558,7 +11611,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3197,
+      "readme_linha": 3205,
       "tipo_fonte": "privado"
     },
     {
@@ -11581,7 +11634,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3201,
+      "readme_linha": 3209,
       "tipo_fonte": "privado"
     },
     {
@@ -11604,7 +11657,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3205,
+      "readme_linha": 3213,
       "tipo_fonte": "estadual"
     },
     {
@@ -11627,7 +11680,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3209,
+      "readme_linha": 3217,
       "tipo_fonte": "federal"
     },
     {
@@ -11656,7 +11709,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3213,
+      "readme_linha": 3221,
       "tipo_fonte": "internacional"
     },
     {
@@ -11680,7 +11733,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3218,
+      "readme_linha": 3226,
       "tipo_fonte": "internacional"
     },
     {
@@ -11704,7 +11757,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3222,
+      "readme_linha": 3230,
       "tipo_fonte": "internacional"
     },
     {
@@ -11728,7 +11781,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3226,
+      "readme_linha": 3234,
       "tipo_fonte": "internacional"
     },
     {
@@ -11752,7 +11805,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3230,
+      "readme_linha": 3238,
       "tipo_fonte": "internacional"
     },
     {
@@ -11776,7 +11829,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3234,
+      "readme_linha": 3242,
       "tipo_fonte": "internacional"
     },
     {
@@ -11800,7 +11853,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3238,
+      "readme_linha": 3246,
       "tipo_fonte": "internacional"
     },
     {
@@ -11824,7 +11877,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3242,
+      "readme_linha": 3250,
       "tipo_fonte": "internacional"
     },
     {
@@ -11847,7 +11900,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3246,
+      "readme_linha": 3254,
       "tipo_fonte": "estadual"
     },
     {
@@ -11921,7 +11974,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3256,
+      "readme_linha": 3264,
       "tipo_fonte": "ministerio_publico"
     },
     {
@@ -11981,7 +12034,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3297,
+      "readme_linha": 3305,
       "tipo_fonte": "defensoria"
     },
     {
@@ -12015,7 +12068,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3329,
+      "readme_linha": 3337,
       "tipo_fonte": "ong"
     },
     {
@@ -12044,7 +12097,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3346,
+      "readme_linha": 3354,
       "tipo_fonte": "estadual"
     },
     {
@@ -12073,7 +12126,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3366,
+      "readme_linha": 3374,
       "tipo_fonte": "privado"
     },
     {
@@ -12122,7 +12175,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3371,
+      "readme_linha": 3379,
       "tipo_fonte": "estadual"
     },
     {
@@ -12147,7 +12200,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 3390,
+      "readme_linha": 3398,
       "tipo_fonte": "federal"
     },
     {
@@ -12172,7 +12225,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3394,
+      "readme_linha": 3402,
       "tipo_fonte": "ong"
     },
     {
@@ -12197,7 +12250,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3398,
+      "readme_linha": 3406,
       "tipo_fonte": "federal"
     },
     {
@@ -12220,7 +12273,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3402,
+      "readme_linha": 3410,
       "tipo_fonte": "privado"
     },
     {
@@ -12245,7 +12298,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3406,
+      "readme_linha": 3414,
       "tipo_fonte": "federal"
     },
     {
@@ -12268,7 +12321,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3410,
+      "readme_linha": 3418,
       "tipo_fonte": "federal"
     },
     {
@@ -12289,7 +12342,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3414,
+      "readme_linha": 3422,
       "tipo_fonte": "federal"
     },
     {
@@ -12317,7 +12370,7 @@
         "mandado_prisao",
         "veiculo"
       ],
-      "readme_linha": 3418,
+      "readme_linha": 3426,
       "tipo_fonte": "federal"
     },
     {
@@ -12358,7 +12411,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3427,
+      "readme_linha": 3435,
       "tipo_fonte": "privado"
     },
     {
@@ -12389,7 +12442,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3446,
+      "readme_linha": 3454,
       "tipo_fonte": "privado"
     },
     {
@@ -12418,7 +12471,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3460,
+      "readme_linha": 3468,
       "tipo_fonte": "privado"
     },
     {
@@ -12446,7 +12499,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3487,
+      "readme_linha": 3495,
       "tipo_fonte": "privado"
     },
     {
@@ -12476,7 +12529,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3509,
+      "readme_linha": 3517,
       "tipo_fonte": "privado"
     },
     {
@@ -12503,7 +12556,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3533,
+      "readme_linha": 3541,
       "tipo_fonte": "federal"
     },
     {
@@ -12530,7 +12583,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3556,
+      "readme_linha": 3564,
       "tipo_fonte": "federal"
     },
     {
@@ -12560,7 +12613,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3560,
+      "readme_linha": 3568,
       "tipo_fonte": "ong"
     },
     {
@@ -12586,7 +12639,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3583,
+      "readme_linha": 3591,
       "tipo_fonte": "federal"
     },
     {
@@ -12610,7 +12663,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3587,
+      "readme_linha": 3595,
       "tipo_fonte": "federal"
     },
     {
@@ -12633,7 +12686,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3597,
+      "readme_linha": 3605,
       "tipo_fonte": "federal"
     },
     {
@@ -12656,7 +12709,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3601,
+      "readme_linha": 3609,
       "tipo_fonte": "federal"
     },
     {
@@ -12685,7 +12738,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3605,
+      "readme_linha": 3613,
       "tipo_fonte": "federal"
     },
     {
@@ -12713,7 +12766,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3610,
+      "readme_linha": 3618,
       "tipo_fonte": "federal"
     },
     {
@@ -12736,7 +12789,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3615,
+      "readme_linha": 3623,
       "tipo_fonte": "federal"
     },
     {
@@ -12759,7 +12812,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3619,
+      "readme_linha": 3627,
       "tipo_fonte": "federal"
     },
     {
@@ -12788,7 +12841,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3629,
+      "readme_linha": 3637,
       "tipo_fonte": "federal"
     },
     {
@@ -12812,7 +12865,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3634,
+      "readme_linha": 3642,
       "tipo_fonte": "federal"
     },
     {
@@ -12836,7 +12889,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3638,
+      "readme_linha": 3646,
       "tipo_fonte": "federal"
     },
     {
@@ -12866,7 +12919,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3642,
+      "readme_linha": 3650,
       "tipo_fonte": "ong"
     },
     {
@@ -12896,7 +12949,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3647,
+      "readme_linha": 3655,
       "tipo_fonte": "federal"
     },
     {
@@ -12921,7 +12974,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3652,
+      "readme_linha": 3660,
       "tipo_fonte": "federal"
     },
     {
@@ -12945,7 +12998,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3656,
+      "readme_linha": 3664,
       "tipo_fonte": "federal"
     },
     {
@@ -12969,7 +13022,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3660,
+      "readme_linha": 3668,
       "tipo_fonte": "federal"
     },
     {
@@ -13024,7 +13077,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3670,
+      "readme_linha": 3678,
       "tipo_fonte": "ong"
     },
     {
@@ -13148,7 +13201,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3709,
+      "readme_linha": 3717,
       "tipo_fonte": "estadual"
     },
     {
@@ -13268,7 +13321,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3750,
+      "readme_linha": 3758,
       "tipo_fonte": "ong"
     },
     {
@@ -13302,7 +13355,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3779,
+      "readme_linha": 3787,
       "tipo_fonte": "estadual"
     },
     {
@@ -13328,7 +13381,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3791,
+      "readme_linha": 3799,
       "tipo_fonte": "estadual"
     },
     {
@@ -13354,7 +13407,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3795,
+      "readme_linha": 3803,
       "tipo_fonte": "estadual"
     },
     {
@@ -13378,7 +13431,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3799,
+      "readme_linha": 3807,
       "tipo_fonte": "estadual"
     },
     {
@@ -13401,7 +13454,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3809,
+      "readme_linha": 3817,
       "tipo_fonte": "ong"
     },
     {
@@ -13424,7 +13477,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3813,
+      "readme_linha": 3821,
       "tipo_fonte": "federal"
     },
     {
@@ -13448,7 +13501,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3817,
+      "readme_linha": 3825,
       "tipo_fonte": "ong"
     },
     {
@@ -13471,7 +13524,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3821,
+      "readme_linha": 3829,
       "tipo_fonte": "federal"
     },
     {
@@ -13494,7 +13547,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3825,
+      "readme_linha": 3833,
       "tipo_fonte": "federal"
     },
     {
@@ -13522,7 +13575,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3829,
+      "readme_linha": 3837,
       "tipo_fonte": "privado"
     },
     {
@@ -13610,7 +13663,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3841,
+      "readme_linha": 3849,
       "tipo_fonte": "privado"
     },
     {
@@ -13661,7 +13714,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3863,
+      "readme_linha": 3871,
       "tipo_fonte": "privado"
     },
     {
@@ -13684,7 +13737,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3876,
+      "readme_linha": 3884,
       "tipo_fonte": "estadual"
     },
     {
@@ -13717,7 +13770,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3882,
+      "readme_linha": 3890,
       "tipo_fonte": "privado"
     },
     {
@@ -13741,7 +13794,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3893,
+      "readme_linha": 3901,
       "tipo_fonte": "privado"
     },
     {
@@ -13764,7 +13817,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3897,
+      "readme_linha": 3905,
       "tipo_fonte": "federal"
     },
     {
@@ -13798,7 +13851,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3903,
+      "readme_linha": 3911,
       "tipo_fonte": "privado"
     },
     {
@@ -13884,7 +13937,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3913,
+      "readme_linha": 3921,
       "tipo_fonte": "privado"
     },
     {
@@ -13908,7 +13961,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3962,
+      "readme_linha": 3970,
       "tipo_fonte": "estadual"
     },
     {
@@ -13942,9 +13995,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4125,
+      "readme_linha": 4133,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 442
+  "total": 444
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -76,23 +76,6 @@
       "categoria": "Benefícios sociais (Políticas Públicas)",
       "categoria_id": "beneficios-sociais-politicas-publicas",
       "classificacao": "heuristica",
-      "descricao": "",
-      "id": "beneficios-sociais-politicas-publicas/extrato-do-beneficio-de-prestacao-continuada-inss",
-      "input": [
-        "cpf"
-      ],
-      "links": [],
-      "nome": "Extrato do Benefício de Prestação Continuada (INSS)",
-      "output": [
-        "beneficio"
-      ],
-      "readme_linha": 209,
-      "tipo_fonte": "indefinido"
-    },
-    {
-      "categoria": "Benefícios sociais (Políticas Públicas)",
-      "categoria_id": "beneficios-sociais-politicas-publicas",
-      "classificacao": "heuristica",
       "descricao": "Portal oficial para consulta de benefícios previdenciários, extrato de contribuições, agendamentos e outros serviços do INSS.",
       "id": "beneficios-sociais-politicas-publicas/meu-inss",
       "input": [
@@ -109,7 +92,7 @@
       "output": [
         "beneficio"
       ],
-      "readme_linha": 213,
+      "readme_linha": 209,
       "tipo_fonte": "federal"
     },
     {
@@ -137,7 +120,7 @@
       "output": [
         "beneficio"
       ],
-      "readme_linha": 217,
+      "readme_linha": 213,
       "tipo_fonte": "federal"
     },
     {
@@ -160,7 +143,7 @@
       "output": [
         "beneficio"
       ],
-      "readme_linha": 225,
+      "readme_linha": 221,
       "tipo_fonte": "federal"
     },
     {
@@ -278,7 +261,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 236,
+      "readme_linha": 232,
       "tipo_fonte": "estadual"
     },
     {
@@ -302,7 +285,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 266,
+      "readme_linha": 262,
       "tipo_fonte": "estadual"
     },
     {
@@ -326,7 +309,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 272,
+      "readme_linha": 268,
       "tipo_fonte": "estadual"
     },
     {
@@ -349,7 +332,7 @@
       "output": [
         "mandado_prisao"
       ],
-      "readme_linha": 284,
+      "readme_linha": 280,
       "tipo_fonte": "federal"
     },
     {
@@ -372,7 +355,7 @@
       "output": [
         "mandado_prisao"
       ],
-      "readme_linha": 289,
+      "readme_linha": 285,
       "tipo_fonte": "estadual"
     },
     {
@@ -395,7 +378,7 @@
       "output": [
         "mandado_prisao"
       ],
-      "readme_linha": 294,
+      "readme_linha": 290,
       "tipo_fonte": "estadual"
     },
     {
@@ -418,7 +401,7 @@
       "output": [
         "mandado_prisao"
       ],
-      "readme_linha": 299,
+      "readme_linha": 295,
       "tipo_fonte": "estadual"
     },
     {
@@ -441,7 +424,7 @@
       "output": [
         "mandado_prisao"
       ],
-      "readme_linha": 304,
+      "readme_linha": 300,
       "tipo_fonte": "internacional"
     },
     {
@@ -474,7 +457,7 @@
       "output": [
         "mandado_prisao"
       ],
-      "readme_linha": 309,
+      "readme_linha": 305,
       "tipo_fonte": "federal"
     },
     {
@@ -523,7 +506,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 323,
+      "readme_linha": 319,
       "tipo_fonte": "judiciario"
     },
     {
@@ -591,7 +574,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 338,
+      "readme_linha": 334,
       "tipo_fonte": "judiciario"
     },
     {
@@ -619,7 +602,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 372,
+      "readme_linha": 368,
       "tipo_fonte": "judiciario"
     },
     {
@@ -647,7 +630,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 376,
+      "readme_linha": 372,
       "tipo_fonte": "judiciario"
     },
     {
@@ -676,7 +659,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 380,
+      "readme_linha": 376,
       "tipo_fonte": "judiciario"
     },
     {
@@ -719,7 +702,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 386,
+      "readme_linha": 382,
       "tipo_fonte": "judiciario"
     },
     {
@@ -747,7 +730,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 401,
+      "readme_linha": 397,
       "tipo_fonte": "privado"
     },
     {
@@ -775,7 +758,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 407,
+      "readme_linha": 403,
       "tipo_fonte": "privado"
     },
     {
@@ -803,7 +786,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 413,
+      "readme_linha": 409,
       "tipo_fonte": "ong"
     },
     {
@@ -866,7 +849,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 419,
+      "readme_linha": 415,
       "tipo_fonte": "judiciario"
     },
     {
@@ -894,7 +877,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 435,
+      "readme_linha": 431,
       "tipo_fonte": "judiciario"
     },
     {
@@ -922,7 +905,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 439,
+      "readme_linha": 435,
       "tipo_fonte": "judiciario"
     },
     {
@@ -950,7 +933,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 443,
+      "readme_linha": 439,
       "tipo_fonte": "judiciario"
     },
     {
@@ -978,7 +961,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 447,
+      "readme_linha": 443,
       "tipo_fonte": "judiciario"
     },
     {
@@ -1081,7 +1064,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 451,
+      "readme_linha": 447,
       "tipo_fonte": "judiciario"
     },
     {
@@ -1106,7 +1089,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 501,
+      "readme_linha": 497,
       "tipo_fonte": "federal"
     },
     {
@@ -1231,7 +1214,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 505,
+      "readme_linha": 501,
       "tipo_fonte": "federal"
     },
     {
@@ -1257,7 +1240,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 535,
+      "readme_linha": 531,
       "tipo_fonte": "federal"
     },
     {
@@ -1283,7 +1266,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 539,
+      "readme_linha": 535,
       "tipo_fonte": "internacional"
     },
     {
@@ -1308,7 +1291,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 545,
+      "readme_linha": 541,
       "tipo_fonte": "internacional"
     },
     {
@@ -1333,7 +1316,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 551,
+      "readme_linha": 547,
       "tipo_fonte": "privado"
     },
     {
@@ -1360,7 +1343,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 557,
+      "readme_linha": 553,
       "tipo_fonte": "judiciario"
     },
     {
@@ -1391,7 +1374,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 563,
+      "readme_linha": 559,
       "tipo_fonte": "privado"
     },
     {
@@ -1442,7 +1425,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 571,
+      "readme_linha": 567,
       "tipo_fonte": "estadual"
     },
     {
@@ -1469,7 +1452,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 595,
+      "readme_linha": 591,
       "tipo_fonte": "ong"
     },
     {
@@ -1495,7 +1478,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 602,
+      "readme_linha": 598,
       "tipo_fonte": "ong"
     },
     {
@@ -1521,7 +1504,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 609,
+      "readme_linha": 605,
       "tipo_fonte": "ong"
     },
     {
@@ -1547,7 +1530,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 616,
+      "readme_linha": 612,
       "tipo_fonte": "federal"
     },
     {
@@ -1573,7 +1556,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 620,
+      "readme_linha": 616,
       "tipo_fonte": "ong"
     },
     {
@@ -1599,7 +1582,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 624,
+      "readme_linha": 620,
       "tipo_fonte": "federal"
     },
     {
@@ -1625,7 +1608,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 628,
+      "readme_linha": 624,
       "tipo_fonte": "ong"
     },
     {
@@ -1651,7 +1634,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 632,
+      "readme_linha": 628,
       "tipo_fonte": "ong"
     },
     {
@@ -1681,7 +1664,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 641,
+      "readme_linha": 637,
       "tipo_fonte": "federal"
     },
     {
@@ -1807,7 +1790,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 648,
+      "readme_linha": 644,
       "tipo_fonte": "estadual"
     },
     {
@@ -1832,7 +1815,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 678,
+      "readme_linha": 674,
       "tipo_fonte": "federal"
     },
     {
@@ -1846,15 +1829,21 @@
         "cpf",
         "nome"
       ],
-      "links": [],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://www.restituicao.receita.fazenda.gov.br/"
+        }
+      ],
       "nome": "Consulta Restituição do Imposto de Renda",
       "output": [
         "dados_cadastrais",
         "debito",
         "situacao_cadastral"
       ],
-      "readme_linha": 683,
-      "tipo_fonte": "indefinido"
+      "readme_linha": 679,
+      "tipo_fonte": "federal"
     },
     {
       "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
@@ -1878,7 +1867,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 687,
+      "readme_linha": 684,
       "tipo_fonte": "federal"
     },
     {
@@ -1906,7 +1895,7 @@
         "sancao",
         "situacao_cadastral"
       ],
-      "readme_linha": 691,
+      "readme_linha": 688,
       "tipo_fonte": "federal"
     },
     {
@@ -1932,7 +1921,7 @@
         "sancao",
         "situacao_cadastral"
       ],
-      "readme_linha": 695,
+      "readme_linha": 692,
       "tipo_fonte": "federal"
     },
     {
@@ -1959,7 +1948,7 @@
         "sancao",
         "situacao_cadastral"
       ],
-      "readme_linha": 699,
+      "readme_linha": 696,
       "tipo_fonte": "federal"
     },
     {
@@ -2006,7 +1995,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 704,
+      "readme_linha": 701,
       "tipo_fonte": "estadual"
     },
     {
@@ -2031,7 +2020,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 719,
+      "readme_linha": 716,
       "tipo_fonte": "federal"
     },
     {
@@ -2056,7 +2045,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 723,
+      "readme_linha": 720,
       "tipo_fonte": "federal"
     },
     {
@@ -2087,7 +2076,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 728,
+      "readme_linha": 725,
       "tipo_fonte": "federal"
     },
     {
@@ -2115,7 +2104,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 744,
+      "readme_linha": 741,
       "tipo_fonte": "federal"
     },
     {
@@ -2223,7 +2212,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 756,
+      "readme_linha": 753,
       "tipo_fonte": "estadual"
     },
     {
@@ -2251,7 +2240,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 817,
+      "readme_linha": 814,
       "tipo_fonte": "ong"
     },
     {
@@ -2274,7 +2263,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 822,
+      "readme_linha": 819,
       "tipo_fonte": "privado"
     },
     {
@@ -2297,7 +2286,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 826,
+      "readme_linha": 823,
       "tipo_fonte": "ong"
     },
     {
@@ -2321,7 +2310,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 830,
+      "readme_linha": 827,
       "tipo_fonte": "privado"
     },
     {
@@ -2346,7 +2335,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 840,
+      "readme_linha": 837,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2371,7 +2360,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 844,
+      "readme_linha": 841,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2396,7 +2385,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 848,
+      "readme_linha": 845,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2421,7 +2410,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 852,
+      "readme_linha": 849,
       "tipo_fonte": "legislativo"
     },
     {
@@ -2446,7 +2435,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 856,
+      "readme_linha": 853,
       "tipo_fonte": "legislativo"
     },
     {
@@ -2472,7 +2461,7 @@
         "dados_cadastrais",
         "dataset"
       ],
-      "readme_linha": 860,
+      "readme_linha": 857,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2498,7 +2487,7 @@
         "dados_cadastrais",
         "dataset"
       ],
-      "readme_linha": 864,
+      "readme_linha": 861,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2524,7 +2513,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 868,
+      "readme_linha": 865,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2549,7 +2538,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 872,
+      "readme_linha": 869,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2575,7 +2564,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 876,
+      "readme_linha": 873,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2601,7 +2590,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 880,
+      "readme_linha": 877,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2629,7 +2618,7 @@
         "debito",
         "multa"
       ],
-      "readme_linha": 884,
+      "readme_linha": 881,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2654,7 +2643,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 888,
+      "readme_linha": 885,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2680,7 +2669,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 892,
+      "readme_linha": 889,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2705,7 +2694,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 896,
+      "readme_linha": 893,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2733,7 +2722,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 900,
+      "readme_linha": 897,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2758,16 +2747,20 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 904,
+      "readme_linha": 901,
       "tipo_fonte": "judiciario"
     },
     {
-      "categoria": "Consultar Zonas Eleitorais por UF",
-      "categoria_id": "consultar-zonas-eleitorais-por-uf",
-      "classificacao": "indefinido",
-      "descricao": "",
-      "id": "consultar-zonas-eleitorais-por-uf/consultar-zonas-eleitorais-por-uf",
-      "input": [],
+      "categoria": "Registros Eleitorais e Políticos",
+      "categoria_id": "registros-eleitorais-e-politicos",
+      "classificacao": "heuristica",
+      "descricao": "Lista as zonas eleitorais e unidades da Justiça Eleitoral de cada estado.",
+      "id": "registros-eleitorais-e-politicos/consultar-zonas-eleitorais-por-uf",
+      "input": [
+        "cpf",
+        "nome",
+        "titulo_eleitor"
+      ],
       "links": [
         {
           "label": "",
@@ -2776,18 +2769,22 @@
         }
       ],
       "nome": "Consultar Zonas Eleitorais por UF",
-      "output": [],
-      "readme_linha": 909,
+      "output": [
+        "dados_cadastrais"
+      ],
+      "readme_linha": 906,
       "tipo_fonte": "judiciario"
     },
     {
-      "categoria": "Consultar Zonas Eleitorais por UF",
-      "categoria_id": "consultar-zonas-eleitorais-por-uf",
+      "categoria": "Registros Eleitorais e Políticos",
+      "categoria_id": "registros-eleitorais-e-politicos",
       "classificacao": "heuristica",
       "descricao": "Dados eleitorais tratados, padronizados e prontos para análise estatística.",
-      "id": "consultar-zonas-eleitorais-por-uf/base-dos-dados-eleicoes",
+      "id": "registros-eleitorais-e-politicos/base-dos-dados-eleicoes",
       "input": [
-        "nenhum"
+        "cpf",
+        "nome",
+        "titulo_eleitor"
       ],
       "links": [
         {
@@ -2798,9 +2795,10 @@
       ],
       "nome": "Base dos Dados - Eleições",
       "output": [
+        "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 912,
+      "readme_linha": 910,
       "tipo_fonte": "ong"
     },
     {
@@ -2824,7 +2822,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 922,
+      "readme_linha": 920,
       "tipo_fonte": "ong"
     },
     {
@@ -2848,7 +2846,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 926,
+      "readme_linha": 924,
       "tipo_fonte": "estadual"
     },
     {
@@ -2872,7 +2870,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 930,
+      "readme_linha": 928,
       "tipo_fonte": "municipal"
     },
     {
@@ -2896,7 +2894,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 934,
+      "readme_linha": 932,
       "tipo_fonte": "federal"
     },
     {
@@ -2920,7 +2918,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 938,
+      "readme_linha": 936,
       "tipo_fonte": "federal"
     },
     {
@@ -2946,7 +2944,7 @@
         "certidao",
         "imovel"
       ],
-      "readme_linha": 942,
+      "readme_linha": 940,
       "tipo_fonte": "ong"
     },
     {
@@ -2970,7 +2968,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 952,
+      "readme_linha": 950,
       "tipo_fonte": "federal"
     },
     {
@@ -2994,7 +2992,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 956,
+      "readme_linha": 954,
       "tipo_fonte": "federal"
     },
     {
@@ -3018,7 +3016,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 960,
+      "readme_linha": 958,
       "tipo_fonte": "federal"
     },
     {
@@ -3042,7 +3040,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 964,
+      "readme_linha": 962,
       "tipo_fonte": "estadual"
     },
     {
@@ -3067,7 +3065,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 968,
+      "readme_linha": 966,
       "tipo_fonte": "ong"
     },
     {
@@ -3092,7 +3090,7 @@
         "estatistica",
         "licenca_ambiental"
       ],
-      "readme_linha": 972,
+      "readme_linha": 970,
       "tipo_fonte": "ong"
     },
     {
@@ -3117,7 +3115,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 976,
+      "readme_linha": 974,
       "tipo_fonte": "ong"
     },
     {
@@ -3140,7 +3138,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 986,
+      "readme_linha": 984,
       "tipo_fonte": "federal"
     },
     {
@@ -3163,7 +3161,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 990,
+      "readme_linha": 988,
       "tipo_fonte": "federal"
     },
     {
@@ -3186,7 +3184,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 994,
+      "readme_linha": 992,
       "tipo_fonte": "federal"
     },
     {
@@ -3209,7 +3207,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 998,
+      "readme_linha": 996,
       "tipo_fonte": "federal"
     },
     {
@@ -3233,7 +3231,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1008,
+      "readme_linha": 1006,
       "tipo_fonte": "federal"
     },
     {
@@ -3257,7 +3255,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1012,
+      "readme_linha": 1010,
       "tipo_fonte": "federal"
     },
     {
@@ -3281,7 +3279,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1016,
+      "readme_linha": 1014,
       "tipo_fonte": "federal"
     },
     {
@@ -3307,7 +3305,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1026,
+      "readme_linha": 1024,
       "tipo_fonte": "federal"
     },
     {
@@ -3333,7 +3331,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1030,
+      "readme_linha": 1028,
       "tipo_fonte": "federal"
     },
     {
@@ -3360,7 +3358,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1034,
+      "readme_linha": 1032,
       "tipo_fonte": "federal"
     },
     {
@@ -3387,7 +3385,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1038,
+      "readme_linha": 1036,
       "tipo_fonte": "federal"
     },
     {
@@ -3414,7 +3412,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1042,
+      "readme_linha": 1040,
       "tipo_fonte": "federal"
     },
     {
@@ -3440,7 +3438,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1046,
+      "readme_linha": 1044,
       "tipo_fonte": "federal"
     },
     {
@@ -3466,7 +3464,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1050,
+      "readme_linha": 1048,
       "tipo_fonte": "federal"
     },
     {
@@ -3494,7 +3492,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1054,
+      "readme_linha": 1052,
       "tipo_fonte": "federal"
     },
     {
@@ -3525,7 +3523,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1058,
+      "readme_linha": 1056,
       "tipo_fonte": "federal"
     },
     {
@@ -3551,7 +3549,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1099,
+      "readme_linha": 1097,
       "tipo_fonte": "federal"
     },
     {
@@ -3577,7 +3575,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1103,
+      "readme_linha": 1101,
       "tipo_fonte": "federal"
     },
     {
@@ -3603,7 +3601,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1107,
+      "readme_linha": 1105,
       "tipo_fonte": "federal"
     },
     {
@@ -3629,7 +3627,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1111,
+      "readme_linha": 1109,
       "tipo_fonte": "federal"
     },
     {
@@ -3655,7 +3653,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1115,
+      "readme_linha": 1113,
       "tipo_fonte": "federal"
     },
     {
@@ -3681,7 +3679,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1119,
+      "readme_linha": 1117,
       "tipo_fonte": "federal"
     },
     {
@@ -3707,7 +3705,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1123,
+      "readme_linha": 1121,
       "tipo_fonte": "federal"
     },
     {
@@ -3734,7 +3732,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1127,
+      "readme_linha": 1125,
       "tipo_fonte": "federal"
     },
     {
@@ -3760,7 +3758,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1131,
+      "readme_linha": 1129,
       "tipo_fonte": "estadual"
     },
     {
@@ -3787,7 +3785,7 @@
         "remuneracao",
         "sancao"
       ],
-      "readme_linha": 1135,
+      "readme_linha": 1133,
       "tipo_fonte": "estadual"
     },
     {
@@ -3813,7 +3811,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1139,
+      "readme_linha": 1137,
       "tipo_fonte": "federal"
     },
     {
@@ -3884,7 +3882,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1143,
+      "readme_linha": 1141,
       "tipo_fonte": "estadual"
     },
     {
@@ -3910,7 +3908,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1187,
+      "readme_linha": 1185,
       "tipo_fonte": "federal"
     },
     {
@@ -4076,7 +4074,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1191,
+      "readme_linha": 1189,
       "tipo_fonte": "estadual"
     },
     {
@@ -4100,7 +4098,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1260,
+      "readme_linha": 1258,
       "tipo_fonte": "federal"
     },
     {
@@ -4124,7 +4122,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1264,
+      "readme_linha": 1262,
       "tipo_fonte": "federal"
     },
     {
@@ -4148,7 +4146,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1268,
+      "readme_linha": 1266,
       "tipo_fonte": "ong"
     },
     {
@@ -4302,7 +4300,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1272,
+      "readme_linha": 1270,
       "tipo_fonte": "estadual"
     },
     {
@@ -4328,7 +4326,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 1337,
+      "readme_linha": 1335,
       "tipo_fonte": "federal"
     },
     {
@@ -4352,7 +4350,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1341,
+      "readme_linha": 1339,
       "tipo_fonte": "federal"
     },
     {
@@ -4376,7 +4374,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1345,
+      "readme_linha": 1343,
       "tipo_fonte": "federal"
     },
     {
@@ -4400,7 +4398,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1349,
+      "readme_linha": 1347,
       "tipo_fonte": "federal"
     },
     {
@@ -4424,7 +4422,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1353,
+      "readme_linha": 1351,
       "tipo_fonte": "federal"
     },
     {
@@ -4448,7 +4446,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1357,
+      "readme_linha": 1355,
       "tipo_fonte": "federal"
     },
     {
@@ -4472,7 +4470,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1361,
+      "readme_linha": 1359,
       "tipo_fonte": "federal"
     },
     {
@@ -4496,7 +4494,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1365,
+      "readme_linha": 1363,
       "tipo_fonte": "federal"
     },
     {
@@ -4520,7 +4518,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1369,
+      "readme_linha": 1367,
       "tipo_fonte": "federal"
     },
     {
@@ -4544,7 +4542,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1373,
+      "readme_linha": 1371,
       "tipo_fonte": "federal"
     },
     {
@@ -4578,7 +4576,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1382,
+      "readme_linha": 1380,
       "tipo_fonte": "privado"
     },
     {
@@ -4606,7 +4604,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1395,
+      "readme_linha": 1393,
       "tipo_fonte": "privado"
     },
     {
@@ -4644,7 +4642,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1400,
+      "readme_linha": 1398,
       "tipo_fonte": "privado"
     },
     {
@@ -4668,7 +4666,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1412,
+      "readme_linha": 1410,
       "tipo_fonte": "privado"
     },
     {
@@ -4732,7 +4730,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1418,
+      "readme_linha": 1416,
       "tipo_fonte": "ong"
     },
     {
@@ -4757,7 +4755,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1436,
+      "readme_linha": 1434,
       "tipo_fonte": "federal"
     },
     {
@@ -4782,7 +4780,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1440,
+      "readme_linha": 1438,
       "tipo_fonte": "federal"
     },
     {
@@ -4806,7 +4804,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1444,
+      "readme_linha": 1442,
       "tipo_fonte": "federal"
     },
     {
@@ -4829,7 +4827,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1448,
+      "readme_linha": 1446,
       "tipo_fonte": "federal"
     },
     {
@@ -4852,7 +4850,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1452,
+      "readme_linha": 1450,
       "tipo_fonte": "federal"
     },
     {
@@ -4881,7 +4879,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1456,
+      "readme_linha": 1454,
       "tipo_fonte": "privado"
     },
     {
@@ -4905,7 +4903,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1461,
+      "readme_linha": 1459,
       "tipo_fonte": "federal"
     },
     {
@@ -4928,7 +4926,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1465,
+      "readme_linha": 1463,
       "tipo_fonte": "federal"
     },
     {
@@ -4953,25 +4951,8 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1469,
+      "readme_linha": 1467,
       "tipo_fonte": "federal"
-    },
-    {
-      "categoria": "Telecom",
-      "categoria_id": "telecom",
-      "classificacao": "heuristica",
-      "descricao": "",
-      "id": "telecom/paineis-de-telecomunicacoes-anatel",
-      "input": [
-        "telefone"
-      ],
-      "links": [],
-      "nome": "Painéis de Telecomunicações (ANATEL)",
-      "output": [
-        "operadora"
-      ],
-      "readme_linha": 1475,
-      "tipo_fonte": "indefinido"
     },
     {
       "categoria": "Telecom",
@@ -4996,7 +4977,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1477,
+      "readme_linha": 1475,
       "tipo_fonte": "federal"
     },
     {
@@ -5021,7 +5002,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1483,
+      "readme_linha": 1481,
       "tipo_fonte": "federal"
     },
     {
@@ -5046,7 +5027,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1489,
+      "readme_linha": 1487,
       "tipo_fonte": "federal"
     },
     {
@@ -5071,7 +5052,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1495,
+      "readme_linha": 1493,
       "tipo_fonte": "federal"
     },
     {
@@ -5095,7 +5076,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1502,
+      "readme_linha": 1500,
       "tipo_fonte": "federal"
     },
     {
@@ -5118,7 +5099,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1509,
+      "readme_linha": 1507,
       "tipo_fonte": "federal"
     },
     {
@@ -5145,7 +5126,7 @@
         "outorga",
         "radiofrequencia"
       ],
-      "readme_linha": 1516,
+      "readme_linha": 1514,
       "tipo_fonte": "federal"
     },
     {
@@ -5170,7 +5151,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1523,
+      "readme_linha": 1521,
       "tipo_fonte": "federal"
     },
     {
@@ -5193,7 +5174,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1530,
+      "readme_linha": 1528,
       "tipo_fonte": "federal"
     },
     {
@@ -5217,7 +5198,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1537,
+      "readme_linha": 1535,
       "tipo_fonte": "federal"
     },
     {
@@ -5241,7 +5222,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1544,
+      "readme_linha": 1542,
       "tipo_fonte": "federal"
     },
     {
@@ -5265,7 +5246,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1557,
+      "readme_linha": 1555,
       "tipo_fonte": "federal"
     },
     {
@@ -5290,7 +5271,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1563,
+      "readme_linha": 1561,
       "tipo_fonte": "ong"
     },
     {
@@ -5323,7 +5304,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1569,
+      "readme_linha": 1567,
       "tipo_fonte": "privado"
     },
     {
@@ -5351,7 +5332,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1580,
+      "readme_linha": 1578,
       "tipo_fonte": "ong"
     },
     {
@@ -5422,7 +5403,7 @@
         "erb",
         "operadora"
       ],
-      "readme_linha": 1589,
+      "readme_linha": 1587,
       "tipo_fonte": "privado"
     },
     {
@@ -5446,7 +5427,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1615,
+      "readme_linha": 1613,
       "tipo_fonte": "privado"
     },
     {
@@ -5472,7 +5453,7 @@
         "processo",
         "publicacao_academica"
       ],
-      "readme_linha": 1621,
+      "readme_linha": 1619,
       "tipo_fonte": "federal"
     },
     {
@@ -5496,7 +5477,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1627,
+      "readme_linha": 1625,
       "tipo_fonte": "privado"
     },
     {
@@ -5520,7 +5501,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1631,
+      "readme_linha": 1629,
       "tipo_fonte": "academico"
     },
     {
@@ -5544,7 +5525,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1635,
+      "readme_linha": 1633,
       "tipo_fonte": "academico"
     },
     {
@@ -5568,7 +5549,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1639,
+      "readme_linha": 1637,
       "tipo_fonte": "academico"
     },
     {
@@ -5592,7 +5573,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1643,
+      "readme_linha": 1641,
       "tipo_fonte": "academico"
     },
     {
@@ -5616,7 +5597,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1647,
+      "readme_linha": 1645,
       "tipo_fonte": "federal"
     },
     {
@@ -5640,7 +5621,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1651,
+      "readme_linha": 1649,
       "tipo_fonte": "privado"
     },
     {
@@ -5664,7 +5645,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1655,
+      "readme_linha": 1653,
       "tipo_fonte": "federal"
     },
     {
@@ -5688,7 +5669,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1659,
+      "readme_linha": 1657,
       "tipo_fonte": "ong"
     },
     {
@@ -5713,7 +5694,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1663,
+      "readme_linha": 1661,
       "tipo_fonte": "federal"
     },
     {
@@ -5739,7 +5720,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1667,
+      "readme_linha": 1665,
       "tipo_fonte": "federal"
     },
     {
@@ -5764,7 +5745,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 1671,
+      "readme_linha": 1669,
       "tipo_fonte": "federal"
     },
     {
@@ -5788,7 +5769,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1675,
+      "readme_linha": 1673,
       "tipo_fonte": "federal"
     },
     {
@@ -5812,7 +5793,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1679,
+      "readme_linha": 1677,
       "tipo_fonte": "federal"
     },
     {
@@ -5836,7 +5817,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1683,
+      "readme_linha": 1681,
       "tipo_fonte": "federal"
     },
     {
@@ -5976,7 +5957,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1692,
+      "readme_linha": 1690,
       "tipo_fonte": "privado"
     },
     {
@@ -6007,7 +5988,7 @@
         "area_rural",
         "mapa"
       ],
-      "readme_linha": 1726,
+      "readme_linha": 1724,
       "tipo_fonte": "federal"
     },
     {
@@ -6031,7 +6012,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1733,
+      "readme_linha": 1731,
       "tipo_fonte": "federal"
     },
     {
@@ -6060,7 +6041,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1739,
+      "readme_linha": 1737,
       "tipo_fonte": "federal"
     },
     {
@@ -6084,7 +6065,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1746,
+      "readme_linha": 1744,
       "tipo_fonte": "privado"
     },
     {
@@ -6125,7 +6106,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1750,
+      "readme_linha": 1748,
       "tipo_fonte": "internacional"
     },
     {
@@ -6154,7 +6135,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1762,
+      "readme_linha": 1760,
       "tipo_fonte": "federal"
     },
     {
@@ -6179,7 +6160,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1769,
+      "readme_linha": 1767,
       "tipo_fonte": "federal"
     },
     {
@@ -6203,7 +6184,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1775,
+      "readme_linha": 1773,
       "tipo_fonte": "federal"
     },
     {
@@ -6242,7 +6223,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1779,
+      "readme_linha": 1777,
       "tipo_fonte": "federal"
     },
     {
@@ -6266,7 +6247,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1791,
+      "readme_linha": 1789,
       "tipo_fonte": "federal"
     },
     {
@@ -6290,7 +6271,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1795,
+      "readme_linha": 1793,
       "tipo_fonte": "federal"
     },
     {
@@ -6315,7 +6296,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1805,
+      "readme_linha": 1803,
       "tipo_fonte": "federal"
     },
     {
@@ -6340,7 +6321,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1812,
+      "readme_linha": 1810,
       "tipo_fonte": "federal"
     },
     {
@@ -6367,7 +6348,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1819,
+      "readme_linha": 1817,
       "tipo_fonte": "federal"
     },
     {
@@ -6396,7 +6377,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1826,
+      "readme_linha": 1824,
       "tipo_fonte": "federal"
     },
     {
@@ -6422,7 +6403,7 @@
         "mapa",
         "sancao"
       ],
-      "readme_linha": 1833,
+      "readme_linha": 1831,
       "tipo_fonte": "federal"
     },
     {
@@ -6447,7 +6428,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1840,
+      "readme_linha": 1838,
       "tipo_fonte": "federal"
     },
     {
@@ -6474,7 +6455,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1847,
+      "readme_linha": 1845,
       "tipo_fonte": "federal"
     },
     {
@@ -6500,7 +6481,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1854,
+      "readme_linha": 1852,
       "tipo_fonte": "privado"
     },
     {
@@ -6525,7 +6506,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1861,
+      "readme_linha": 1859,
       "tipo_fonte": "federal"
     },
     {
@@ -6552,7 +6533,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1868,
+      "readme_linha": 1866,
       "tipo_fonte": "federal"
     },
     {
@@ -6577,7 +6558,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1875,
+      "readme_linha": 1873,
       "tipo_fonte": "federal"
     },
     {
@@ -6603,7 +6584,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1882,
+      "readme_linha": 1880,
       "tipo_fonte": "federal"
     },
     {
@@ -6629,7 +6610,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1889,
+      "readme_linha": 1887,
       "tipo_fonte": "federal"
     },
     {
@@ -6654,7 +6635,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1896,
+      "readme_linha": 1894,
       "tipo_fonte": "federal"
     },
     {
@@ -6681,7 +6662,7 @@
         "mapa",
         "processo"
       ],
-      "readme_linha": 1903,
+      "readme_linha": 1901,
       "tipo_fonte": "federal"
     },
     {
@@ -6708,7 +6689,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1910,
+      "readme_linha": 1908,
       "tipo_fonte": "federal"
     },
     {
@@ -6732,7 +6713,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1921,
+      "readme_linha": 1919,
       "tipo_fonte": "federal"
     },
     {
@@ -6756,7 +6737,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1927,
+      "readme_linha": 1925,
       "tipo_fonte": "federal"
     },
     {
@@ -6781,7 +6762,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1931,
+      "readme_linha": 1929,
       "tipo_fonte": "federal"
     },
     {
@@ -6805,7 +6786,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1935,
+      "readme_linha": 1933,
       "tipo_fonte": "federal"
     },
     {
@@ -6829,7 +6810,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1939,
+      "readme_linha": 1937,
       "tipo_fonte": "federal"
     },
     {
@@ -6853,7 +6834,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1943,
+      "readme_linha": 1941,
       "tipo_fonte": "federal"
     },
     {
@@ -6882,7 +6863,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1947,
+      "readme_linha": 1945,
       "tipo_fonte": "federal"
     },
     {
@@ -6907,7 +6888,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1952,
+      "readme_linha": 1950,
       "tipo_fonte": "ong"
     },
     {
@@ -6932,7 +6913,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1956,
+      "readme_linha": 1954,
       "tipo_fonte": "academico"
     },
     {
@@ -6956,7 +6937,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1960,
+      "readme_linha": 1958,
       "tipo_fonte": "academico"
     },
     {
@@ -6990,7 +6971,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1964,
+      "readme_linha": 1962,
       "tipo_fonte": "federal"
     },
     {
@@ -7028,7 +7009,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 1981,
+      "readme_linha": 1979,
       "tipo_fonte": "dork"
     },
     {
@@ -7056,7 +7037,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 1994,
+      "readme_linha": 1992,
       "tipo_fonte": "dork"
     },
     {
@@ -7084,7 +7065,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2001,
+      "readme_linha": 1999,
       "tipo_fonte": "dork"
     },
     {
@@ -7117,7 +7098,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2010,
+      "readme_linha": 2008,
       "tipo_fonte": "dork"
     },
     {
@@ -7155,7 +7136,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2021,
+      "readme_linha": 2019,
       "tipo_fonte": "dork"
     },
     {
@@ -7194,7 +7175,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2034,
+      "readme_linha": 2032,
       "tipo_fonte": "dork"
     },
     {
@@ -7233,7 +7214,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2050,
+      "readme_linha": 2048,
       "tipo_fonte": "internacional"
     },
     {
@@ -7267,7 +7248,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2062,
+      "readme_linha": 2060,
       "tipo_fonte": "internacional"
     },
     {
@@ -7295,7 +7276,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2069,
+      "readme_linha": 2067,
       "tipo_fonte": "dork"
     },
     {
@@ -7343,7 +7324,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2076,
+      "readme_linha": 2074,
       "tipo_fonte": "dork"
     },
     {
@@ -7381,7 +7362,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2096,
+      "readme_linha": 2094,
       "tipo_fonte": "dork"
     },
     {
@@ -7420,7 +7401,7 @@
         "dork",
         "video_ao_vivo"
       ],
-      "readme_linha": 2111,
+      "readme_linha": 2109,
       "tipo_fonte": "dork"
     },
     {
@@ -7461,7 +7442,7 @@
         "dork",
         "operadora"
       ],
-      "readme_linha": 2126,
+      "readme_linha": 2124,
       "tipo_fonte": "dork"
     },
     {
@@ -7495,7 +7476,7 @@
         "dork",
         "publicacao_academica"
       ],
-      "readme_linha": 2141,
+      "readme_linha": 2139,
       "tipo_fonte": "dork"
     },
     {
@@ -7528,7 +7509,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2153,
+      "readme_linha": 2151,
       "tipo_fonte": "dork"
     },
     {
@@ -7556,7 +7537,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2165,
+      "readme_linha": 2163,
       "tipo_fonte": "dork"
     },
     {
@@ -7585,7 +7566,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2175,
+      "readme_linha": 2173,
       "tipo_fonte": "internacional"
     },
     {
@@ -7628,7 +7609,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2187,
+      "readme_linha": 2185,
       "tipo_fonte": "dork"
     },
     {
@@ -7653,7 +7634,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2211,
+      "readme_linha": 2209,
       "tipo_fonte": "internacional"
     },
     {
@@ -7688,7 +7669,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2217,
+      "readme_linha": 2215,
       "tipo_fonte": "internacional"
     },
     {
@@ -7718,7 +7699,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2228,
+      "readme_linha": 2226,
       "tipo_fonte": "internacional"
     },
     {
@@ -7743,7 +7724,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2236,
+      "readme_linha": 2234,
       "tipo_fonte": "internacional"
     },
     {
@@ -7769,7 +7750,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2242,
+      "readme_linha": 2240,
       "tipo_fonte": "internacional"
     },
     {
@@ -7795,7 +7776,7 @@
         "estatistica",
         "perfil_social"
       ],
-      "readme_linha": 2248,
+      "readme_linha": 2246,
       "tipo_fonte": "internacional"
     },
     {
@@ -7820,7 +7801,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2254,
+      "readme_linha": 2252,
       "tipo_fonte": "internacional"
     },
     {
@@ -7845,7 +7826,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2260,
+      "readme_linha": 2258,
       "tipo_fonte": "internacional"
     },
     {
@@ -7870,7 +7851,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2264,
+      "readme_linha": 2262,
       "tipo_fonte": "internacional"
     },
     {
@@ -7895,7 +7876,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2268,
+      "readme_linha": 2266,
       "tipo_fonte": "internacional"
     },
     {
@@ -7920,7 +7901,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2272,
+      "readme_linha": 2270,
       "tipo_fonte": "internacional"
     },
     {
@@ -7945,7 +7926,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2276,
+      "readme_linha": 2274,
       "tipo_fonte": "internacional"
     },
     {
@@ -7970,7 +7951,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2280,
+      "readme_linha": 2278,
       "tipo_fonte": "internacional"
     },
     {
@@ -7996,7 +7977,7 @@
         "mandado_prisao",
         "perfil_social"
       ],
-      "readme_linha": 2286,
+      "readme_linha": 2284,
       "tipo_fonte": "privado"
     },
     {
@@ -8026,7 +8007,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2292,
+      "readme_linha": 2290,
       "tipo_fonte": "privado"
     },
     {
@@ -8056,7 +8037,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2299,
+      "readme_linha": 2297,
       "tipo_fonte": "internacional"
     },
     {
@@ -8082,7 +8063,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2305,
+      "readme_linha": 2303,
       "tipo_fonte": "internacional"
     },
     {
@@ -8107,7 +8088,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2312,
+      "readme_linha": 2310,
       "tipo_fonte": "privado"
     },
     {
@@ -8132,7 +8113,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2318,
+      "readme_linha": 2316,
       "tipo_fonte": "internacional"
     },
     {
@@ -8215,7 +8196,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2331,
+      "readme_linha": 2329,
       "tipo_fonte": "privado"
     },
     {
@@ -8278,7 +8259,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2356,
+      "readme_linha": 2354,
       "tipo_fonte": "privado"
     },
     {
@@ -8301,7 +8282,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2383,
+      "readme_linha": 2381,
       "tipo_fonte": "federal"
     },
     {
@@ -8324,7 +8305,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2389,
+      "readme_linha": 2387,
       "tipo_fonte": "privado"
     },
     {
@@ -8347,7 +8328,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2395,
+      "readme_linha": 2393,
       "tipo_fonte": "federal"
     },
     {
@@ -8370,7 +8351,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2401,
+      "readme_linha": 2399,
       "tipo_fonte": "privado"
     },
     {
@@ -8393,7 +8374,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2407,
+      "readme_linha": 2405,
       "tipo_fonte": "federal"
     },
     {
@@ -8416,7 +8397,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2413,
+      "readme_linha": 2411,
       "tipo_fonte": "federal"
     },
     {
@@ -8439,7 +8420,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2419,
+      "readme_linha": 2417,
       "tipo_fonte": "federal"
     },
     {
@@ -8463,7 +8444,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2425,
+      "readme_linha": 2423,
       "tipo_fonte": "federal"
     },
     {
@@ -8492,7 +8473,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 2429,
+      "readme_linha": 2427,
       "tipo_fonte": "federal"
     },
     {
@@ -8515,7 +8496,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2436,
+      "readme_linha": 2434,
       "tipo_fonte": "federal"
     },
     {
@@ -8538,7 +8519,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2440,
+      "readme_linha": 2438,
       "tipo_fonte": "federal"
     },
     {
@@ -8562,7 +8543,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2446,
+      "readme_linha": 2444,
       "tipo_fonte": "federal"
     },
     {
@@ -8585,7 +8566,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2452,
+      "readme_linha": 2450,
       "tipo_fonte": "estadual"
     },
     {
@@ -8609,7 +8590,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2458,
+      "readme_linha": 2456,
       "tipo_fonte": "estadual"
     },
     {
@@ -8633,7 +8614,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2464,
+      "readme_linha": 2462,
       "tipo_fonte": "federal"
     },
     {
@@ -8656,7 +8637,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2470,
+      "readme_linha": 2468,
       "tipo_fonte": "federal"
     },
     {
@@ -8679,7 +8660,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2476,
+      "readme_linha": 2474,
       "tipo_fonte": "estadual"
     },
     {
@@ -8703,7 +8684,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2482,
+      "readme_linha": 2480,
       "tipo_fonte": "federal"
     },
     {
@@ -8726,7 +8707,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2488,
+      "readme_linha": 2486,
       "tipo_fonte": "estadual"
     },
     {
@@ -8749,7 +8730,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2494,
+      "readme_linha": 2492,
       "tipo_fonte": "estadual"
     },
     {
@@ -8772,7 +8753,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2500,
+      "readme_linha": 2498,
       "tipo_fonte": "federal"
     },
     {
@@ -8795,7 +8776,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2506,
+      "readme_linha": 2504,
       "tipo_fonte": "estadual"
     },
     {
@@ -8818,7 +8799,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2512,
+      "readme_linha": 2510,
       "tipo_fonte": "estadual"
     },
     {
@@ -8841,7 +8822,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2516,
+      "readme_linha": 2514,
       "tipo_fonte": "federal"
     },
     {
@@ -8864,7 +8845,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2522,
+      "readme_linha": 2520,
       "tipo_fonte": "federal"
     },
     {
@@ -8887,7 +8868,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2528,
+      "readme_linha": 2526,
       "tipo_fonte": "estadual"
     },
     {
@@ -8910,7 +8891,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2534,
+      "readme_linha": 2532,
       "tipo_fonte": "federal"
     },
     {
@@ -8938,7 +8919,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2540,
+      "readme_linha": 2538,
       "tipo_fonte": "federal"
     },
     {
@@ -8963,7 +8944,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2547,
+      "readme_linha": 2545,
       "tipo_fonte": "estadual"
     },
     {
@@ -8986,7 +8967,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2551,
+      "readme_linha": 2549,
       "tipo_fonte": "federal"
     },
     {
@@ -9010,7 +8991,7 @@
         "dataset",
         "diario_oficial"
       ],
-      "readme_linha": 2555,
+      "readme_linha": 2553,
       "tipo_fonte": "ong"
     },
     {
@@ -9033,7 +9014,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2561,
+      "readme_linha": 2559,
       "tipo_fonte": "ong"
     },
     {
@@ -9056,7 +9037,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2565,
+      "readme_linha": 2563,
       "tipo_fonte": "federal"
     },
     {
@@ -9079,7 +9060,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2569,
+      "readme_linha": 2567,
       "tipo_fonte": "federal"
     },
     {
@@ -9102,7 +9083,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2573,
+      "readme_linha": 2571,
       "tipo_fonte": "privado"
     },
     {
@@ -9125,7 +9106,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2577,
+      "readme_linha": 2575,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9148,7 +9129,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2581,
+      "readme_linha": 2579,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9172,7 +9153,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2585,
+      "readme_linha": 2583,
       "tipo_fonte": "federal"
     },
     {
@@ -9195,7 +9176,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2589,
+      "readme_linha": 2587,
       "tipo_fonte": "federal"
     },
     {
@@ -9219,7 +9200,7 @@
         "dataset",
         "endereco"
       ],
-      "readme_linha": 2593,
+      "readme_linha": 2591,
       "tipo_fonte": "privado"
     },
     {
@@ -9244,7 +9225,7 @@
         "beneficio",
         "remuneracao"
       ],
-      "readme_linha": 2603,
+      "readme_linha": 2601,
       "tipo_fonte": "ong"
     },
     {
@@ -9268,7 +9249,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2611,
+      "readme_linha": 2609,
       "tipo_fonte": "estadual"
     },
     {
@@ -9292,7 +9273,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2615,
+      "readme_linha": 2613,
       "tipo_fonte": "estadual"
     },
     {
@@ -9391,7 +9372,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2621,
+      "readme_linha": 2619,
       "tipo_fonte": "privado"
     },
     {
@@ -9450,7 +9431,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2644,
+      "readme_linha": 2642,
       "tipo_fonte": "ong"
     },
     {
@@ -9479,7 +9460,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2659,
+      "readme_linha": 2657,
       "tipo_fonte": "privado"
     },
     {
@@ -9503,7 +9484,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2666,
+      "readme_linha": 2664,
       "tipo_fonte": "privado"
     },
     {
@@ -9527,7 +9508,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2672,
+      "readme_linha": 2670,
       "tipo_fonte": "federal"
     },
     {
@@ -9551,7 +9532,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2678,
+      "readme_linha": 2676,
       "tipo_fonte": "federal"
     },
     {
@@ -9576,7 +9557,7 @@
         "veiculo",
         "video_ao_vivo"
       ],
-      "readme_linha": 2684,
+      "readme_linha": 2682,
       "tipo_fonte": "internacional"
     },
     {
@@ -9600,7 +9581,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2688,
+      "readme_linha": 2686,
       "tipo_fonte": "internacional"
     },
     {
@@ -9625,7 +9606,7 @@
         "multa",
         "veiculo"
       ],
-      "readme_linha": 2692,
+      "readme_linha": 2690,
       "tipo_fonte": "federal"
     },
     {
@@ -9651,7 +9632,7 @@
         "dados_cadastrais",
         "veiculo"
       ],
-      "readme_linha": 2696,
+      "readme_linha": 2694,
       "tipo_fonte": "federal"
     },
     {
@@ -9675,7 +9656,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2700,
+      "readme_linha": 2698,
       "tipo_fonte": "federal"
     },
     {
@@ -9699,7 +9680,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2704,
+      "readme_linha": 2702,
       "tipo_fonte": "privado"
     },
     {
@@ -9723,7 +9704,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2710,
+      "readme_linha": 2708,
       "tipo_fonte": "federal"
     },
     {
@@ -9747,7 +9728,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2716,
+      "readme_linha": 2714,
       "tipo_fonte": "federal"
     },
     {
@@ -9772,7 +9753,7 @@
         "dataset",
         "veiculo"
       ],
-      "readme_linha": 2722,
+      "readme_linha": 2720,
       "tipo_fonte": "federal"
     },
     {
@@ -9801,7 +9782,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2728,
+      "readme_linha": 2726,
       "tipo_fonte": "estadual"
     },
     {
@@ -9830,7 +9811,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2735,
+      "readme_linha": 2733,
       "tipo_fonte": "estadual"
     },
     {
@@ -9999,7 +9980,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2742,
+      "readme_linha": 2740,
       "tipo_fonte": "estadual"
     },
     {
@@ -10023,7 +10004,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 2812,
+      "readme_linha": 2810,
       "tipo_fonte": "privado"
     },
     {
@@ -10046,7 +10027,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2818,
+      "readme_linha": 2816,
       "tipo_fonte": "privado"
     },
     {
@@ -10089,7 +10070,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2824,
+      "readme_linha": 2822,
       "tipo_fonte": "estadual"
     },
     {
@@ -10112,7 +10093,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2844,
+      "readme_linha": 2842,
       "tipo_fonte": "privado"
     },
     {
@@ -10135,7 +10116,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2850,
+      "readme_linha": 2848,
       "tipo_fonte": "privado"
     },
     {
@@ -10158,7 +10139,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2856,
+      "readme_linha": 2854,
       "tipo_fonte": "privado"
     },
     {
@@ -10183,7 +10164,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 2868,
+      "readme_linha": 2866,
       "tipo_fonte": "federal"
     },
     {
@@ -10209,7 +10190,7 @@
         "estatistica",
         "multa"
       ],
-      "readme_linha": 2872,
+      "readme_linha": 2870,
       "tipo_fonte": "privado"
     },
     {
@@ -10232,7 +10213,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2876,
+      "readme_linha": 2874,
       "tipo_fonte": "federal"
     },
     {
@@ -10255,7 +10236,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2880,
+      "readme_linha": 2878,
       "tipo_fonte": "federal"
     },
     {
@@ -10278,7 +10259,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2884,
+      "readme_linha": 2882,
       "tipo_fonte": "federal"
     },
     {
@@ -10301,7 +10282,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2888,
+      "readme_linha": 2886,
       "tipo_fonte": "federal"
     },
     {
@@ -10329,7 +10310,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2892,
+      "readme_linha": 2890,
       "tipo_fonte": "internacional"
     },
     {
@@ -10352,7 +10333,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2897,
+      "readme_linha": 2895,
       "tipo_fonte": "privado"
     },
     {
@@ -10375,7 +10356,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2901,
+      "readme_linha": 2899,
       "tipo_fonte": "privado"
     },
     {
@@ -10398,7 +10379,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2905,
+      "readme_linha": 2903,
       "tipo_fonte": "privado"
     },
     {
@@ -10421,7 +10402,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2915,
+      "readme_linha": 2913,
       "tipo_fonte": "federal"
     },
     {
@@ -10447,7 +10428,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 2921,
+      "readme_linha": 2919,
       "tipo_fonte": "privado"
     },
     {
@@ -10470,7 +10451,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2927,
+      "readme_linha": 2925,
       "tipo_fonte": "federal"
     },
     {
@@ -10495,7 +10476,7 @@
         "dados_cadastrais",
         "multa"
       ],
-      "readme_linha": 2933,
+      "readme_linha": 2931,
       "tipo_fonte": "federal"
     },
     {
@@ -10573,7 +10554,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2937,
+      "readme_linha": 2935,
       "tipo_fonte": "federal"
     },
     {
@@ -10596,7 +10577,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2965,
+      "readme_linha": 2963,
       "tipo_fonte": "estadual"
     },
     {
@@ -10619,7 +10600,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2971,
+      "readme_linha": 2969,
       "tipo_fonte": "privado"
     },
     {
@@ -10642,7 +10623,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2975,
+      "readme_linha": 2973,
       "tipo_fonte": "estadual"
     },
     {
@@ -10665,7 +10646,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2979,
+      "readme_linha": 2977,
       "tipo_fonte": "internacional"
     },
     {
@@ -10708,7 +10689,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2983,
+      "readme_linha": 2981,
       "tipo_fonte": "privado"
     },
     {
@@ -10756,7 +10737,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2998,
+      "readme_linha": 2996,
       "tipo_fonte": "privado"
     },
     {
@@ -10859,7 +10840,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3012,
+      "readme_linha": 3010,
       "tipo_fonte": "privado"
     },
     {
@@ -10882,7 +10863,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3053,
+      "readme_linha": 3051,
       "tipo_fonte": "privado"
     },
     {
@@ -10930,7 +10911,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3057,
+      "readme_linha": 3055,
       "tipo_fonte": "estadual"
     },
     {
@@ -11253,7 +11234,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3071,
+      "readme_linha": 3069,
       "tipo_fonte": "privado"
     },
     {
@@ -11276,7 +11257,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3146,
+      "readme_linha": 3144,
       "tipo_fonte": "privado"
     },
     {
@@ -11299,7 +11280,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3150,
+      "readme_linha": 3148,
       "tipo_fonte": "privado"
     },
     {
@@ -11322,7 +11303,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3154,
+      "readme_linha": 3152,
       "tipo_fonte": "estadual"
     },
     {
@@ -11345,7 +11326,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3158,
+      "readme_linha": 3156,
       "tipo_fonte": "federal"
     },
     {
@@ -11374,7 +11355,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3162,
+      "readme_linha": 3160,
       "tipo_fonte": "internacional"
     },
     {
@@ -11398,7 +11379,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3167,
+      "readme_linha": 3165,
       "tipo_fonte": "internacional"
     },
     {
@@ -11422,7 +11403,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3171,
+      "readme_linha": 3169,
       "tipo_fonte": "internacional"
     },
     {
@@ -11446,7 +11427,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3175,
+      "readme_linha": 3173,
       "tipo_fonte": "internacional"
     },
     {
@@ -11470,7 +11451,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3179,
+      "readme_linha": 3177,
       "tipo_fonte": "internacional"
     },
     {
@@ -11494,26 +11475,8 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3183,
+      "readme_linha": 3181,
       "tipo_fonte": "internacional"
-    },
-    {
-      "categoria": "Câmeras Online",
-      "categoria_id": "cameras-online",
-      "classificacao": "heuristica",
-      "descricao": "",
-      "id": "cameras-online/camera-do-aeroporto-da-pampulha-belo-horizonte-24-horas-bhz-sbbh",
-      "input": [
-        "prefixo_aeronave"
-      ],
-      "links": [],
-      "nome": "Câmera do Aeroporto da Pampulha - Belo Horizonte 24 horas (BHZ)(SBBH)",
-      "output": [
-        "dados_cadastrais",
-        "video_ao_vivo"
-      ],
-      "readme_linha": 3187,
-      "tipo_fonte": "indefinido"
     },
     {
       "categoria": "Câmeras Online",
@@ -11536,7 +11499,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3191,
+      "readme_linha": 3185,
       "tipo_fonte": "internacional"
     },
     {
@@ -11560,7 +11523,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3195,
+      "readme_linha": 3189,
       "tipo_fonte": "internacional"
     },
     {
@@ -11583,7 +11546,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3199,
+      "readme_linha": 3193,
       "tipo_fonte": "estadual"
     },
     {
@@ -11657,7 +11620,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3209,
+      "readme_linha": 3203,
       "tipo_fonte": "ministerio_publico"
     },
     {
@@ -11717,7 +11680,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3250,
+      "readme_linha": 3244,
       "tipo_fonte": "defensoria"
     },
     {
@@ -11751,7 +11714,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3282,
+      "readme_linha": 3276,
       "tipo_fonte": "ong"
     },
     {
@@ -11780,7 +11743,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3299,
+      "readme_linha": 3293,
       "tipo_fonte": "estadual"
     },
     {
@@ -11809,7 +11772,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3319,
+      "readme_linha": 3313,
       "tipo_fonte": "privado"
     },
     {
@@ -11858,7 +11821,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3324,
+      "readme_linha": 3318,
       "tipo_fonte": "estadual"
     },
     {
@@ -11877,7 +11840,7 @@
       ],
       "nome": "MCTI - Ministério da Ciência, Tecnologia e Inovação",
       "output": [],
-      "readme_linha": 3343,
+      "readme_linha": 3337,
       "tipo_fonte": "federal"
     },
     {
@@ -11896,7 +11859,7 @@
       ],
       "nome": "Embrapii - Unidades de Pesquisa e Inovação",
       "output": [],
-      "readme_linha": 3347,
+      "readme_linha": 3341,
       "tipo_fonte": "ong"
     },
     {
@@ -11915,7 +11878,7 @@
       ],
       "nome": "Finep - Financiadora de Estudos e Projetos",
       "output": [],
-      "readme_linha": 3351,
+      "readme_linha": 3345,
       "tipo_fonte": "federal"
     },
     {
@@ -11938,7 +11901,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3355,
+      "readme_linha": 3349,
       "tipo_fonte": "privado"
     },
     {
@@ -11957,7 +11920,7 @@
       ],
       "nome": "SUFRAMA - Superintendência da Zona Franca de Manaus",
       "output": [],
-      "readme_linha": 3359,
+      "readme_linha": 3353,
       "tipo_fonte": "federal"
     },
     {
@@ -11980,7 +11943,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3363,
+      "readme_linha": 3357,
       "tipo_fonte": "federal"
     },
     {
@@ -12001,7 +11964,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3367,
+      "readme_linha": 3361,
       "tipo_fonte": "federal"
     },
     {
@@ -12020,7 +11983,7 @@
       ],
       "nome": "Sinesp Cidadão (Site a APP)",
       "output": [],
-      "readme_linha": 3371,
+      "readme_linha": 3365,
       "tipo_fonte": "federal"
     },
     {
@@ -12061,7 +12024,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3380,
+      "readme_linha": 3374,
       "tipo_fonte": "privado"
     },
     {
@@ -12092,7 +12055,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3399,
+      "readme_linha": 3393,
       "tipo_fonte": "privado"
     },
     {
@@ -12121,7 +12084,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3413,
+      "readme_linha": 3407,
       "tipo_fonte": "privado"
     },
     {
@@ -12149,7 +12112,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3440,
+      "readme_linha": 3434,
       "tipo_fonte": "privado"
     },
     {
@@ -12179,7 +12142,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3462,
+      "readme_linha": 3456,
       "tipo_fonte": "privado"
     },
     {
@@ -12206,7 +12169,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3486,
+      "readme_linha": 3480,
       "tipo_fonte": "federal"
     },
     {
@@ -12233,7 +12196,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3509,
+      "readme_linha": 3503,
       "tipo_fonte": "federal"
     },
     {
@@ -12263,7 +12226,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3513,
+      "readme_linha": 3507,
       "tipo_fonte": "ong"
     },
     {
@@ -12289,7 +12252,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3536,
+      "readme_linha": 3530,
       "tipo_fonte": "federal"
     },
     {
@@ -12313,7 +12276,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3540,
+      "readme_linha": 3534,
       "tipo_fonte": "federal"
     },
     {
@@ -12336,7 +12299,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3550,
+      "readme_linha": 3544,
       "tipo_fonte": "federal"
     },
     {
@@ -12359,7 +12322,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3554,
+      "readme_linha": 3548,
       "tipo_fonte": "federal"
     },
     {
@@ -12388,7 +12351,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3558,
+      "readme_linha": 3552,
       "tipo_fonte": "federal"
     },
     {
@@ -12416,7 +12379,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3563,
+      "readme_linha": 3557,
       "tipo_fonte": "federal"
     },
     {
@@ -12439,7 +12402,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3568,
+      "readme_linha": 3562,
       "tipo_fonte": "federal"
     },
     {
@@ -12462,7 +12425,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3572,
+      "readme_linha": 3566,
       "tipo_fonte": "federal"
     },
     {
@@ -12491,7 +12454,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3582,
+      "readme_linha": 3576,
       "tipo_fonte": "federal"
     },
     {
@@ -12515,7 +12478,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3587,
+      "readme_linha": 3581,
       "tipo_fonte": "federal"
     },
     {
@@ -12539,7 +12502,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3591,
+      "readme_linha": 3585,
       "tipo_fonte": "federal"
     },
     {
@@ -12569,7 +12532,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3595,
+      "readme_linha": 3589,
       "tipo_fonte": "ong"
     },
     {
@@ -12599,7 +12562,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3600,
+      "readme_linha": 3594,
       "tipo_fonte": "federal"
     },
     {
@@ -12624,7 +12587,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3605,
+      "readme_linha": 3599,
       "tipo_fonte": "federal"
     },
     {
@@ -12648,7 +12611,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3609,
+      "readme_linha": 3603,
       "tipo_fonte": "federal"
     },
     {
@@ -12672,7 +12635,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3613,
+      "readme_linha": 3607,
       "tipo_fonte": "federal"
     },
     {
@@ -12727,7 +12690,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3623,
+      "readme_linha": 3617,
       "tipo_fonte": "ong"
     },
     {
@@ -12851,7 +12814,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3662,
+      "readme_linha": 3656,
       "tipo_fonte": "estadual"
     },
     {
@@ -12971,7 +12934,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3703,
+      "readme_linha": 3697,
       "tipo_fonte": "ong"
     },
     {
@@ -13005,7 +12968,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3732,
+      "readme_linha": 3726,
       "tipo_fonte": "estadual"
     },
     {
@@ -13031,7 +12994,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3744,
+      "readme_linha": 3738,
       "tipo_fonte": "estadual"
     },
     {
@@ -13057,7 +13020,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3748,
+      "readme_linha": 3742,
       "tipo_fonte": "estadual"
     },
     {
@@ -13081,7 +13044,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3752,
+      "readme_linha": 3746,
       "tipo_fonte": "estadual"
     },
     {
@@ -13104,7 +13067,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3762,
+      "readme_linha": 3756,
       "tipo_fonte": "ong"
     },
     {
@@ -13127,7 +13090,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3766,
+      "readme_linha": 3760,
       "tipo_fonte": "federal"
     },
     {
@@ -13151,7 +13114,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3770,
+      "readme_linha": 3764,
       "tipo_fonte": "ong"
     },
     {
@@ -13174,7 +13137,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3774,
+      "readme_linha": 3768,
       "tipo_fonte": "federal"
     },
     {
@@ -13197,7 +13160,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3778,
+      "readme_linha": 3772,
       "tipo_fonte": "federal"
     },
     {
@@ -13225,7 +13188,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3782,
+      "readme_linha": 3776,
       "tipo_fonte": "privado"
     },
     {
@@ -13313,7 +13276,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3794,
+      "readme_linha": 3788,
       "tipo_fonte": "privado"
     },
     {
@@ -13357,7 +13320,7 @@
       ],
       "nome": "Conhecimento de empreendimentos por dentro",
       "output": [],
-      "readme_linha": 3816,
+      "readme_linha": 3810,
       "tipo_fonte": "privado"
     },
     {
@@ -13380,7 +13343,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3829,
+      "readme_linha": 3823,
       "tipo_fonte": "estadual"
     },
     {
@@ -13413,7 +13376,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3835,
+      "readme_linha": 3829,
       "tipo_fonte": "privado"
     },
     {
@@ -13437,7 +13400,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3846,
+      "readme_linha": 3840,
       "tipo_fonte": "privado"
     },
     {
@@ -13460,7 +13423,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3850,
+      "readme_linha": 3844,
       "tipo_fonte": "federal"
     },
     {
@@ -13494,7 +13457,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3856,
+      "readme_linha": 3850,
       "tipo_fonte": "privado"
     },
     {
@@ -13580,7 +13543,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3866,
+      "readme_linha": 3860,
       "tipo_fonte": "privado"
     },
     {
@@ -13604,7 +13567,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3915,
+      "readme_linha": 3909,
       "tipo_fonte": "estadual"
     },
     {
@@ -13638,9 +13601,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4078,
+      "readme_linha": 4072,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 435
+  "total": 432
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -912,6 +912,34 @@
       "categoria": "Consulta de Processos",
       "categoria_id": "consulta-de-processos",
       "classificacao": "heuristica",
+      "descricao": "Pesquisa pública de processos e documentos do Conselho Administrativo de Defesa Econômica por número SEI, texto, interessado, unidade geradora e tipo de processo.",
+      "id": "consulta-de-processos/cade-pesquisa-publica-de-processos",
+      "input": [
+        "cnpj",
+        "cpf",
+        "nome",
+        "numero_processo"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://sei.cade.gov.br/sei/modulos/pesquisa/md_pesq_processo_pesquisar.php?acao_externa=protocolo_pesquisar&acao_origem_externa=protocolo_pesquisar&id_orgao_acesso_externo=0"
+        }
+      ],
+      "nome": "CADE - Pesquisa Pública de Processos",
+      "output": [
+        "movimentacao",
+        "partes",
+        "processo"
+      ],
+      "readme_linha": 439,
+      "tipo_fonte": "federal"
+    },
+    {
+      "categoria": "Consulta de Processos",
+      "categoria_id": "consulta-de-processos",
+      "classificacao": "heuristica",
       "descricao": "Sistema de Gestão de Tabelas Processuais Unificadas - consulta de classes processuais.",
       "id": "consulta-de-processos/cnj-consulta-de-classes-processuais-sgt",
       "input": [
@@ -933,7 +961,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 439,
+      "readme_linha": 443,
       "tipo_fonte": "judiciario"
     },
     {
@@ -961,7 +989,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 443,
+      "readme_linha": 447,
       "tipo_fonte": "judiciario"
     },
     {
@@ -1064,7 +1092,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 447,
+      "readme_linha": 451,
       "tipo_fonte": "judiciario"
     },
     {
@@ -1089,7 +1117,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 497,
+      "readme_linha": 501,
       "tipo_fonte": "federal"
     },
     {
@@ -1214,7 +1242,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 501,
+      "readme_linha": 505,
       "tipo_fonte": "federal"
     },
     {
@@ -1240,7 +1268,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 531,
+      "readme_linha": 535,
       "tipo_fonte": "federal"
     },
     {
@@ -1266,7 +1294,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 535,
+      "readme_linha": 539,
       "tipo_fonte": "internacional"
     },
     {
@@ -1291,7 +1319,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 541,
+      "readme_linha": 545,
       "tipo_fonte": "internacional"
     },
     {
@@ -1316,7 +1344,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 547,
+      "readme_linha": 551,
       "tipo_fonte": "privado"
     },
     {
@@ -1343,7 +1371,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 553,
+      "readme_linha": 557,
       "tipo_fonte": "judiciario"
     },
     {
@@ -1374,7 +1402,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 559,
+      "readme_linha": 563,
       "tipo_fonte": "privado"
     },
     {
@@ -1425,7 +1453,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 567,
+      "readme_linha": 571,
       "tipo_fonte": "estadual"
     },
     {
@@ -1452,7 +1480,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 591,
+      "readme_linha": 595,
       "tipo_fonte": "ong"
     },
     {
@@ -1478,7 +1506,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 598,
+      "readme_linha": 602,
       "tipo_fonte": "ong"
     },
     {
@@ -1504,7 +1532,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 605,
+      "readme_linha": 609,
       "tipo_fonte": "ong"
     },
     {
@@ -1530,7 +1558,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 612,
+      "readme_linha": 616,
       "tipo_fonte": "federal"
     },
     {
@@ -1556,7 +1584,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 616,
+      "readme_linha": 620,
       "tipo_fonte": "ong"
     },
     {
@@ -1582,7 +1610,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 620,
+      "readme_linha": 624,
       "tipo_fonte": "federal"
     },
     {
@@ -1608,7 +1636,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 624,
+      "readme_linha": 628,
       "tipo_fonte": "ong"
     },
     {
@@ -1634,7 +1662,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 628,
+      "readme_linha": 632,
       "tipo_fonte": "ong"
     },
     {
@@ -1664,7 +1692,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 637,
+      "readme_linha": 641,
       "tipo_fonte": "federal"
     },
     {
@@ -1790,7 +1818,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 644,
+      "readme_linha": 648,
       "tipo_fonte": "estadual"
     },
     {
@@ -1815,7 +1843,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 674,
+      "readme_linha": 678,
       "tipo_fonte": "federal"
     },
     {
@@ -1839,7 +1867,7 @@
       "output": [
         "debito"
       ],
-      "readme_linha": 679,
+      "readme_linha": 683,
       "tipo_fonte": "federal"
     },
     {
@@ -1864,7 +1892,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 684,
+      "readme_linha": 688,
       "tipo_fonte": "federal"
     },
     {
@@ -1892,7 +1920,7 @@
         "sancao",
         "situacao_cadastral"
       ],
-      "readme_linha": 688,
+      "readme_linha": 692,
       "tipo_fonte": "federal"
     },
     {
@@ -1918,7 +1946,7 @@
         "sancao",
         "situacao_cadastral"
       ],
-      "readme_linha": 692,
+      "readme_linha": 696,
       "tipo_fonte": "federal"
     },
     {
@@ -1945,7 +1973,7 @@
         "sancao",
         "situacao_cadastral"
       ],
-      "readme_linha": 696,
+      "readme_linha": 700,
       "tipo_fonte": "federal"
     },
     {
@@ -1992,7 +2020,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 701,
+      "readme_linha": 705,
       "tipo_fonte": "estadual"
     },
     {
@@ -2017,7 +2045,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 716,
+      "readme_linha": 720,
       "tipo_fonte": "federal"
     },
     {
@@ -2042,7 +2070,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 720,
+      "readme_linha": 724,
       "tipo_fonte": "federal"
     },
     {
@@ -2073,7 +2101,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 725,
+      "readme_linha": 729,
       "tipo_fonte": "federal"
     },
     {
@@ -2099,7 +2127,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 732,
+      "readme_linha": 736,
       "tipo_fonte": "federal"
     },
     {
@@ -2127,7 +2155,7 @@
         "dados_cadastrais",
         "debito"
       ],
-      "readme_linha": 736,
+      "readme_linha": 740,
       "tipo_fonte": "federal"
     },
     {
@@ -2153,7 +2181,7 @@
         "certidao",
         "debito"
       ],
-      "readme_linha": 740,
+      "readme_linha": 744,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2179,7 +2207,7 @@
         "certidao",
         "situacao_cadastral"
       ],
-      "readme_linha": 744,
+      "readme_linha": 748,
       "tipo_fonte": "federal"
     },
     {
@@ -2207,7 +2235,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 748,
+      "readme_linha": 752,
       "tipo_fonte": "federal"
     },
     {
@@ -2232,7 +2260,7 @@
       "output": [
         "debito"
       ],
-      "readme_linha": 752,
+      "readme_linha": 756,
       "tipo_fonte": "privado"
     },
     {
@@ -2260,7 +2288,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 765,
+      "readme_linha": 769,
       "tipo_fonte": "federal"
     },
     {
@@ -2368,7 +2396,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 777,
+      "readme_linha": 781,
       "tipo_fonte": "estadual"
     },
     {
@@ -2396,7 +2424,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 838,
+      "readme_linha": 842,
       "tipo_fonte": "ong"
     },
     {
@@ -2419,7 +2447,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 843,
+      "readme_linha": 847,
       "tipo_fonte": "privado"
     },
     {
@@ -2442,7 +2470,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 847,
+      "readme_linha": 851,
       "tipo_fonte": "ong"
     },
     {
@@ -2466,7 +2494,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 851,
+      "readme_linha": 855,
       "tipo_fonte": "privado"
     },
     {
@@ -2491,7 +2519,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 861,
+      "readme_linha": 865,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2516,7 +2544,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 865,
+      "readme_linha": 869,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2541,7 +2569,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 869,
+      "readme_linha": 873,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2566,7 +2594,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 873,
+      "readme_linha": 877,
       "tipo_fonte": "legislativo"
     },
     {
@@ -2591,7 +2619,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 877,
+      "readme_linha": 881,
       "tipo_fonte": "legislativo"
     },
     {
@@ -2617,7 +2645,7 @@
         "dados_cadastrais",
         "dataset"
       ],
-      "readme_linha": 881,
+      "readme_linha": 885,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2643,7 +2671,7 @@
         "dados_cadastrais",
         "dataset"
       ],
-      "readme_linha": 885,
+      "readme_linha": 889,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2669,7 +2697,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 889,
+      "readme_linha": 893,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2694,7 +2722,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 893,
+      "readme_linha": 897,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2720,7 +2748,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 897,
+      "readme_linha": 901,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2746,7 +2774,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 901,
+      "readme_linha": 905,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2772,7 +2800,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 905,
+      "readme_linha": 909,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2798,7 +2826,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 909,
+      "readme_linha": 913,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2825,7 +2853,7 @@
         "dados_cadastrais",
         "debito"
       ],
-      "readme_linha": 913,
+      "readme_linha": 917,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2851,7 +2879,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 917,
+      "readme_linha": 921,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2879,7 +2907,7 @@
         "debito",
         "multa"
       ],
-      "readme_linha": 921,
+      "readme_linha": 925,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2904,7 +2932,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 925,
+      "readme_linha": 929,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2930,7 +2958,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 929,
+      "readme_linha": 933,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2955,7 +2983,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 933,
+      "readme_linha": 937,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2983,7 +3011,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 937,
+      "readme_linha": 941,
       "tipo_fonte": "judiciario"
     },
     {
@@ -3008,7 +3036,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 941,
+      "readme_linha": 945,
       "tipo_fonte": "judiciario"
     },
     {
@@ -3033,7 +3061,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 946,
+      "readme_linha": 950,
       "tipo_fonte": "judiciario"
     },
     {
@@ -3059,7 +3087,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 950,
+      "readme_linha": 954,
       "tipo_fonte": "ong"
     },
     {
@@ -3083,7 +3111,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 960,
+      "readme_linha": 964,
       "tipo_fonte": "ong"
     },
     {
@@ -3107,7 +3135,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 964,
+      "readme_linha": 968,
       "tipo_fonte": "estadual"
     },
     {
@@ -3131,7 +3159,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 968,
+      "readme_linha": 972,
       "tipo_fonte": "municipal"
     },
     {
@@ -3155,7 +3183,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 972,
+      "readme_linha": 976,
       "tipo_fonte": "federal"
     },
     {
@@ -3179,7 +3207,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 976,
+      "readme_linha": 980,
       "tipo_fonte": "federal"
     },
     {
@@ -3205,7 +3233,7 @@
         "certidao",
         "imovel"
       ],
-      "readme_linha": 980,
+      "readme_linha": 984,
       "tipo_fonte": "ong"
     },
     {
@@ -3229,7 +3257,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 990,
+      "readme_linha": 994,
       "tipo_fonte": "federal"
     },
     {
@@ -3253,7 +3281,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 994,
+      "readme_linha": 998,
       "tipo_fonte": "federal"
     },
     {
@@ -3277,7 +3305,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 998,
+      "readme_linha": 1002,
       "tipo_fonte": "federal"
     },
     {
@@ -3301,7 +3329,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 1002,
+      "readme_linha": 1006,
       "tipo_fonte": "estadual"
     },
     {
@@ -3326,7 +3354,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 1006,
+      "readme_linha": 1010,
       "tipo_fonte": "ong"
     },
     {
@@ -3351,7 +3379,7 @@
         "estatistica",
         "licenca_ambiental"
       ],
-      "readme_linha": 1010,
+      "readme_linha": 1014,
       "tipo_fonte": "ong"
     },
     {
@@ -3376,7 +3404,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 1014,
+      "readme_linha": 1018,
       "tipo_fonte": "ong"
     },
     {
@@ -3399,7 +3427,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1024,
+      "readme_linha": 1028,
       "tipo_fonte": "federal"
     },
     {
@@ -3422,7 +3450,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1028,
+      "readme_linha": 1032,
       "tipo_fonte": "federal"
     },
     {
@@ -3445,7 +3473,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1032,
+      "readme_linha": 1036,
       "tipo_fonte": "federal"
     },
     {
@@ -3468,7 +3496,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1036,
+      "readme_linha": 1040,
       "tipo_fonte": "federal"
     },
     {
@@ -3492,7 +3520,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1046,
+      "readme_linha": 1050,
       "tipo_fonte": "federal"
     },
     {
@@ -3516,7 +3544,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1050,
+      "readme_linha": 1054,
       "tipo_fonte": "federal"
     },
     {
@@ -3540,7 +3568,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1054,
+      "readme_linha": 1058,
       "tipo_fonte": "federal"
     },
     {
@@ -3566,7 +3594,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1064,
+      "readme_linha": 1068,
       "tipo_fonte": "federal"
     },
     {
@@ -3592,7 +3620,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1068,
+      "readme_linha": 1072,
       "tipo_fonte": "federal"
     },
     {
@@ -3624,7 +3652,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1072,
+      "readme_linha": 1076,
       "tipo_fonte": "federal"
     },
     {
@@ -3651,7 +3679,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1113,
+      "readme_linha": 1117,
       "tipo_fonte": "federal"
     },
     {
@@ -3678,7 +3706,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1117,
+      "readme_linha": 1121,
       "tipo_fonte": "federal"
     },
     {
@@ -3704,7 +3732,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1121,
+      "readme_linha": 1125,
       "tipo_fonte": "federal"
     },
     {
@@ -3730,7 +3758,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1125,
+      "readme_linha": 1129,
       "tipo_fonte": "federal"
     },
     {
@@ -3756,7 +3784,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 1129,
+      "readme_linha": 1133,
       "tipo_fonte": "federal"
     },
     {
@@ -3784,7 +3812,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1133,
+      "readme_linha": 1137,
       "tipo_fonte": "federal"
     },
     {
@@ -3810,7 +3838,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1137,
+      "readme_linha": 1141,
       "tipo_fonte": "federal"
     },
     {
@@ -3877,7 +3905,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1141,
+      "readme_linha": 1145,
       "tipo_fonte": "federal"
     },
     {
@@ -3903,7 +3931,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1158,
+      "readme_linha": 1162,
       "tipo_fonte": "federal"
     },
     {
@@ -3929,7 +3957,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1162,
+      "readme_linha": 1166,
       "tipo_fonte": "federal"
     },
     {
@@ -3955,7 +3983,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1166,
+      "readme_linha": 1170,
       "tipo_fonte": "federal"
     },
     {
@@ -3981,7 +4009,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1170,
+      "readme_linha": 1174,
       "tipo_fonte": "federal"
     },
     {
@@ -4007,7 +4035,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1174,
+      "readme_linha": 1178,
       "tipo_fonte": "federal"
     },
     {
@@ -4033,7 +4061,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1178,
+      "readme_linha": 1182,
       "tipo_fonte": "federal"
     },
     {
@@ -4059,7 +4087,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1182,
+      "readme_linha": 1186,
       "tipo_fonte": "federal"
     },
     {
@@ -4086,7 +4114,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1186,
+      "readme_linha": 1190,
       "tipo_fonte": "federal"
     },
     {
@@ -4112,7 +4140,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1190,
+      "readme_linha": 1194,
       "tipo_fonte": "estadual"
     },
     {
@@ -4139,7 +4167,7 @@
         "remuneracao",
         "sancao"
       ],
-      "readme_linha": 1194,
+      "readme_linha": 1198,
       "tipo_fonte": "estadual"
     },
     {
@@ -4165,7 +4193,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1198,
+      "readme_linha": 1202,
       "tipo_fonte": "federal"
     },
     {
@@ -4236,7 +4264,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1202,
+      "readme_linha": 1206,
       "tipo_fonte": "estadual"
     },
     {
@@ -4262,7 +4290,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1246,
+      "readme_linha": 1250,
       "tipo_fonte": "federal"
     },
     {
@@ -4428,7 +4456,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1250,
+      "readme_linha": 1254,
       "tipo_fonte": "estadual"
     },
     {
@@ -4452,7 +4480,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1319,
+      "readme_linha": 1323,
       "tipo_fonte": "federal"
     },
     {
@@ -4476,7 +4504,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1323,
+      "readme_linha": 1327,
       "tipo_fonte": "federal"
     },
     {
@@ -4500,7 +4528,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1327,
+      "readme_linha": 1331,
       "tipo_fonte": "ong"
     },
     {
@@ -4654,7 +4682,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1331,
+      "readme_linha": 1335,
       "tipo_fonte": "estadual"
     },
     {
@@ -4680,7 +4708,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 1396,
+      "readme_linha": 1400,
       "tipo_fonte": "federal"
     },
     {
@@ -4704,7 +4732,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1400,
+      "readme_linha": 1404,
       "tipo_fonte": "federal"
     },
     {
@@ -4728,7 +4756,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1404,
+      "readme_linha": 1408,
       "tipo_fonte": "federal"
     },
     {
@@ -4752,7 +4780,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1408,
+      "readme_linha": 1412,
       "tipo_fonte": "federal"
     },
     {
@@ -4776,7 +4804,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1412,
+      "readme_linha": 1416,
       "tipo_fonte": "federal"
     },
     {
@@ -4800,7 +4828,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1416,
+      "readme_linha": 1420,
       "tipo_fonte": "federal"
     },
     {
@@ -4824,7 +4852,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1420,
+      "readme_linha": 1424,
       "tipo_fonte": "federal"
     },
     {
@@ -4848,7 +4876,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1424,
+      "readme_linha": 1428,
       "tipo_fonte": "federal"
     },
     {
@@ -4872,7 +4900,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1428,
+      "readme_linha": 1432,
       "tipo_fonte": "federal"
     },
     {
@@ -4896,7 +4924,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1432,
+      "readme_linha": 1436,
       "tipo_fonte": "federal"
     },
     {
@@ -4930,7 +4958,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1441,
+      "readme_linha": 1445,
       "tipo_fonte": "privado"
     },
     {
@@ -4958,7 +4986,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1454,
+      "readme_linha": 1458,
       "tipo_fonte": "privado"
     },
     {
@@ -4996,7 +5024,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1459,
+      "readme_linha": 1463,
       "tipo_fonte": "privado"
     },
     {
@@ -5020,7 +5048,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1471,
+      "readme_linha": 1475,
       "tipo_fonte": "privado"
     },
     {
@@ -5084,7 +5112,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1477,
+      "readme_linha": 1481,
       "tipo_fonte": "ong"
     },
     {
@@ -5109,7 +5137,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1495,
+      "readme_linha": 1499,
       "tipo_fonte": "federal"
     },
     {
@@ -5134,7 +5162,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1499,
+      "readme_linha": 1503,
       "tipo_fonte": "federal"
     },
     {
@@ -5158,7 +5186,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1503,
+      "readme_linha": 1507,
       "tipo_fonte": "federal"
     },
     {
@@ -5181,7 +5209,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1507,
+      "readme_linha": 1511,
       "tipo_fonte": "federal"
     },
     {
@@ -5204,7 +5232,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1511,
+      "readme_linha": 1515,
       "tipo_fonte": "federal"
     },
     {
@@ -5233,7 +5261,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1515,
+      "readme_linha": 1519,
       "tipo_fonte": "privado"
     },
     {
@@ -5257,7 +5285,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1520,
+      "readme_linha": 1524,
       "tipo_fonte": "federal"
     },
     {
@@ -5280,7 +5308,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1524,
+      "readme_linha": 1528,
       "tipo_fonte": "federal"
     },
     {
@@ -5305,7 +5333,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1528,
+      "readme_linha": 1532,
       "tipo_fonte": "federal"
     },
     {
@@ -5331,7 +5359,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1536,
+      "readme_linha": 1540,
       "tipo_fonte": "federal"
     },
     {
@@ -5356,7 +5384,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1542,
+      "readme_linha": 1546,
       "tipo_fonte": "federal"
     },
     {
@@ -5381,7 +5409,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1548,
+      "readme_linha": 1552,
       "tipo_fonte": "federal"
     },
     {
@@ -5406,7 +5434,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1554,
+      "readme_linha": 1558,
       "tipo_fonte": "federal"
     },
     {
@@ -5430,7 +5458,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1561,
+      "readme_linha": 1565,
       "tipo_fonte": "federal"
     },
     {
@@ -5453,7 +5481,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1568,
+      "readme_linha": 1572,
       "tipo_fonte": "federal"
     },
     {
@@ -5480,7 +5508,7 @@
         "outorga",
         "radiofrequencia"
       ],
-      "readme_linha": 1575,
+      "readme_linha": 1579,
       "tipo_fonte": "federal"
     },
     {
@@ -5505,7 +5533,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1582,
+      "readme_linha": 1586,
       "tipo_fonte": "federal"
     },
     {
@@ -5528,7 +5556,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1589,
+      "readme_linha": 1593,
       "tipo_fonte": "federal"
     },
     {
@@ -5552,7 +5580,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1596,
+      "readme_linha": 1600,
       "tipo_fonte": "federal"
     },
     {
@@ -5576,7 +5604,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1603,
+      "readme_linha": 1607,
       "tipo_fonte": "federal"
     },
     {
@@ -5600,7 +5628,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1616,
+      "readme_linha": 1620,
       "tipo_fonte": "federal"
     },
     {
@@ -5625,7 +5653,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1622,
+      "readme_linha": 1626,
       "tipo_fonte": "ong"
     },
     {
@@ -5658,7 +5686,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1628,
+      "readme_linha": 1632,
       "tipo_fonte": "privado"
     },
     {
@@ -5686,7 +5714,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1639,
+      "readme_linha": 1643,
       "tipo_fonte": "ong"
     },
     {
@@ -5757,7 +5785,7 @@
         "erb",
         "operadora"
       ],
-      "readme_linha": 1648,
+      "readme_linha": 1652,
       "tipo_fonte": "privado"
     },
     {
@@ -5781,7 +5809,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1674,
+      "readme_linha": 1678,
       "tipo_fonte": "privado"
     },
     {
@@ -5807,7 +5835,7 @@
         "processo",
         "publicacao_academica"
       ],
-      "readme_linha": 1680,
+      "readme_linha": 1684,
       "tipo_fonte": "federal"
     },
     {
@@ -5831,7 +5859,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1686,
+      "readme_linha": 1690,
       "tipo_fonte": "privado"
     },
     {
@@ -5855,7 +5883,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1690,
+      "readme_linha": 1694,
       "tipo_fonte": "academico"
     },
     {
@@ -5879,7 +5907,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1694,
+      "readme_linha": 1698,
       "tipo_fonte": "academico"
     },
     {
@@ -5903,7 +5931,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1698,
+      "readme_linha": 1702,
       "tipo_fonte": "academico"
     },
     {
@@ -5927,7 +5955,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1702,
+      "readme_linha": 1706,
       "tipo_fonte": "academico"
     },
     {
@@ -5951,7 +5979,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1706,
+      "readme_linha": 1710,
       "tipo_fonte": "federal"
     },
     {
@@ -5975,7 +6003,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1710,
+      "readme_linha": 1714,
       "tipo_fonte": "privado"
     },
     {
@@ -5999,7 +6027,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1714,
+      "readme_linha": 1718,
       "tipo_fonte": "federal"
     },
     {
@@ -6023,7 +6051,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1718,
+      "readme_linha": 1722,
       "tipo_fonte": "ong"
     },
     {
@@ -6048,7 +6076,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1722,
+      "readme_linha": 1726,
       "tipo_fonte": "federal"
     },
     {
@@ -6074,7 +6102,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1726,
+      "readme_linha": 1730,
       "tipo_fonte": "federal"
     },
     {
@@ -6099,7 +6127,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 1730,
+      "readme_linha": 1734,
       "tipo_fonte": "federal"
     },
     {
@@ -6123,7 +6151,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1734,
+      "readme_linha": 1738,
       "tipo_fonte": "federal"
     },
     {
@@ -6147,7 +6175,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1738,
+      "readme_linha": 1742,
       "tipo_fonte": "federal"
     },
     {
@@ -6171,7 +6199,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1742,
+      "readme_linha": 1746,
       "tipo_fonte": "federal"
     },
     {
@@ -6311,7 +6339,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1751,
+      "readme_linha": 1755,
       "tipo_fonte": "privado"
     },
     {
@@ -6342,7 +6370,7 @@
         "area_rural",
         "mapa"
       ],
-      "readme_linha": 1785,
+      "readme_linha": 1789,
       "tipo_fonte": "federal"
     },
     {
@@ -6366,7 +6394,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1792,
+      "readme_linha": 1796,
       "tipo_fonte": "federal"
     },
     {
@@ -6395,7 +6423,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1798,
+      "readme_linha": 1802,
       "tipo_fonte": "federal"
     },
     {
@@ -6419,7 +6447,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1805,
+      "readme_linha": 1809,
       "tipo_fonte": "privado"
     },
     {
@@ -6460,7 +6488,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1809,
+      "readme_linha": 1813,
       "tipo_fonte": "internacional"
     },
     {
@@ -6489,7 +6517,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1821,
+      "readme_linha": 1825,
       "tipo_fonte": "federal"
     },
     {
@@ -6514,7 +6542,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1828,
+      "readme_linha": 1832,
       "tipo_fonte": "federal"
     },
     {
@@ -6538,7 +6566,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1834,
+      "readme_linha": 1838,
       "tipo_fonte": "federal"
     },
     {
@@ -6577,7 +6605,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1838,
+      "readme_linha": 1842,
       "tipo_fonte": "federal"
     },
     {
@@ -6601,7 +6629,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1850,
+      "readme_linha": 1854,
       "tipo_fonte": "federal"
     },
     {
@@ -6625,7 +6653,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1854,
+      "readme_linha": 1858,
       "tipo_fonte": "federal"
     },
     {
@@ -6650,7 +6678,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1864,
+      "readme_linha": 1868,
       "tipo_fonte": "federal"
     },
     {
@@ -6675,7 +6703,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1871,
+      "readme_linha": 1875,
       "tipo_fonte": "federal"
     },
     {
@@ -6702,7 +6730,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1878,
+      "readme_linha": 1882,
       "tipo_fonte": "federal"
     },
     {
@@ -6731,7 +6759,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1885,
+      "readme_linha": 1889,
       "tipo_fonte": "federal"
     },
     {
@@ -6757,7 +6785,7 @@
         "mapa",
         "sancao"
       ],
-      "readme_linha": 1892,
+      "readme_linha": 1896,
       "tipo_fonte": "federal"
     },
     {
@@ -6782,7 +6810,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1899,
+      "readme_linha": 1903,
       "tipo_fonte": "federal"
     },
     {
@@ -6809,7 +6837,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1906,
+      "readme_linha": 1910,
       "tipo_fonte": "federal"
     },
     {
@@ -6835,7 +6863,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1913,
+      "readme_linha": 1917,
       "tipo_fonte": "privado"
     },
     {
@@ -6860,7 +6888,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1920,
+      "readme_linha": 1924,
       "tipo_fonte": "federal"
     },
     {
@@ -6887,7 +6915,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1927,
+      "readme_linha": 1931,
       "tipo_fonte": "federal"
     },
     {
@@ -6912,7 +6940,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1934,
+      "readme_linha": 1938,
       "tipo_fonte": "federal"
     },
     {
@@ -6938,7 +6966,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1941,
+      "readme_linha": 1945,
       "tipo_fonte": "federal"
     },
     {
@@ -6964,7 +6992,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1948,
+      "readme_linha": 1952,
       "tipo_fonte": "federal"
     },
     {
@@ -6989,7 +7017,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1955,
+      "readme_linha": 1959,
       "tipo_fonte": "federal"
     },
     {
@@ -7016,7 +7044,7 @@
         "mapa",
         "processo"
       ],
-      "readme_linha": 1962,
+      "readme_linha": 1966,
       "tipo_fonte": "federal"
     },
     {
@@ -7043,7 +7071,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1969,
+      "readme_linha": 1973,
       "tipo_fonte": "federal"
     },
     {
@@ -7067,7 +7095,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1980,
+      "readme_linha": 1984,
       "tipo_fonte": "federal"
     },
     {
@@ -7091,7 +7119,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1986,
+      "readme_linha": 1990,
       "tipo_fonte": "federal"
     },
     {
@@ -7116,7 +7144,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1990,
+      "readme_linha": 1994,
       "tipo_fonte": "federal"
     },
     {
@@ -7140,7 +7168,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1994,
+      "readme_linha": 1998,
       "tipo_fonte": "federal"
     },
     {
@@ -7164,7 +7192,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1998,
+      "readme_linha": 2002,
       "tipo_fonte": "federal"
     },
     {
@@ -7188,7 +7216,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2002,
+      "readme_linha": 2006,
       "tipo_fonte": "federal"
     },
     {
@@ -7217,7 +7245,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2006,
+      "readme_linha": 2010,
       "tipo_fonte": "federal"
     },
     {
@@ -7242,7 +7270,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 2011,
+      "readme_linha": 2015,
       "tipo_fonte": "ong"
     },
     {
@@ -7267,7 +7295,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 2015,
+      "readme_linha": 2019,
       "tipo_fonte": "academico"
     },
     {
@@ -7291,7 +7319,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2019,
+      "readme_linha": 2023,
       "tipo_fonte": "academico"
     },
     {
@@ -7325,7 +7353,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2023,
+      "readme_linha": 2027,
       "tipo_fonte": "federal"
     },
     {
@@ -7363,7 +7391,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2040,
+      "readme_linha": 2044,
       "tipo_fonte": "dork"
     },
     {
@@ -7391,7 +7419,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2053,
+      "readme_linha": 2057,
       "tipo_fonte": "dork"
     },
     {
@@ -7419,7 +7447,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2060,
+      "readme_linha": 2064,
       "tipo_fonte": "dork"
     },
     {
@@ -7452,7 +7480,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2069,
+      "readme_linha": 2073,
       "tipo_fonte": "dork"
     },
     {
@@ -7490,7 +7518,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2080,
+      "readme_linha": 2084,
       "tipo_fonte": "dork"
     },
     {
@@ -7529,7 +7557,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2093,
+      "readme_linha": 2097,
       "tipo_fonte": "dork"
     },
     {
@@ -7568,7 +7596,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2109,
+      "readme_linha": 2113,
       "tipo_fonte": "internacional"
     },
     {
@@ -7602,7 +7630,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2121,
+      "readme_linha": 2125,
       "tipo_fonte": "internacional"
     },
     {
@@ -7630,7 +7658,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2128,
+      "readme_linha": 2132,
       "tipo_fonte": "dork"
     },
     {
@@ -7678,7 +7706,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2135,
+      "readme_linha": 2139,
       "tipo_fonte": "dork"
     },
     {
@@ -7716,7 +7744,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2155,
+      "readme_linha": 2159,
       "tipo_fonte": "dork"
     },
     {
@@ -7755,7 +7783,7 @@
         "dork",
         "video_ao_vivo"
       ],
-      "readme_linha": 2170,
+      "readme_linha": 2174,
       "tipo_fonte": "dork"
     },
     {
@@ -7796,7 +7824,7 @@
         "dork",
         "operadora"
       ],
-      "readme_linha": 2185,
+      "readme_linha": 2189,
       "tipo_fonte": "dork"
     },
     {
@@ -7830,7 +7858,7 @@
         "dork",
         "publicacao_academica"
       ],
-      "readme_linha": 2200,
+      "readme_linha": 2204,
       "tipo_fonte": "dork"
     },
     {
@@ -7863,7 +7891,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2212,
+      "readme_linha": 2216,
       "tipo_fonte": "dork"
     },
     {
@@ -7891,7 +7919,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2224,
+      "readme_linha": 2228,
       "tipo_fonte": "dork"
     },
     {
@@ -7920,7 +7948,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2234,
+      "readme_linha": 2238,
       "tipo_fonte": "internacional"
     },
     {
@@ -7963,7 +7991,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2246,
+      "readme_linha": 2250,
       "tipo_fonte": "dork"
     },
     {
@@ -7988,7 +8016,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2270,
+      "readme_linha": 2274,
       "tipo_fonte": "internacional"
     },
     {
@@ -8023,7 +8051,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2276,
+      "readme_linha": 2280,
       "tipo_fonte": "internacional"
     },
     {
@@ -8053,7 +8081,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2287,
+      "readme_linha": 2291,
       "tipo_fonte": "internacional"
     },
     {
@@ -8078,7 +8106,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2295,
+      "readme_linha": 2299,
       "tipo_fonte": "internacional"
     },
     {
@@ -8104,7 +8132,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2301,
+      "readme_linha": 2305,
       "tipo_fonte": "internacional"
     },
     {
@@ -8130,7 +8158,7 @@
         "estatistica",
         "perfil_social"
       ],
-      "readme_linha": 2307,
+      "readme_linha": 2311,
       "tipo_fonte": "internacional"
     },
     {
@@ -8155,7 +8183,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2313,
+      "readme_linha": 2317,
       "tipo_fonte": "internacional"
     },
     {
@@ -8180,7 +8208,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2319,
+      "readme_linha": 2323,
       "tipo_fonte": "internacional"
     },
     {
@@ -8205,7 +8233,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2323,
+      "readme_linha": 2327,
       "tipo_fonte": "internacional"
     },
     {
@@ -8230,7 +8258,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2327,
+      "readme_linha": 2331,
       "tipo_fonte": "internacional"
     },
     {
@@ -8255,7 +8283,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2331,
+      "readme_linha": 2335,
       "tipo_fonte": "internacional"
     },
     {
@@ -8280,7 +8308,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2335,
+      "readme_linha": 2339,
       "tipo_fonte": "internacional"
     },
     {
@@ -8305,7 +8333,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2339,
+      "readme_linha": 2343,
       "tipo_fonte": "internacional"
     },
     {
@@ -8331,7 +8359,7 @@
         "mandado_prisao",
         "perfil_social"
       ],
-      "readme_linha": 2345,
+      "readme_linha": 2349,
       "tipo_fonte": "privado"
     },
     {
@@ -8361,7 +8389,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2351,
+      "readme_linha": 2355,
       "tipo_fonte": "privado"
     },
     {
@@ -8391,7 +8419,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2358,
+      "readme_linha": 2362,
       "tipo_fonte": "internacional"
     },
     {
@@ -8417,7 +8445,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2364,
+      "readme_linha": 2368,
       "tipo_fonte": "internacional"
     },
     {
@@ -8442,7 +8470,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2371,
+      "readme_linha": 2375,
       "tipo_fonte": "privado"
     },
     {
@@ -8467,7 +8495,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2377,
+      "readme_linha": 2381,
       "tipo_fonte": "internacional"
     },
     {
@@ -8550,7 +8578,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2390,
+      "readme_linha": 2394,
       "tipo_fonte": "privado"
     },
     {
@@ -8613,7 +8641,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2415,
+      "readme_linha": 2419,
       "tipo_fonte": "privado"
     },
     {
@@ -8636,7 +8664,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2442,
+      "readme_linha": 2446,
       "tipo_fonte": "federal"
     },
     {
@@ -8659,7 +8687,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2448,
+      "readme_linha": 2452,
       "tipo_fonte": "privado"
     },
     {
@@ -8682,7 +8710,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2454,
+      "readme_linha": 2458,
       "tipo_fonte": "federal"
     },
     {
@@ -8705,7 +8733,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2460,
+      "readme_linha": 2464,
       "tipo_fonte": "privado"
     },
     {
@@ -8728,7 +8756,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2466,
+      "readme_linha": 2470,
       "tipo_fonte": "federal"
     },
     {
@@ -8751,7 +8779,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2472,
+      "readme_linha": 2476,
       "tipo_fonte": "federal"
     },
     {
@@ -8774,7 +8802,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2478,
+      "readme_linha": 2482,
       "tipo_fonte": "federal"
     },
     {
@@ -8798,7 +8826,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2484,
+      "readme_linha": 2488,
       "tipo_fonte": "federal"
     },
     {
@@ -8827,7 +8855,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 2488,
+      "readme_linha": 2492,
       "tipo_fonte": "federal"
     },
     {
@@ -8850,7 +8878,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2495,
+      "readme_linha": 2499,
       "tipo_fonte": "federal"
     },
     {
@@ -8873,7 +8901,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2499,
+      "readme_linha": 2503,
       "tipo_fonte": "federal"
     },
     {
@@ -8897,7 +8925,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2505,
+      "readme_linha": 2509,
       "tipo_fonte": "federal"
     },
     {
@@ -8920,7 +8948,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2511,
+      "readme_linha": 2515,
       "tipo_fonte": "estadual"
     },
     {
@@ -8944,7 +8972,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2517,
+      "readme_linha": 2521,
       "tipo_fonte": "estadual"
     },
     {
@@ -8968,7 +8996,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2523,
+      "readme_linha": 2527,
       "tipo_fonte": "federal"
     },
     {
@@ -8991,7 +9019,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2529,
+      "readme_linha": 2533,
       "tipo_fonte": "federal"
     },
     {
@@ -9014,7 +9042,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2535,
+      "readme_linha": 2539,
       "tipo_fonte": "estadual"
     },
     {
@@ -9038,7 +9066,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2541,
+      "readme_linha": 2545,
       "tipo_fonte": "federal"
     },
     {
@@ -9061,7 +9089,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2547,
+      "readme_linha": 2551,
       "tipo_fonte": "estadual"
     },
     {
@@ -9084,7 +9112,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2553,
+      "readme_linha": 2557,
       "tipo_fonte": "estadual"
     },
     {
@@ -9107,7 +9135,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2559,
+      "readme_linha": 2563,
       "tipo_fonte": "federal"
     },
     {
@@ -9130,7 +9158,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2565,
+      "readme_linha": 2569,
       "tipo_fonte": "estadual"
     },
     {
@@ -9153,7 +9181,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2571,
+      "readme_linha": 2575,
       "tipo_fonte": "estadual"
     },
     {
@@ -9176,7 +9204,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2575,
+      "readme_linha": 2579,
       "tipo_fonte": "federal"
     },
     {
@@ -9199,7 +9227,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2581,
+      "readme_linha": 2585,
       "tipo_fonte": "federal"
     },
     {
@@ -9222,7 +9250,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2587,
+      "readme_linha": 2591,
       "tipo_fonte": "estadual"
     },
     {
@@ -9245,7 +9273,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2593,
+      "readme_linha": 2597,
       "tipo_fonte": "federal"
     },
     {
@@ -9273,7 +9301,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2599,
+      "readme_linha": 2603,
       "tipo_fonte": "federal"
     },
     {
@@ -9298,7 +9326,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2606,
+      "readme_linha": 2610,
       "tipo_fonte": "estadual"
     },
     {
@@ -9321,7 +9349,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2610,
+      "readme_linha": 2614,
       "tipo_fonte": "federal"
     },
     {
@@ -9345,7 +9373,7 @@
         "dataset",
         "diario_oficial"
       ],
-      "readme_linha": 2614,
+      "readme_linha": 2618,
       "tipo_fonte": "ong"
     },
     {
@@ -9368,7 +9396,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2620,
+      "readme_linha": 2624,
       "tipo_fonte": "ong"
     },
     {
@@ -9391,7 +9419,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2624,
+      "readme_linha": 2628,
       "tipo_fonte": "federal"
     },
     {
@@ -9414,7 +9442,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2628,
+      "readme_linha": 2632,
       "tipo_fonte": "federal"
     },
     {
@@ -9437,7 +9465,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2632,
+      "readme_linha": 2636,
       "tipo_fonte": "privado"
     },
     {
@@ -9460,7 +9488,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2636,
+      "readme_linha": 2640,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9483,7 +9511,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2640,
+      "readme_linha": 2644,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9507,7 +9535,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2644,
+      "readme_linha": 2648,
       "tipo_fonte": "federal"
     },
     {
@@ -9530,7 +9558,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2648,
+      "readme_linha": 2652,
       "tipo_fonte": "federal"
     },
     {
@@ -9554,7 +9582,7 @@
         "dataset",
         "endereco"
       ],
-      "readme_linha": 2652,
+      "readme_linha": 2656,
       "tipo_fonte": "privado"
     },
     {
@@ -9579,7 +9607,7 @@
         "beneficio",
         "remuneracao"
       ],
-      "readme_linha": 2662,
+      "readme_linha": 2666,
       "tipo_fonte": "ong"
     },
     {
@@ -9603,7 +9631,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2670,
+      "readme_linha": 2674,
       "tipo_fonte": "estadual"
     },
     {
@@ -9627,7 +9655,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2674,
+      "readme_linha": 2678,
       "tipo_fonte": "estadual"
     },
     {
@@ -9726,7 +9754,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2680,
+      "readme_linha": 2684,
       "tipo_fonte": "privado"
     },
     {
@@ -9785,7 +9813,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2703,
+      "readme_linha": 2707,
       "tipo_fonte": "ong"
     },
     {
@@ -9814,7 +9842,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2718,
+      "readme_linha": 2722,
       "tipo_fonte": "privado"
     },
     {
@@ -9838,7 +9866,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2725,
+      "readme_linha": 2729,
       "tipo_fonte": "privado"
     },
     {
@@ -9862,7 +9890,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2731,
+      "readme_linha": 2735,
       "tipo_fonte": "federal"
     },
     {
@@ -9886,7 +9914,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2737,
+      "readme_linha": 2741,
       "tipo_fonte": "federal"
     },
     {
@@ -9911,7 +9939,7 @@
         "veiculo",
         "video_ao_vivo"
       ],
-      "readme_linha": 2743,
+      "readme_linha": 2747,
       "tipo_fonte": "internacional"
     },
     {
@@ -9935,7 +9963,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2747,
+      "readme_linha": 2751,
       "tipo_fonte": "internacional"
     },
     {
@@ -9960,7 +9988,7 @@
         "multa",
         "veiculo"
       ],
-      "readme_linha": 2751,
+      "readme_linha": 2755,
       "tipo_fonte": "federal"
     },
     {
@@ -9986,7 +10014,7 @@
         "dados_cadastrais",
         "veiculo"
       ],
-      "readme_linha": 2755,
+      "readme_linha": 2759,
       "tipo_fonte": "federal"
     },
     {
@@ -10010,7 +10038,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2759,
+      "readme_linha": 2763,
       "tipo_fonte": "federal"
     },
     {
@@ -10034,7 +10062,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2763,
+      "readme_linha": 2767,
       "tipo_fonte": "privado"
     },
     {
@@ -10058,7 +10086,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2769,
+      "readme_linha": 2773,
       "tipo_fonte": "federal"
     },
     {
@@ -10082,7 +10110,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2775,
+      "readme_linha": 2779,
       "tipo_fonte": "federal"
     },
     {
@@ -10107,7 +10135,7 @@
         "dataset",
         "veiculo"
       ],
-      "readme_linha": 2781,
+      "readme_linha": 2785,
       "tipo_fonte": "federal"
     },
     {
@@ -10136,7 +10164,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2787,
+      "readme_linha": 2791,
       "tipo_fonte": "estadual"
     },
     {
@@ -10165,7 +10193,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2794,
+      "readme_linha": 2798,
       "tipo_fonte": "estadual"
     },
     {
@@ -10334,7 +10362,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2801,
+      "readme_linha": 2805,
       "tipo_fonte": "estadual"
     },
     {
@@ -10358,7 +10386,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 2871,
+      "readme_linha": 2875,
       "tipo_fonte": "privado"
     },
     {
@@ -10381,7 +10409,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2877,
+      "readme_linha": 2881,
       "tipo_fonte": "privado"
     },
     {
@@ -10424,7 +10452,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2883,
+      "readme_linha": 2887,
       "tipo_fonte": "estadual"
     },
     {
@@ -10447,7 +10475,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2903,
+      "readme_linha": 2907,
       "tipo_fonte": "privado"
     },
     {
@@ -10470,7 +10498,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2909,
+      "readme_linha": 2913,
       "tipo_fonte": "privado"
     },
     {
@@ -10493,7 +10521,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2915,
+      "readme_linha": 2919,
       "tipo_fonte": "privado"
     },
     {
@@ -10518,7 +10546,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 2927,
+      "readme_linha": 2931,
       "tipo_fonte": "federal"
     },
     {
@@ -10544,7 +10572,7 @@
         "estatistica",
         "multa"
       ],
-      "readme_linha": 2931,
+      "readme_linha": 2935,
       "tipo_fonte": "privado"
     },
     {
@@ -10567,7 +10595,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2935,
+      "readme_linha": 2939,
       "tipo_fonte": "federal"
     },
     {
@@ -10590,7 +10618,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2939,
+      "readme_linha": 2943,
       "tipo_fonte": "federal"
     },
     {
@@ -10613,7 +10641,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2943,
+      "readme_linha": 2947,
       "tipo_fonte": "federal"
     },
     {
@@ -10636,7 +10664,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2947,
+      "readme_linha": 2951,
       "tipo_fonte": "federal"
     },
     {
@@ -10664,7 +10692,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2951,
+      "readme_linha": 2955,
       "tipo_fonte": "internacional"
     },
     {
@@ -10687,7 +10715,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2956,
+      "readme_linha": 2960,
       "tipo_fonte": "privado"
     },
     {
@@ -10710,7 +10738,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2960,
+      "readme_linha": 2964,
       "tipo_fonte": "privado"
     },
     {
@@ -10733,7 +10761,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2964,
+      "readme_linha": 2968,
       "tipo_fonte": "privado"
     },
     {
@@ -10756,7 +10784,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2974,
+      "readme_linha": 2978,
       "tipo_fonte": "federal"
     },
     {
@@ -10782,7 +10810,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 2980,
+      "readme_linha": 2984,
       "tipo_fonte": "privado"
     },
     {
@@ -10805,7 +10833,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2986,
+      "readme_linha": 2990,
       "tipo_fonte": "federal"
     },
     {
@@ -10830,7 +10858,7 @@
         "dados_cadastrais",
         "multa"
       ],
-      "readme_linha": 2992,
+      "readme_linha": 2996,
       "tipo_fonte": "federal"
     },
     {
@@ -10908,7 +10936,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2996,
+      "readme_linha": 3000,
       "tipo_fonte": "federal"
     },
     {
@@ -10931,7 +10959,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3024,
+      "readme_linha": 3028,
       "tipo_fonte": "estadual"
     },
     {
@@ -10954,7 +10982,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3030,
+      "readme_linha": 3034,
       "tipo_fonte": "privado"
     },
     {
@@ -10977,7 +11005,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3034,
+      "readme_linha": 3038,
       "tipo_fonte": "estadual"
     },
     {
@@ -11000,7 +11028,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3038,
+      "readme_linha": 3042,
       "tipo_fonte": "internacional"
     },
     {
@@ -11043,7 +11071,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3042,
+      "readme_linha": 3046,
       "tipo_fonte": "privado"
     },
     {
@@ -11091,7 +11119,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3057,
+      "readme_linha": 3061,
       "tipo_fonte": "privado"
     },
     {
@@ -11194,7 +11222,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3071,
+      "readme_linha": 3075,
       "tipo_fonte": "privado"
     },
     {
@@ -11217,7 +11245,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3112,
+      "readme_linha": 3116,
       "tipo_fonte": "privado"
     },
     {
@@ -11265,7 +11293,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3116,
+      "readme_linha": 3120,
       "tipo_fonte": "estadual"
     },
     {
@@ -11588,7 +11616,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3130,
+      "readme_linha": 3134,
       "tipo_fonte": "privado"
     },
     {
@@ -11611,7 +11639,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3205,
+      "readme_linha": 3209,
       "tipo_fonte": "privado"
     },
     {
@@ -11634,7 +11662,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3209,
+      "readme_linha": 3213,
       "tipo_fonte": "privado"
     },
     {
@@ -11657,7 +11685,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3213,
+      "readme_linha": 3217,
       "tipo_fonte": "estadual"
     },
     {
@@ -11680,7 +11708,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3217,
+      "readme_linha": 3221,
       "tipo_fonte": "federal"
     },
     {
@@ -11709,7 +11737,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3221,
+      "readme_linha": 3225,
       "tipo_fonte": "internacional"
     },
     {
@@ -11733,7 +11761,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3226,
+      "readme_linha": 3230,
       "tipo_fonte": "internacional"
     },
     {
@@ -11757,7 +11785,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3230,
+      "readme_linha": 3234,
       "tipo_fonte": "internacional"
     },
     {
@@ -11781,7 +11809,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3234,
+      "readme_linha": 3238,
       "tipo_fonte": "internacional"
     },
     {
@@ -11805,7 +11833,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3238,
+      "readme_linha": 3242,
       "tipo_fonte": "internacional"
     },
     {
@@ -11829,7 +11857,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3242,
+      "readme_linha": 3246,
       "tipo_fonte": "internacional"
     },
     {
@@ -11853,7 +11881,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3246,
+      "readme_linha": 3250,
       "tipo_fonte": "internacional"
     },
     {
@@ -11877,7 +11905,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3250,
+      "readme_linha": 3254,
       "tipo_fonte": "internacional"
     },
     {
@@ -11900,7 +11928,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3254,
+      "readme_linha": 3258,
       "tipo_fonte": "estadual"
     },
     {
@@ -11974,7 +12002,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3264,
+      "readme_linha": 3268,
       "tipo_fonte": "ministerio_publico"
     },
     {
@@ -12034,7 +12062,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3305,
+      "readme_linha": 3309,
       "tipo_fonte": "defensoria"
     },
     {
@@ -12068,7 +12096,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3337,
+      "readme_linha": 3341,
       "tipo_fonte": "ong"
     },
     {
@@ -12097,7 +12125,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3354,
+      "readme_linha": 3358,
       "tipo_fonte": "estadual"
     },
     {
@@ -12126,7 +12154,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3374,
+      "readme_linha": 3378,
       "tipo_fonte": "privado"
     },
     {
@@ -12175,7 +12203,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3379,
+      "readme_linha": 3383,
       "tipo_fonte": "estadual"
     },
     {
@@ -12200,7 +12228,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 3398,
+      "readme_linha": 3402,
       "tipo_fonte": "federal"
     },
     {
@@ -12225,7 +12253,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3402,
+      "readme_linha": 3406,
       "tipo_fonte": "ong"
     },
     {
@@ -12250,7 +12278,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3406,
+      "readme_linha": 3410,
       "tipo_fonte": "federal"
     },
     {
@@ -12273,7 +12301,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3410,
+      "readme_linha": 3414,
       "tipo_fonte": "privado"
     },
     {
@@ -12298,7 +12326,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3414,
+      "readme_linha": 3418,
       "tipo_fonte": "federal"
     },
     {
@@ -12321,7 +12349,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3418,
+      "readme_linha": 3422,
       "tipo_fonte": "federal"
     },
     {
@@ -12342,7 +12370,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3422,
+      "readme_linha": 3426,
       "tipo_fonte": "federal"
     },
     {
@@ -12370,7 +12398,7 @@
         "mandado_prisao",
         "veiculo"
       ],
-      "readme_linha": 3426,
+      "readme_linha": 3430,
       "tipo_fonte": "federal"
     },
     {
@@ -12411,7 +12439,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3435,
+      "readme_linha": 3439,
       "tipo_fonte": "privado"
     },
     {
@@ -12442,7 +12470,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3454,
+      "readme_linha": 3458,
       "tipo_fonte": "privado"
     },
     {
@@ -12471,7 +12499,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3468,
+      "readme_linha": 3472,
       "tipo_fonte": "privado"
     },
     {
@@ -12499,7 +12527,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3495,
+      "readme_linha": 3499,
       "tipo_fonte": "privado"
     },
     {
@@ -12529,7 +12557,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3517,
+      "readme_linha": 3521,
       "tipo_fonte": "privado"
     },
     {
@@ -12556,7 +12584,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3541,
+      "readme_linha": 3545,
       "tipo_fonte": "federal"
     },
     {
@@ -12583,7 +12611,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3564,
+      "readme_linha": 3568,
       "tipo_fonte": "federal"
     },
     {
@@ -12613,7 +12641,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3568,
+      "readme_linha": 3572,
       "tipo_fonte": "ong"
     },
     {
@@ -12639,7 +12667,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3591,
+      "readme_linha": 3595,
       "tipo_fonte": "federal"
     },
     {
@@ -12663,7 +12691,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3595,
+      "readme_linha": 3599,
       "tipo_fonte": "federal"
     },
     {
@@ -12686,7 +12714,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3605,
+      "readme_linha": 3609,
       "tipo_fonte": "federal"
     },
     {
@@ -12709,7 +12737,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3609,
+      "readme_linha": 3613,
       "tipo_fonte": "federal"
     },
     {
@@ -12738,7 +12766,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3613,
+      "readme_linha": 3617,
       "tipo_fonte": "federal"
     },
     {
@@ -12766,7 +12794,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3618,
+      "readme_linha": 3622,
       "tipo_fonte": "federal"
     },
     {
@@ -12789,7 +12817,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3623,
+      "readme_linha": 3627,
       "tipo_fonte": "federal"
     },
     {
@@ -12812,7 +12840,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3627,
+      "readme_linha": 3631,
       "tipo_fonte": "federal"
     },
     {
@@ -12841,7 +12869,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3637,
+      "readme_linha": 3641,
       "tipo_fonte": "federal"
     },
     {
@@ -12865,7 +12893,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3642,
+      "readme_linha": 3646,
       "tipo_fonte": "federal"
     },
     {
@@ -12889,7 +12917,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3646,
+      "readme_linha": 3650,
       "tipo_fonte": "federal"
     },
     {
@@ -12919,7 +12947,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3650,
+      "readme_linha": 3654,
       "tipo_fonte": "ong"
     },
     {
@@ -12949,7 +12977,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3655,
+      "readme_linha": 3659,
       "tipo_fonte": "federal"
     },
     {
@@ -12974,7 +13002,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3660,
+      "readme_linha": 3664,
       "tipo_fonte": "federal"
     },
     {
@@ -12998,7 +13026,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3664,
+      "readme_linha": 3668,
       "tipo_fonte": "federal"
     },
     {
@@ -13022,7 +13050,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3668,
+      "readme_linha": 3672,
       "tipo_fonte": "federal"
     },
     {
@@ -13077,7 +13105,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3678,
+      "readme_linha": 3682,
       "tipo_fonte": "ong"
     },
     {
@@ -13201,7 +13229,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3717,
+      "readme_linha": 3721,
       "tipo_fonte": "estadual"
     },
     {
@@ -13321,7 +13349,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3758,
+      "readme_linha": 3762,
       "tipo_fonte": "ong"
     },
     {
@@ -13355,7 +13383,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3787,
+      "readme_linha": 3791,
       "tipo_fonte": "estadual"
     },
     {
@@ -13381,7 +13409,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3799,
+      "readme_linha": 3803,
       "tipo_fonte": "estadual"
     },
     {
@@ -13407,7 +13435,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3803,
+      "readme_linha": 3807,
       "tipo_fonte": "estadual"
     },
     {
@@ -13431,7 +13459,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3807,
+      "readme_linha": 3811,
       "tipo_fonte": "estadual"
     },
     {
@@ -13454,7 +13482,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3817,
+      "readme_linha": 3821,
       "tipo_fonte": "ong"
     },
     {
@@ -13477,7 +13505,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3821,
+      "readme_linha": 3825,
       "tipo_fonte": "federal"
     },
     {
@@ -13501,7 +13529,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3825,
+      "readme_linha": 3829,
       "tipo_fonte": "ong"
     },
     {
@@ -13524,7 +13552,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3829,
+      "readme_linha": 3833,
       "tipo_fonte": "federal"
     },
     {
@@ -13547,7 +13575,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3833,
+      "readme_linha": 3837,
       "tipo_fonte": "federal"
     },
     {
@@ -13575,7 +13603,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3837,
+      "readme_linha": 3841,
       "tipo_fonte": "privado"
     },
     {
@@ -13663,7 +13691,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3849,
+      "readme_linha": 3853,
       "tipo_fonte": "privado"
     },
     {
@@ -13714,7 +13742,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3871,
+      "readme_linha": 3875,
       "tipo_fonte": "privado"
     },
     {
@@ -13737,7 +13765,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3884,
+      "readme_linha": 3888,
       "tipo_fonte": "estadual"
     },
     {
@@ -13770,7 +13798,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3890,
+      "readme_linha": 3894,
       "tipo_fonte": "privado"
     },
     {
@@ -13794,7 +13822,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3901,
+      "readme_linha": 3905,
       "tipo_fonte": "privado"
     },
     {
@@ -13817,7 +13845,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3905,
+      "readme_linha": 3909,
       "tipo_fonte": "federal"
     },
     {
@@ -13851,7 +13879,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3911,
+      "readme_linha": 3915,
       "tipo_fonte": "privado"
     },
     {
@@ -13937,7 +13965,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3921,
+      "readme_linha": 3925,
       "tipo_fonte": "privado"
     },
     {
@@ -13961,7 +13989,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3970,
+      "readme_linha": 3974,
       "tipo_fonte": "estadual"
     },
     {
@@ -13995,9 +14023,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4133,
+      "readme_linha": 4137,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 444
+  "total": 445
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -8837,7 +8837,7 @@
       "categoria_id": "datasets-dados-abertos",
       "classificacao": "heuristica",
       "descricao": "O Plano de Dados Abertos do MTur abrange os setores do turismo e da cultura, e é o documento orientador para as ações de implementação e promoção de abertura de dados produzidos ou que estão sob a responsabilidade do Ministério do Turismo (MTur)",
-      "id": "datasets-dados-abertos/dados-mtur-ministerio-do-meio-ambiente-e-mudanca-do-clima",
+      "id": "datasets-dados-abertos/dados-mtur-ministerio-do-turismo",
       "input": [
         "nenhum"
       ],
@@ -8848,7 +8848,7 @@
           "url": "https://dados.turismo.gov.br/dataset/"
         }
       ],
-      "nome": "Dados MTur - Ministério do Meio Ambiente e Mudança do Clima",
+      "nome": "Dados MTur - Ministério do Turismo",
       "output": [
         "dataset"
       ],

--- a/data/sources.json
+++ b/data/sources.json
@@ -3683,6 +3683,32 @@
     {
       "categoria": "Transparência Pública e Defesa do Consumidor",
       "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
+      "classificacao": "override",
+      "descricao": "Consulta pública de pessoas físicas, jurídicas e estrangeiros com restrição para contratar com a Administração Pública, por CNPJ, CPF ou razão social.",
+      "id": "transparencia-publica-e-defesa-do-consumidor/sicaf-consulta-de-restricao-para-contratar-com-a-administracao-publica",
+      "input": [
+        "cnpj",
+        "cpf",
+        "razao_social"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://www3.comprasnet.gov.br/sicaf-web/public/pages/consultas/consultarRestricaoContratarAdministracaoPublica.jsf"
+        }
+      ],
+      "nome": "SICAF - Consulta de Restrição para Contratar com a Administração Pública",
+      "observacao": "Sem cadastro, com hCaptcha.",
+      "output": [
+        "sancao"
+      ],
+      "readme_linha": 1121,
+      "tipo_fonte": "federal"
+    },
+    {
+      "categoria": "Transparência Pública e Defesa do Consumidor",
+      "categoria_id": "transparencia-publica-e-defesa-do-consumidor",
       "classificacao": "heuristica",
       "descricao": "Fiscalização de gastos públicos federais, relatórios de auditoria e decisões.",
       "id": "transparencia-publica-e-defesa-do-consumidor/tcu-tribunal-de-contas-da-uniao",
@@ -3705,7 +3731,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1121,
+      "readme_linha": 1125,
       "tipo_fonte": "federal"
     },
     {
@@ -3731,7 +3757,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1125,
+      "readme_linha": 1129,
       "tipo_fonte": "federal"
     },
     {
@@ -3798,7 +3824,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1129,
+      "readme_linha": 1133,
       "tipo_fonte": "federal"
     },
     {
@@ -3824,7 +3850,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1146,
+      "readme_linha": 1150,
       "tipo_fonte": "federal"
     },
     {
@@ -3850,7 +3876,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1150,
+      "readme_linha": 1154,
       "tipo_fonte": "federal"
     },
     {
@@ -3876,7 +3902,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1154,
+      "readme_linha": 1158,
       "tipo_fonte": "federal"
     },
     {
@@ -3902,7 +3928,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1158,
+      "readme_linha": 1162,
       "tipo_fonte": "federal"
     },
     {
@@ -3928,7 +3954,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1162,
+      "readme_linha": 1166,
       "tipo_fonte": "federal"
     },
     {
@@ -3954,7 +3980,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1166,
+      "readme_linha": 1170,
       "tipo_fonte": "federal"
     },
     {
@@ -3980,7 +4006,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1170,
+      "readme_linha": 1174,
       "tipo_fonte": "federal"
     },
     {
@@ -4007,7 +4033,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1174,
+      "readme_linha": 1178,
       "tipo_fonte": "federal"
     },
     {
@@ -4033,7 +4059,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1178,
+      "readme_linha": 1182,
       "tipo_fonte": "estadual"
     },
     {
@@ -4060,7 +4086,7 @@
         "remuneracao",
         "sancao"
       ],
-      "readme_linha": 1182,
+      "readme_linha": 1186,
       "tipo_fonte": "estadual"
     },
     {
@@ -4086,7 +4112,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1186,
+      "readme_linha": 1190,
       "tipo_fonte": "federal"
     },
     {
@@ -4157,7 +4183,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1190,
+      "readme_linha": 1194,
       "tipo_fonte": "estadual"
     },
     {
@@ -4183,7 +4209,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1234,
+      "readme_linha": 1238,
       "tipo_fonte": "federal"
     },
     {
@@ -4349,7 +4375,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1238,
+      "readme_linha": 1242,
       "tipo_fonte": "estadual"
     },
     {
@@ -4373,7 +4399,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1307,
+      "readme_linha": 1311,
       "tipo_fonte": "federal"
     },
     {
@@ -4397,7 +4423,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1311,
+      "readme_linha": 1315,
       "tipo_fonte": "federal"
     },
     {
@@ -4421,7 +4447,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1315,
+      "readme_linha": 1319,
       "tipo_fonte": "ong"
     },
     {
@@ -4575,7 +4601,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1319,
+      "readme_linha": 1323,
       "tipo_fonte": "estadual"
     },
     {
@@ -4601,7 +4627,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 1384,
+      "readme_linha": 1388,
       "tipo_fonte": "federal"
     },
     {
@@ -4625,7 +4651,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1388,
+      "readme_linha": 1392,
       "tipo_fonte": "federal"
     },
     {
@@ -4649,7 +4675,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1392,
+      "readme_linha": 1396,
       "tipo_fonte": "federal"
     },
     {
@@ -4673,7 +4699,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1396,
+      "readme_linha": 1400,
       "tipo_fonte": "federal"
     },
     {
@@ -4697,7 +4723,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1400,
+      "readme_linha": 1404,
       "tipo_fonte": "federal"
     },
     {
@@ -4721,7 +4747,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1404,
+      "readme_linha": 1408,
       "tipo_fonte": "federal"
     },
     {
@@ -4745,7 +4771,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1408,
+      "readme_linha": 1412,
       "tipo_fonte": "federal"
     },
     {
@@ -4769,7 +4795,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1412,
+      "readme_linha": 1416,
       "tipo_fonte": "federal"
     },
     {
@@ -4793,7 +4819,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1416,
+      "readme_linha": 1420,
       "tipo_fonte": "federal"
     },
     {
@@ -4817,7 +4843,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1420,
+      "readme_linha": 1424,
       "tipo_fonte": "federal"
     },
     {
@@ -4851,7 +4877,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1429,
+      "readme_linha": 1433,
       "tipo_fonte": "privado"
     },
     {
@@ -4879,7 +4905,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1442,
+      "readme_linha": 1446,
       "tipo_fonte": "privado"
     },
     {
@@ -4917,7 +4943,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1447,
+      "readme_linha": 1451,
       "tipo_fonte": "privado"
     },
     {
@@ -4941,7 +4967,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1459,
+      "readme_linha": 1463,
       "tipo_fonte": "privado"
     },
     {
@@ -5005,7 +5031,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1465,
+      "readme_linha": 1469,
       "tipo_fonte": "ong"
     },
     {
@@ -5030,7 +5056,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1483,
+      "readme_linha": 1487,
       "tipo_fonte": "federal"
     },
     {
@@ -5055,7 +5081,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1487,
+      "readme_linha": 1491,
       "tipo_fonte": "federal"
     },
     {
@@ -5079,7 +5105,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1491,
+      "readme_linha": 1495,
       "tipo_fonte": "federal"
     },
     {
@@ -5102,7 +5128,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1495,
+      "readme_linha": 1499,
       "tipo_fonte": "federal"
     },
     {
@@ -5125,7 +5151,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1499,
+      "readme_linha": 1503,
       "tipo_fonte": "federal"
     },
     {
@@ -5154,7 +5180,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1503,
+      "readme_linha": 1507,
       "tipo_fonte": "privado"
     },
     {
@@ -5178,7 +5204,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1508,
+      "readme_linha": 1512,
       "tipo_fonte": "federal"
     },
     {
@@ -5201,7 +5227,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1512,
+      "readme_linha": 1516,
       "tipo_fonte": "federal"
     },
     {
@@ -5226,7 +5252,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1516,
+      "readme_linha": 1520,
       "tipo_fonte": "federal"
     },
     {
@@ -5252,7 +5278,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1524,
+      "readme_linha": 1528,
       "tipo_fonte": "federal"
     },
     {
@@ -5277,7 +5303,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1530,
+      "readme_linha": 1534,
       "tipo_fonte": "federal"
     },
     {
@@ -5302,7 +5328,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1536,
+      "readme_linha": 1540,
       "tipo_fonte": "federal"
     },
     {
@@ -5327,7 +5353,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1542,
+      "readme_linha": 1546,
       "tipo_fonte": "federal"
     },
     {
@@ -5351,7 +5377,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1549,
+      "readme_linha": 1553,
       "tipo_fonte": "federal"
     },
     {
@@ -5374,7 +5400,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1556,
+      "readme_linha": 1560,
       "tipo_fonte": "federal"
     },
     {
@@ -5401,7 +5427,7 @@
         "outorga",
         "radiofrequencia"
       ],
-      "readme_linha": 1563,
+      "readme_linha": 1567,
       "tipo_fonte": "federal"
     },
     {
@@ -5426,7 +5452,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1570,
+      "readme_linha": 1574,
       "tipo_fonte": "federal"
     },
     {
@@ -5449,7 +5475,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1577,
+      "readme_linha": 1581,
       "tipo_fonte": "federal"
     },
     {
@@ -5473,7 +5499,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1584,
+      "readme_linha": 1588,
       "tipo_fonte": "federal"
     },
     {
@@ -5497,7 +5523,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1591,
+      "readme_linha": 1595,
       "tipo_fonte": "federal"
     },
     {
@@ -5521,7 +5547,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1604,
+      "readme_linha": 1608,
       "tipo_fonte": "federal"
     },
     {
@@ -5546,7 +5572,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1610,
+      "readme_linha": 1614,
       "tipo_fonte": "ong"
     },
     {
@@ -5579,7 +5605,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1616,
+      "readme_linha": 1620,
       "tipo_fonte": "privado"
     },
     {
@@ -5607,7 +5633,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1627,
+      "readme_linha": 1631,
       "tipo_fonte": "ong"
     },
     {
@@ -5678,7 +5704,7 @@
         "erb",
         "operadora"
       ],
-      "readme_linha": 1636,
+      "readme_linha": 1640,
       "tipo_fonte": "privado"
     },
     {
@@ -5702,7 +5728,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1662,
+      "readme_linha": 1666,
       "tipo_fonte": "privado"
     },
     {
@@ -5728,7 +5754,7 @@
         "processo",
         "publicacao_academica"
       ],
-      "readme_linha": 1668,
+      "readme_linha": 1672,
       "tipo_fonte": "federal"
     },
     {
@@ -5752,7 +5778,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1674,
+      "readme_linha": 1678,
       "tipo_fonte": "privado"
     },
     {
@@ -5776,7 +5802,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1678,
+      "readme_linha": 1682,
       "tipo_fonte": "academico"
     },
     {
@@ -5800,7 +5826,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1682,
+      "readme_linha": 1686,
       "tipo_fonte": "academico"
     },
     {
@@ -5824,7 +5850,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1686,
+      "readme_linha": 1690,
       "tipo_fonte": "academico"
     },
     {
@@ -5848,7 +5874,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1690,
+      "readme_linha": 1694,
       "tipo_fonte": "academico"
     },
     {
@@ -5872,7 +5898,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1694,
+      "readme_linha": 1698,
       "tipo_fonte": "federal"
     },
     {
@@ -5896,7 +5922,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1698,
+      "readme_linha": 1702,
       "tipo_fonte": "privado"
     },
     {
@@ -5920,7 +5946,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1702,
+      "readme_linha": 1706,
       "tipo_fonte": "federal"
     },
     {
@@ -5944,7 +5970,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1706,
+      "readme_linha": 1710,
       "tipo_fonte": "ong"
     },
     {
@@ -5969,7 +5995,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1710,
+      "readme_linha": 1714,
       "tipo_fonte": "federal"
     },
     {
@@ -5995,7 +6021,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1714,
+      "readme_linha": 1718,
       "tipo_fonte": "federal"
     },
     {
@@ -6020,7 +6046,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 1718,
+      "readme_linha": 1722,
       "tipo_fonte": "federal"
     },
     {
@@ -6044,7 +6070,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1722,
+      "readme_linha": 1726,
       "tipo_fonte": "federal"
     },
     {
@@ -6068,7 +6094,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1726,
+      "readme_linha": 1730,
       "tipo_fonte": "federal"
     },
     {
@@ -6092,7 +6118,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1730,
+      "readme_linha": 1734,
       "tipo_fonte": "federal"
     },
     {
@@ -6232,7 +6258,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1739,
+      "readme_linha": 1743,
       "tipo_fonte": "privado"
     },
     {
@@ -6263,7 +6289,7 @@
         "area_rural",
         "mapa"
       ],
-      "readme_linha": 1773,
+      "readme_linha": 1777,
       "tipo_fonte": "federal"
     },
     {
@@ -6287,7 +6313,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1780,
+      "readme_linha": 1784,
       "tipo_fonte": "federal"
     },
     {
@@ -6316,7 +6342,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1786,
+      "readme_linha": 1790,
       "tipo_fonte": "federal"
     },
     {
@@ -6340,7 +6366,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1793,
+      "readme_linha": 1797,
       "tipo_fonte": "privado"
     },
     {
@@ -6381,7 +6407,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1797,
+      "readme_linha": 1801,
       "tipo_fonte": "internacional"
     },
     {
@@ -6410,7 +6436,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1809,
+      "readme_linha": 1813,
       "tipo_fonte": "federal"
     },
     {
@@ -6435,7 +6461,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1816,
+      "readme_linha": 1820,
       "tipo_fonte": "federal"
     },
     {
@@ -6459,7 +6485,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1822,
+      "readme_linha": 1826,
       "tipo_fonte": "federal"
     },
     {
@@ -6498,7 +6524,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1826,
+      "readme_linha": 1830,
       "tipo_fonte": "federal"
     },
     {
@@ -6522,7 +6548,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1838,
+      "readme_linha": 1842,
       "tipo_fonte": "federal"
     },
     {
@@ -6546,7 +6572,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1842,
+      "readme_linha": 1846,
       "tipo_fonte": "federal"
     },
     {
@@ -6571,7 +6597,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1852,
+      "readme_linha": 1856,
       "tipo_fonte": "federal"
     },
     {
@@ -6596,7 +6622,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1859,
+      "readme_linha": 1863,
       "tipo_fonte": "federal"
     },
     {
@@ -6623,7 +6649,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1866,
+      "readme_linha": 1870,
       "tipo_fonte": "federal"
     },
     {
@@ -6652,7 +6678,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1873,
+      "readme_linha": 1877,
       "tipo_fonte": "federal"
     },
     {
@@ -6678,7 +6704,7 @@
         "mapa",
         "sancao"
       ],
-      "readme_linha": 1880,
+      "readme_linha": 1884,
       "tipo_fonte": "federal"
     },
     {
@@ -6703,7 +6729,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1887,
+      "readme_linha": 1891,
       "tipo_fonte": "federal"
     },
     {
@@ -6730,7 +6756,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1894,
+      "readme_linha": 1898,
       "tipo_fonte": "federal"
     },
     {
@@ -6756,7 +6782,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1901,
+      "readme_linha": 1905,
       "tipo_fonte": "privado"
     },
     {
@@ -6781,7 +6807,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1908,
+      "readme_linha": 1912,
       "tipo_fonte": "federal"
     },
     {
@@ -6808,7 +6834,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1915,
+      "readme_linha": 1919,
       "tipo_fonte": "federal"
     },
     {
@@ -6833,7 +6859,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1922,
+      "readme_linha": 1926,
       "tipo_fonte": "federal"
     },
     {
@@ -6859,7 +6885,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1929,
+      "readme_linha": 1933,
       "tipo_fonte": "federal"
     },
     {
@@ -6885,7 +6911,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1936,
+      "readme_linha": 1940,
       "tipo_fonte": "federal"
     },
     {
@@ -6910,7 +6936,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1943,
+      "readme_linha": 1947,
       "tipo_fonte": "federal"
     },
     {
@@ -6937,7 +6963,7 @@
         "mapa",
         "processo"
       ],
-      "readme_linha": 1950,
+      "readme_linha": 1954,
       "tipo_fonte": "federal"
     },
     {
@@ -6964,7 +6990,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1957,
+      "readme_linha": 1961,
       "tipo_fonte": "federal"
     },
     {
@@ -6988,7 +7014,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1968,
+      "readme_linha": 1972,
       "tipo_fonte": "federal"
     },
     {
@@ -7012,7 +7038,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1974,
+      "readme_linha": 1978,
       "tipo_fonte": "federal"
     },
     {
@@ -7037,7 +7063,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1978,
+      "readme_linha": 1982,
       "tipo_fonte": "federal"
     },
     {
@@ -7061,7 +7087,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1982,
+      "readme_linha": 1986,
       "tipo_fonte": "federal"
     },
     {
@@ -7085,7 +7111,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1986,
+      "readme_linha": 1990,
       "tipo_fonte": "federal"
     },
     {
@@ -7109,7 +7135,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1990,
+      "readme_linha": 1994,
       "tipo_fonte": "federal"
     },
     {
@@ -7138,7 +7164,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1994,
+      "readme_linha": 1998,
       "tipo_fonte": "federal"
     },
     {
@@ -7163,7 +7189,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1999,
+      "readme_linha": 2003,
       "tipo_fonte": "ong"
     },
     {
@@ -7188,7 +7214,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 2003,
+      "readme_linha": 2007,
       "tipo_fonte": "academico"
     },
     {
@@ -7212,7 +7238,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2007,
+      "readme_linha": 2011,
       "tipo_fonte": "academico"
     },
     {
@@ -7246,7 +7272,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2011,
+      "readme_linha": 2015,
       "tipo_fonte": "federal"
     },
     {
@@ -7284,7 +7310,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2028,
+      "readme_linha": 2032,
       "tipo_fonte": "dork"
     },
     {
@@ -7312,7 +7338,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2041,
+      "readme_linha": 2045,
       "tipo_fonte": "dork"
     },
     {
@@ -7340,7 +7366,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2048,
+      "readme_linha": 2052,
       "tipo_fonte": "dork"
     },
     {
@@ -7373,7 +7399,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2057,
+      "readme_linha": 2061,
       "tipo_fonte": "dork"
     },
     {
@@ -7411,7 +7437,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2068,
+      "readme_linha": 2072,
       "tipo_fonte": "dork"
     },
     {
@@ -7450,7 +7476,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2081,
+      "readme_linha": 2085,
       "tipo_fonte": "dork"
     },
     {
@@ -7489,7 +7515,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2097,
+      "readme_linha": 2101,
       "tipo_fonte": "internacional"
     },
     {
@@ -7523,7 +7549,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2109,
+      "readme_linha": 2113,
       "tipo_fonte": "internacional"
     },
     {
@@ -7551,7 +7577,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2116,
+      "readme_linha": 2120,
       "tipo_fonte": "dork"
     },
     {
@@ -7599,7 +7625,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2123,
+      "readme_linha": 2127,
       "tipo_fonte": "dork"
     },
     {
@@ -7637,7 +7663,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2143,
+      "readme_linha": 2147,
       "tipo_fonte": "dork"
     },
     {
@@ -7676,7 +7702,7 @@
         "dork",
         "video_ao_vivo"
       ],
-      "readme_linha": 2158,
+      "readme_linha": 2162,
       "tipo_fonte": "dork"
     },
     {
@@ -7717,7 +7743,7 @@
         "dork",
         "operadora"
       ],
-      "readme_linha": 2173,
+      "readme_linha": 2177,
       "tipo_fonte": "dork"
     },
     {
@@ -7751,7 +7777,7 @@
         "dork",
         "publicacao_academica"
       ],
-      "readme_linha": 2188,
+      "readme_linha": 2192,
       "tipo_fonte": "dork"
     },
     {
@@ -7784,7 +7810,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2200,
+      "readme_linha": 2204,
       "tipo_fonte": "dork"
     },
     {
@@ -7812,7 +7838,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2212,
+      "readme_linha": 2216,
       "tipo_fonte": "dork"
     },
     {
@@ -7841,7 +7867,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2222,
+      "readme_linha": 2226,
       "tipo_fonte": "internacional"
     },
     {
@@ -7884,7 +7910,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2234,
+      "readme_linha": 2238,
       "tipo_fonte": "dork"
     },
     {
@@ -7909,7 +7935,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2258,
+      "readme_linha": 2262,
       "tipo_fonte": "internacional"
     },
     {
@@ -7944,7 +7970,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2264,
+      "readme_linha": 2268,
       "tipo_fonte": "internacional"
     },
     {
@@ -7974,7 +8000,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2275,
+      "readme_linha": 2279,
       "tipo_fonte": "internacional"
     },
     {
@@ -7999,7 +8025,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2283,
+      "readme_linha": 2287,
       "tipo_fonte": "internacional"
     },
     {
@@ -8025,7 +8051,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2289,
+      "readme_linha": 2293,
       "tipo_fonte": "internacional"
     },
     {
@@ -8051,7 +8077,7 @@
         "estatistica",
         "perfil_social"
       ],
-      "readme_linha": 2295,
+      "readme_linha": 2299,
       "tipo_fonte": "internacional"
     },
     {
@@ -8076,7 +8102,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2301,
+      "readme_linha": 2305,
       "tipo_fonte": "internacional"
     },
     {
@@ -8101,7 +8127,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2307,
+      "readme_linha": 2311,
       "tipo_fonte": "internacional"
     },
     {
@@ -8126,7 +8152,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2311,
+      "readme_linha": 2315,
       "tipo_fonte": "internacional"
     },
     {
@@ -8151,7 +8177,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2315,
+      "readme_linha": 2319,
       "tipo_fonte": "internacional"
     },
     {
@@ -8176,7 +8202,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2319,
+      "readme_linha": 2323,
       "tipo_fonte": "internacional"
     },
     {
@@ -8201,7 +8227,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2323,
+      "readme_linha": 2327,
       "tipo_fonte": "internacional"
     },
     {
@@ -8226,7 +8252,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2327,
+      "readme_linha": 2331,
       "tipo_fonte": "internacional"
     },
     {
@@ -8252,7 +8278,7 @@
         "mandado_prisao",
         "perfil_social"
       ],
-      "readme_linha": 2333,
+      "readme_linha": 2337,
       "tipo_fonte": "privado"
     },
     {
@@ -8282,7 +8308,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2339,
+      "readme_linha": 2343,
       "tipo_fonte": "privado"
     },
     {
@@ -8312,7 +8338,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2346,
+      "readme_linha": 2350,
       "tipo_fonte": "internacional"
     },
     {
@@ -8338,7 +8364,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2352,
+      "readme_linha": 2356,
       "tipo_fonte": "internacional"
     },
     {
@@ -8363,7 +8389,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2359,
+      "readme_linha": 2363,
       "tipo_fonte": "privado"
     },
     {
@@ -8388,7 +8414,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2365,
+      "readme_linha": 2369,
       "tipo_fonte": "internacional"
     },
     {
@@ -8471,7 +8497,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2378,
+      "readme_linha": 2382,
       "tipo_fonte": "privado"
     },
     {
@@ -8534,7 +8560,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2403,
+      "readme_linha": 2407,
       "tipo_fonte": "privado"
     },
     {
@@ -8557,7 +8583,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2430,
+      "readme_linha": 2434,
       "tipo_fonte": "federal"
     },
     {
@@ -8580,7 +8606,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2436,
+      "readme_linha": 2440,
       "tipo_fonte": "privado"
     },
     {
@@ -8603,7 +8629,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2442,
+      "readme_linha": 2446,
       "tipo_fonte": "federal"
     },
     {
@@ -8626,7 +8652,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2448,
+      "readme_linha": 2452,
       "tipo_fonte": "privado"
     },
     {
@@ -8649,7 +8675,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2454,
+      "readme_linha": 2458,
       "tipo_fonte": "federal"
     },
     {
@@ -8672,7 +8698,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2460,
+      "readme_linha": 2464,
       "tipo_fonte": "federal"
     },
     {
@@ -8695,7 +8721,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2466,
+      "readme_linha": 2470,
       "tipo_fonte": "federal"
     },
     {
@@ -8719,7 +8745,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2472,
+      "readme_linha": 2476,
       "tipo_fonte": "federal"
     },
     {
@@ -8748,7 +8774,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 2476,
+      "readme_linha": 2480,
       "tipo_fonte": "federal"
     },
     {
@@ -8771,7 +8797,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2483,
+      "readme_linha": 2487,
       "tipo_fonte": "federal"
     },
     {
@@ -8794,7 +8820,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2487,
+      "readme_linha": 2491,
       "tipo_fonte": "federal"
     },
     {
@@ -8818,7 +8844,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2493,
+      "readme_linha": 2497,
       "tipo_fonte": "federal"
     },
     {
@@ -8841,7 +8867,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2499,
+      "readme_linha": 2503,
       "tipo_fonte": "estadual"
     },
     {
@@ -8865,7 +8891,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2505,
+      "readme_linha": 2509,
       "tipo_fonte": "estadual"
     },
     {
@@ -8889,7 +8915,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2511,
+      "readme_linha": 2515,
       "tipo_fonte": "federal"
     },
     {
@@ -8912,7 +8938,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2517,
+      "readme_linha": 2521,
       "tipo_fonte": "federal"
     },
     {
@@ -8935,7 +8961,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2523,
+      "readme_linha": 2527,
       "tipo_fonte": "estadual"
     },
     {
@@ -8959,7 +8985,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2529,
+      "readme_linha": 2533,
       "tipo_fonte": "federal"
     },
     {
@@ -8982,7 +9008,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2535,
+      "readme_linha": 2539,
       "tipo_fonte": "estadual"
     },
     {
@@ -9005,7 +9031,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2541,
+      "readme_linha": 2545,
       "tipo_fonte": "estadual"
     },
     {
@@ -9028,7 +9054,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2547,
+      "readme_linha": 2551,
       "tipo_fonte": "federal"
     },
     {
@@ -9051,7 +9077,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2553,
+      "readme_linha": 2557,
       "tipo_fonte": "estadual"
     },
     {
@@ -9074,7 +9100,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2559,
+      "readme_linha": 2563,
       "tipo_fonte": "estadual"
     },
     {
@@ -9097,7 +9123,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2563,
+      "readme_linha": 2567,
       "tipo_fonte": "federal"
     },
     {
@@ -9120,7 +9146,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2569,
+      "readme_linha": 2573,
       "tipo_fonte": "federal"
     },
     {
@@ -9143,7 +9169,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2575,
+      "readme_linha": 2579,
       "tipo_fonte": "estadual"
     },
     {
@@ -9166,7 +9192,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2581,
+      "readme_linha": 2585,
       "tipo_fonte": "federal"
     },
     {
@@ -9194,7 +9220,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2587,
+      "readme_linha": 2591,
       "tipo_fonte": "federal"
     },
     {
@@ -9219,7 +9245,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2594,
+      "readme_linha": 2598,
       "tipo_fonte": "estadual"
     },
     {
@@ -9242,7 +9268,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2598,
+      "readme_linha": 2602,
       "tipo_fonte": "federal"
     },
     {
@@ -9266,7 +9292,7 @@
         "dataset",
         "diario_oficial"
       ],
-      "readme_linha": 2602,
+      "readme_linha": 2606,
       "tipo_fonte": "ong"
     },
     {
@@ -9289,7 +9315,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2608,
+      "readme_linha": 2612,
       "tipo_fonte": "ong"
     },
     {
@@ -9312,7 +9338,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2612,
+      "readme_linha": 2616,
       "tipo_fonte": "federal"
     },
     {
@@ -9335,7 +9361,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2616,
+      "readme_linha": 2620,
       "tipo_fonte": "federal"
     },
     {
@@ -9358,7 +9384,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2620,
+      "readme_linha": 2624,
       "tipo_fonte": "privado"
     },
     {
@@ -9381,7 +9407,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2624,
+      "readme_linha": 2628,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9404,7 +9430,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2628,
+      "readme_linha": 2632,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9428,7 +9454,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2632,
+      "readme_linha": 2636,
       "tipo_fonte": "federal"
     },
     {
@@ -9451,7 +9477,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2636,
+      "readme_linha": 2640,
       "tipo_fonte": "federal"
     },
     {
@@ -9475,7 +9501,7 @@
         "dataset",
         "endereco"
       ],
-      "readme_linha": 2640,
+      "readme_linha": 2644,
       "tipo_fonte": "privado"
     },
     {
@@ -9500,7 +9526,7 @@
         "beneficio",
         "remuneracao"
       ],
-      "readme_linha": 2650,
+      "readme_linha": 2654,
       "tipo_fonte": "ong"
     },
     {
@@ -9524,7 +9550,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2658,
+      "readme_linha": 2662,
       "tipo_fonte": "estadual"
     },
     {
@@ -9548,7 +9574,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2662,
+      "readme_linha": 2666,
       "tipo_fonte": "estadual"
     },
     {
@@ -9647,7 +9673,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2668,
+      "readme_linha": 2672,
       "tipo_fonte": "privado"
     },
     {
@@ -9706,7 +9732,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2691,
+      "readme_linha": 2695,
       "tipo_fonte": "ong"
     },
     {
@@ -9735,7 +9761,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2706,
+      "readme_linha": 2710,
       "tipo_fonte": "privado"
     },
     {
@@ -9759,7 +9785,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2713,
+      "readme_linha": 2717,
       "tipo_fonte": "privado"
     },
     {
@@ -9783,7 +9809,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2719,
+      "readme_linha": 2723,
       "tipo_fonte": "federal"
     },
     {
@@ -9807,7 +9833,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2725,
+      "readme_linha": 2729,
       "tipo_fonte": "federal"
     },
     {
@@ -9832,7 +9858,7 @@
         "veiculo",
         "video_ao_vivo"
       ],
-      "readme_linha": 2731,
+      "readme_linha": 2735,
       "tipo_fonte": "internacional"
     },
     {
@@ -9856,7 +9882,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2735,
+      "readme_linha": 2739,
       "tipo_fonte": "internacional"
     },
     {
@@ -9881,7 +9907,7 @@
         "multa",
         "veiculo"
       ],
-      "readme_linha": 2739,
+      "readme_linha": 2743,
       "tipo_fonte": "federal"
     },
     {
@@ -9907,7 +9933,7 @@
         "dados_cadastrais",
         "veiculo"
       ],
-      "readme_linha": 2743,
+      "readme_linha": 2747,
       "tipo_fonte": "federal"
     },
     {
@@ -9931,7 +9957,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2747,
+      "readme_linha": 2751,
       "tipo_fonte": "federal"
     },
     {
@@ -9955,7 +9981,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2751,
+      "readme_linha": 2755,
       "tipo_fonte": "privado"
     },
     {
@@ -9979,7 +10005,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2757,
+      "readme_linha": 2761,
       "tipo_fonte": "federal"
     },
     {
@@ -10003,7 +10029,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2763,
+      "readme_linha": 2767,
       "tipo_fonte": "federal"
     },
     {
@@ -10028,7 +10054,7 @@
         "dataset",
         "veiculo"
       ],
-      "readme_linha": 2769,
+      "readme_linha": 2773,
       "tipo_fonte": "federal"
     },
     {
@@ -10057,7 +10083,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2775,
+      "readme_linha": 2779,
       "tipo_fonte": "estadual"
     },
     {
@@ -10086,7 +10112,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2782,
+      "readme_linha": 2786,
       "tipo_fonte": "estadual"
     },
     {
@@ -10255,7 +10281,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2789,
+      "readme_linha": 2793,
       "tipo_fonte": "estadual"
     },
     {
@@ -10279,7 +10305,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 2859,
+      "readme_linha": 2863,
       "tipo_fonte": "privado"
     },
     {
@@ -10302,7 +10328,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2865,
+      "readme_linha": 2869,
       "tipo_fonte": "privado"
     },
     {
@@ -10345,7 +10371,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2871,
+      "readme_linha": 2875,
       "tipo_fonte": "estadual"
     },
     {
@@ -10368,7 +10394,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2891,
+      "readme_linha": 2895,
       "tipo_fonte": "privado"
     },
     {
@@ -10391,7 +10417,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2897,
+      "readme_linha": 2901,
       "tipo_fonte": "privado"
     },
     {
@@ -10414,7 +10440,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2903,
+      "readme_linha": 2907,
       "tipo_fonte": "privado"
     },
     {
@@ -10439,7 +10465,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 2915,
+      "readme_linha": 2919,
       "tipo_fonte": "federal"
     },
     {
@@ -10465,7 +10491,7 @@
         "estatistica",
         "multa"
       ],
-      "readme_linha": 2919,
+      "readme_linha": 2923,
       "tipo_fonte": "privado"
     },
     {
@@ -10488,7 +10514,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2923,
+      "readme_linha": 2927,
       "tipo_fonte": "federal"
     },
     {
@@ -10511,7 +10537,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2927,
+      "readme_linha": 2931,
       "tipo_fonte": "federal"
     },
     {
@@ -10534,7 +10560,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2931,
+      "readme_linha": 2935,
       "tipo_fonte": "federal"
     },
     {
@@ -10557,7 +10583,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2935,
+      "readme_linha": 2939,
       "tipo_fonte": "federal"
     },
     {
@@ -10585,7 +10611,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2939,
+      "readme_linha": 2943,
       "tipo_fonte": "internacional"
     },
     {
@@ -10608,7 +10634,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2944,
+      "readme_linha": 2948,
       "tipo_fonte": "privado"
     },
     {
@@ -10631,7 +10657,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2948,
+      "readme_linha": 2952,
       "tipo_fonte": "privado"
     },
     {
@@ -10654,7 +10680,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2952,
+      "readme_linha": 2956,
       "tipo_fonte": "privado"
     },
     {
@@ -10677,7 +10703,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2962,
+      "readme_linha": 2966,
       "tipo_fonte": "federal"
     },
     {
@@ -10703,7 +10729,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 2968,
+      "readme_linha": 2972,
       "tipo_fonte": "privado"
     },
     {
@@ -10726,7 +10752,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2974,
+      "readme_linha": 2978,
       "tipo_fonte": "federal"
     },
     {
@@ -10751,7 +10777,7 @@
         "dados_cadastrais",
         "multa"
       ],
-      "readme_linha": 2980,
+      "readme_linha": 2984,
       "tipo_fonte": "federal"
     },
     {
@@ -10829,7 +10855,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2984,
+      "readme_linha": 2988,
       "tipo_fonte": "federal"
     },
     {
@@ -10852,7 +10878,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3012,
+      "readme_linha": 3016,
       "tipo_fonte": "estadual"
     },
     {
@@ -10875,7 +10901,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3018,
+      "readme_linha": 3022,
       "tipo_fonte": "privado"
     },
     {
@@ -10898,7 +10924,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3022,
+      "readme_linha": 3026,
       "tipo_fonte": "estadual"
     },
     {
@@ -10921,7 +10947,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3026,
+      "readme_linha": 3030,
       "tipo_fonte": "internacional"
     },
     {
@@ -10964,7 +10990,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3030,
+      "readme_linha": 3034,
       "tipo_fonte": "privado"
     },
     {
@@ -11012,7 +11038,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3045,
+      "readme_linha": 3049,
       "tipo_fonte": "privado"
     },
     {
@@ -11115,7 +11141,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3059,
+      "readme_linha": 3063,
       "tipo_fonte": "privado"
     },
     {
@@ -11138,7 +11164,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3100,
+      "readme_linha": 3104,
       "tipo_fonte": "privado"
     },
     {
@@ -11186,7 +11212,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3104,
+      "readme_linha": 3108,
       "tipo_fonte": "estadual"
     },
     {
@@ -11509,7 +11535,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3118,
+      "readme_linha": 3122,
       "tipo_fonte": "privado"
     },
     {
@@ -11532,7 +11558,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3193,
+      "readme_linha": 3197,
       "tipo_fonte": "privado"
     },
     {
@@ -11555,7 +11581,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3197,
+      "readme_linha": 3201,
       "tipo_fonte": "privado"
     },
     {
@@ -11578,7 +11604,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3201,
+      "readme_linha": 3205,
       "tipo_fonte": "estadual"
     },
     {
@@ -11601,7 +11627,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3205,
+      "readme_linha": 3209,
       "tipo_fonte": "federal"
     },
     {
@@ -11630,7 +11656,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3209,
+      "readme_linha": 3213,
       "tipo_fonte": "internacional"
     },
     {
@@ -11654,7 +11680,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3214,
+      "readme_linha": 3218,
       "tipo_fonte": "internacional"
     },
     {
@@ -11678,7 +11704,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3218,
+      "readme_linha": 3222,
       "tipo_fonte": "internacional"
     },
     {
@@ -11702,7 +11728,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3222,
+      "readme_linha": 3226,
       "tipo_fonte": "internacional"
     },
     {
@@ -11726,7 +11752,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3226,
+      "readme_linha": 3230,
       "tipo_fonte": "internacional"
     },
     {
@@ -11750,7 +11776,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3230,
+      "readme_linha": 3234,
       "tipo_fonte": "internacional"
     },
     {
@@ -11774,7 +11800,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3234,
+      "readme_linha": 3238,
       "tipo_fonte": "internacional"
     },
     {
@@ -11798,7 +11824,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3238,
+      "readme_linha": 3242,
       "tipo_fonte": "internacional"
     },
     {
@@ -11821,7 +11847,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3242,
+      "readme_linha": 3246,
       "tipo_fonte": "estadual"
     },
     {
@@ -11895,7 +11921,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3252,
+      "readme_linha": 3256,
       "tipo_fonte": "ministerio_publico"
     },
     {
@@ -11955,7 +11981,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3293,
+      "readme_linha": 3297,
       "tipo_fonte": "defensoria"
     },
     {
@@ -11989,7 +12015,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3325,
+      "readme_linha": 3329,
       "tipo_fonte": "ong"
     },
     {
@@ -12018,7 +12044,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3342,
+      "readme_linha": 3346,
       "tipo_fonte": "estadual"
     },
     {
@@ -12047,7 +12073,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3362,
+      "readme_linha": 3366,
       "tipo_fonte": "privado"
     },
     {
@@ -12096,7 +12122,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3367,
+      "readme_linha": 3371,
       "tipo_fonte": "estadual"
     },
     {
@@ -12121,7 +12147,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 3386,
+      "readme_linha": 3390,
       "tipo_fonte": "federal"
     },
     {
@@ -12146,7 +12172,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3390,
+      "readme_linha": 3394,
       "tipo_fonte": "ong"
     },
     {
@@ -12171,7 +12197,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3394,
+      "readme_linha": 3398,
       "tipo_fonte": "federal"
     },
     {
@@ -12194,7 +12220,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3398,
+      "readme_linha": 3402,
       "tipo_fonte": "privado"
     },
     {
@@ -12219,7 +12245,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3402,
+      "readme_linha": 3406,
       "tipo_fonte": "federal"
     },
     {
@@ -12242,7 +12268,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3406,
+      "readme_linha": 3410,
       "tipo_fonte": "federal"
     },
     {
@@ -12263,7 +12289,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3410,
+      "readme_linha": 3414,
       "tipo_fonte": "federal"
     },
     {
@@ -12291,7 +12317,7 @@
         "mandado_prisao",
         "veiculo"
       ],
-      "readme_linha": 3414,
+      "readme_linha": 3418,
       "tipo_fonte": "federal"
     },
     {
@@ -12332,7 +12358,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3423,
+      "readme_linha": 3427,
       "tipo_fonte": "privado"
     },
     {
@@ -12363,7 +12389,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3442,
+      "readme_linha": 3446,
       "tipo_fonte": "privado"
     },
     {
@@ -12392,7 +12418,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3456,
+      "readme_linha": 3460,
       "tipo_fonte": "privado"
     },
     {
@@ -12420,7 +12446,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3483,
+      "readme_linha": 3487,
       "tipo_fonte": "privado"
     },
     {
@@ -12450,7 +12476,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3505,
+      "readme_linha": 3509,
       "tipo_fonte": "privado"
     },
     {
@@ -12477,7 +12503,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3529,
+      "readme_linha": 3533,
       "tipo_fonte": "federal"
     },
     {
@@ -12504,7 +12530,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3552,
+      "readme_linha": 3556,
       "tipo_fonte": "federal"
     },
     {
@@ -12534,7 +12560,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3556,
+      "readme_linha": 3560,
       "tipo_fonte": "ong"
     },
     {
@@ -12560,7 +12586,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3579,
+      "readme_linha": 3583,
       "tipo_fonte": "federal"
     },
     {
@@ -12584,7 +12610,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3583,
+      "readme_linha": 3587,
       "tipo_fonte": "federal"
     },
     {
@@ -12607,7 +12633,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3593,
+      "readme_linha": 3597,
       "tipo_fonte": "federal"
     },
     {
@@ -12630,7 +12656,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3597,
+      "readme_linha": 3601,
       "tipo_fonte": "federal"
     },
     {
@@ -12659,7 +12685,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3601,
+      "readme_linha": 3605,
       "tipo_fonte": "federal"
     },
     {
@@ -12687,7 +12713,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3606,
+      "readme_linha": 3610,
       "tipo_fonte": "federal"
     },
     {
@@ -12710,7 +12736,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3611,
+      "readme_linha": 3615,
       "tipo_fonte": "federal"
     },
     {
@@ -12733,7 +12759,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3615,
+      "readme_linha": 3619,
       "tipo_fonte": "federal"
     },
     {
@@ -12762,7 +12788,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3625,
+      "readme_linha": 3629,
       "tipo_fonte": "federal"
     },
     {
@@ -12786,7 +12812,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3630,
+      "readme_linha": 3634,
       "tipo_fonte": "federal"
     },
     {
@@ -12810,7 +12836,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3634,
+      "readme_linha": 3638,
       "tipo_fonte": "federal"
     },
     {
@@ -12840,7 +12866,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3638,
+      "readme_linha": 3642,
       "tipo_fonte": "ong"
     },
     {
@@ -12870,7 +12896,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3643,
+      "readme_linha": 3647,
       "tipo_fonte": "federal"
     },
     {
@@ -12895,7 +12921,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3648,
+      "readme_linha": 3652,
       "tipo_fonte": "federal"
     },
     {
@@ -12919,7 +12945,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3652,
+      "readme_linha": 3656,
       "tipo_fonte": "federal"
     },
     {
@@ -12943,7 +12969,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3656,
+      "readme_linha": 3660,
       "tipo_fonte": "federal"
     },
     {
@@ -12998,7 +13024,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3666,
+      "readme_linha": 3670,
       "tipo_fonte": "ong"
     },
     {
@@ -13122,7 +13148,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3705,
+      "readme_linha": 3709,
       "tipo_fonte": "estadual"
     },
     {
@@ -13242,7 +13268,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3746,
+      "readme_linha": 3750,
       "tipo_fonte": "ong"
     },
     {
@@ -13276,7 +13302,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3775,
+      "readme_linha": 3779,
       "tipo_fonte": "estadual"
     },
     {
@@ -13302,7 +13328,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3787,
+      "readme_linha": 3791,
       "tipo_fonte": "estadual"
     },
     {
@@ -13328,7 +13354,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3791,
+      "readme_linha": 3795,
       "tipo_fonte": "estadual"
     },
     {
@@ -13352,7 +13378,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3795,
+      "readme_linha": 3799,
       "tipo_fonte": "estadual"
     },
     {
@@ -13375,7 +13401,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3805,
+      "readme_linha": 3809,
       "tipo_fonte": "ong"
     },
     {
@@ -13398,7 +13424,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3809,
+      "readme_linha": 3813,
       "tipo_fonte": "federal"
     },
     {
@@ -13422,7 +13448,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3813,
+      "readme_linha": 3817,
       "tipo_fonte": "ong"
     },
     {
@@ -13445,7 +13471,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3817,
+      "readme_linha": 3821,
       "tipo_fonte": "federal"
     },
     {
@@ -13468,7 +13494,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3821,
+      "readme_linha": 3825,
       "tipo_fonte": "federal"
     },
     {
@@ -13496,7 +13522,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3825,
+      "readme_linha": 3829,
       "tipo_fonte": "privado"
     },
     {
@@ -13584,7 +13610,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3837,
+      "readme_linha": 3841,
       "tipo_fonte": "privado"
     },
     {
@@ -13635,7 +13661,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3859,
+      "readme_linha": 3863,
       "tipo_fonte": "privado"
     },
     {
@@ -13658,7 +13684,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3872,
+      "readme_linha": 3876,
       "tipo_fonte": "estadual"
     },
     {
@@ -13691,7 +13717,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3878,
+      "readme_linha": 3882,
       "tipo_fonte": "privado"
     },
     {
@@ -13715,7 +13741,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3889,
+      "readme_linha": 3893,
       "tipo_fonte": "privado"
     },
     {
@@ -13738,7 +13764,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3893,
+      "readme_linha": 3897,
       "tipo_fonte": "federal"
     },
     {
@@ -13772,7 +13798,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3899,
+      "readme_linha": 3903,
       "tipo_fonte": "privado"
     },
     {
@@ -13858,7 +13884,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3909,
+      "readme_linha": 3913,
       "tipo_fonte": "privado"
     },
     {
@@ -13882,7 +13908,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3958,
+      "readme_linha": 3962,
       "tipo_fonte": "estadual"
     },
     {
@@ -13916,9 +13942,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4121,
+      "readme_linha": 4125,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 441
+  "total": 442
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -2077,6 +2077,32 @@
       "tipo_fonte": "federal"
     },
     {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "classificacao": "override",
+      "descricao": "Pesquisa pública de corretores de seguros habilitados pela Superintendência de Seguros Privados, pessoa natural ou jurídica. Permite filtrar por tipo de pessoa, CNPJ (pessoa jurídica), nome, produto e situação do registro (ativo ou cancelado).",
+      "id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/susep-consulta-de-corretores",
+      "input": [
+        "cnpj",
+        "nome"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://www2.susep.gov.br/safe/Corretores/pesquisa"
+        }
+      ],
+      "nome": "SUSEP - Consulta de Corretores",
+      "observacao": "Sem cadastro. O campo de documento só aceita CNPJ (pessoa jurídica); corretores pessoa natural são localizados pelo nome.",
+      "output": [
+        "dados_cadastrais",
+        "situacao_cadastral"
+      ],
+      "readme_linha": 732,
+      "tipo_fonte": "federal"
+    },
+    {
       "categoria": "Estatísticas Segurança Pública",
       "categoria_id": "estatisticas-seguranca-publica",
       "classificacao": "heuristica",
@@ -2101,7 +2127,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 741,
+      "readme_linha": 745,
       "tipo_fonte": "federal"
     },
     {
@@ -2209,7 +2235,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 753,
+      "readme_linha": 757,
       "tipo_fonte": "estadual"
     },
     {
@@ -2237,7 +2263,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 814,
+      "readme_linha": 818,
       "tipo_fonte": "ong"
     },
     {
@@ -2260,7 +2286,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 819,
+      "readme_linha": 823,
       "tipo_fonte": "privado"
     },
     {
@@ -2283,7 +2309,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 823,
+      "readme_linha": 827,
       "tipo_fonte": "ong"
     },
     {
@@ -2307,7 +2333,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 827,
+      "readme_linha": 831,
       "tipo_fonte": "privado"
     },
     {
@@ -2332,7 +2358,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 837,
+      "readme_linha": 841,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2357,7 +2383,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 841,
+      "readme_linha": 845,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2382,7 +2408,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 845,
+      "readme_linha": 849,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2407,7 +2433,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 849,
+      "readme_linha": 853,
       "tipo_fonte": "legislativo"
     },
     {
@@ -2432,7 +2458,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 853,
+      "readme_linha": 857,
       "tipo_fonte": "legislativo"
     },
     {
@@ -2458,7 +2484,7 @@
         "dados_cadastrais",
         "dataset"
       ],
-      "readme_linha": 857,
+      "readme_linha": 861,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2484,7 +2510,7 @@
         "dados_cadastrais",
         "dataset"
       ],
-      "readme_linha": 861,
+      "readme_linha": 865,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2510,7 +2536,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 865,
+      "readme_linha": 869,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2535,7 +2561,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 869,
+      "readme_linha": 873,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2561,7 +2587,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 873,
+      "readme_linha": 877,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2587,7 +2613,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 877,
+      "readme_linha": 881,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2615,7 +2641,7 @@
         "debito",
         "multa"
       ],
-      "readme_linha": 881,
+      "readme_linha": 885,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2640,7 +2666,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 885,
+      "readme_linha": 889,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2666,7 +2692,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 889,
+      "readme_linha": 893,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2691,7 +2717,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 893,
+      "readme_linha": 897,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2719,7 +2745,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 897,
+      "readme_linha": 901,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2744,7 +2770,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 901,
+      "readme_linha": 905,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2769,7 +2795,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 906,
+      "readme_linha": 910,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2795,7 +2821,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 910,
+      "readme_linha": 914,
       "tipo_fonte": "ong"
     },
     {
@@ -2819,7 +2845,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 920,
+      "readme_linha": 924,
       "tipo_fonte": "ong"
     },
     {
@@ -2843,7 +2869,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 924,
+      "readme_linha": 928,
       "tipo_fonte": "estadual"
     },
     {
@@ -2867,7 +2893,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 928,
+      "readme_linha": 932,
       "tipo_fonte": "municipal"
     },
     {
@@ -2891,7 +2917,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 932,
+      "readme_linha": 936,
       "tipo_fonte": "federal"
     },
     {
@@ -2915,7 +2941,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 936,
+      "readme_linha": 940,
       "tipo_fonte": "federal"
     },
     {
@@ -2941,7 +2967,7 @@
         "certidao",
         "imovel"
       ],
-      "readme_linha": 940,
+      "readme_linha": 944,
       "tipo_fonte": "ong"
     },
     {
@@ -2965,7 +2991,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 950,
+      "readme_linha": 954,
       "tipo_fonte": "federal"
     },
     {
@@ -2989,7 +3015,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 954,
+      "readme_linha": 958,
       "tipo_fonte": "federal"
     },
     {
@@ -3013,7 +3039,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 958,
+      "readme_linha": 962,
       "tipo_fonte": "federal"
     },
     {
@@ -3037,7 +3063,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 962,
+      "readme_linha": 966,
       "tipo_fonte": "estadual"
     },
     {
@@ -3062,7 +3088,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 966,
+      "readme_linha": 970,
       "tipo_fonte": "ong"
     },
     {
@@ -3087,7 +3113,7 @@
         "estatistica",
         "licenca_ambiental"
       ],
-      "readme_linha": 970,
+      "readme_linha": 974,
       "tipo_fonte": "ong"
     },
     {
@@ -3112,7 +3138,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 974,
+      "readme_linha": 978,
       "tipo_fonte": "ong"
     },
     {
@@ -3135,7 +3161,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 984,
+      "readme_linha": 988,
       "tipo_fonte": "federal"
     },
     {
@@ -3158,7 +3184,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 988,
+      "readme_linha": 992,
       "tipo_fonte": "federal"
     },
     {
@@ -3181,7 +3207,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 992,
+      "readme_linha": 996,
       "tipo_fonte": "federal"
     },
     {
@@ -3204,7 +3230,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 996,
+      "readme_linha": 1000,
       "tipo_fonte": "federal"
     },
     {
@@ -3228,7 +3254,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1006,
+      "readme_linha": 1010,
       "tipo_fonte": "federal"
     },
     {
@@ -3252,7 +3278,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1010,
+      "readme_linha": 1014,
       "tipo_fonte": "federal"
     },
     {
@@ -3276,7 +3302,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1014,
+      "readme_linha": 1018,
       "tipo_fonte": "federal"
     },
     {
@@ -3302,7 +3328,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1024,
+      "readme_linha": 1028,
       "tipo_fonte": "federal"
     },
     {
@@ -3328,7 +3354,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1028,
+      "readme_linha": 1032,
       "tipo_fonte": "federal"
     },
     {
@@ -3355,7 +3381,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1032,
+      "readme_linha": 1036,
       "tipo_fonte": "federal"
     },
     {
@@ -3382,7 +3408,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1036,
+      "readme_linha": 1040,
       "tipo_fonte": "federal"
     },
     {
@@ -3409,7 +3435,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1040,
+      "readme_linha": 1044,
       "tipo_fonte": "federal"
     },
     {
@@ -3435,7 +3461,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1044,
+      "readme_linha": 1048,
       "tipo_fonte": "federal"
     },
     {
@@ -3461,7 +3487,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1048,
+      "readme_linha": 1052,
       "tipo_fonte": "federal"
     },
     {
@@ -3489,7 +3515,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1052,
+      "readme_linha": 1056,
       "tipo_fonte": "federal"
     },
     {
@@ -3520,7 +3546,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1056,
+      "readme_linha": 1060,
       "tipo_fonte": "federal"
     },
     {
@@ -3546,7 +3572,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1097,
+      "readme_linha": 1101,
       "tipo_fonte": "federal"
     },
     {
@@ -3572,7 +3598,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1101,
+      "readme_linha": 1105,
       "tipo_fonte": "federal"
     },
     {
@@ -3598,7 +3624,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1105,
+      "readme_linha": 1109,
       "tipo_fonte": "federal"
     },
     {
@@ -3624,7 +3650,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1109,
+      "readme_linha": 1113,
       "tipo_fonte": "federal"
     },
     {
@@ -3650,7 +3676,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1113,
+      "readme_linha": 1117,
       "tipo_fonte": "federal"
     },
     {
@@ -3676,7 +3702,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1117,
+      "readme_linha": 1121,
       "tipo_fonte": "federal"
     },
     {
@@ -3702,7 +3728,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1121,
+      "readme_linha": 1125,
       "tipo_fonte": "federal"
     },
     {
@@ -3729,7 +3755,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1125,
+      "readme_linha": 1129,
       "tipo_fonte": "federal"
     },
     {
@@ -3755,7 +3781,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1129,
+      "readme_linha": 1133,
       "tipo_fonte": "estadual"
     },
     {
@@ -3782,7 +3808,7 @@
         "remuneracao",
         "sancao"
       ],
-      "readme_linha": 1133,
+      "readme_linha": 1137,
       "tipo_fonte": "estadual"
     },
     {
@@ -3808,7 +3834,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1137,
+      "readme_linha": 1141,
       "tipo_fonte": "federal"
     },
     {
@@ -3879,7 +3905,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1141,
+      "readme_linha": 1145,
       "tipo_fonte": "estadual"
     },
     {
@@ -3905,7 +3931,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1185,
+      "readme_linha": 1189,
       "tipo_fonte": "federal"
     },
     {
@@ -4071,7 +4097,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1189,
+      "readme_linha": 1193,
       "tipo_fonte": "estadual"
     },
     {
@@ -4095,7 +4121,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1258,
+      "readme_linha": 1262,
       "tipo_fonte": "federal"
     },
     {
@@ -4119,7 +4145,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1262,
+      "readme_linha": 1266,
       "tipo_fonte": "federal"
     },
     {
@@ -4143,7 +4169,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1266,
+      "readme_linha": 1270,
       "tipo_fonte": "ong"
     },
     {
@@ -4297,7 +4323,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1270,
+      "readme_linha": 1274,
       "tipo_fonte": "estadual"
     },
     {
@@ -4323,7 +4349,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 1335,
+      "readme_linha": 1339,
       "tipo_fonte": "federal"
     },
     {
@@ -4347,7 +4373,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1339,
+      "readme_linha": 1343,
       "tipo_fonte": "federal"
     },
     {
@@ -4371,7 +4397,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1343,
+      "readme_linha": 1347,
       "tipo_fonte": "federal"
     },
     {
@@ -4395,7 +4421,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1347,
+      "readme_linha": 1351,
       "tipo_fonte": "federal"
     },
     {
@@ -4419,7 +4445,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1351,
+      "readme_linha": 1355,
       "tipo_fonte": "federal"
     },
     {
@@ -4443,7 +4469,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1355,
+      "readme_linha": 1359,
       "tipo_fonte": "federal"
     },
     {
@@ -4467,7 +4493,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1359,
+      "readme_linha": 1363,
       "tipo_fonte": "federal"
     },
     {
@@ -4491,7 +4517,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1363,
+      "readme_linha": 1367,
       "tipo_fonte": "federal"
     },
     {
@@ -4515,7 +4541,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1367,
+      "readme_linha": 1371,
       "tipo_fonte": "federal"
     },
     {
@@ -4539,7 +4565,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1371,
+      "readme_linha": 1375,
       "tipo_fonte": "federal"
     },
     {
@@ -4573,7 +4599,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1380,
+      "readme_linha": 1384,
       "tipo_fonte": "privado"
     },
     {
@@ -4601,7 +4627,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1393,
+      "readme_linha": 1397,
       "tipo_fonte": "privado"
     },
     {
@@ -4639,7 +4665,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1398,
+      "readme_linha": 1402,
       "tipo_fonte": "privado"
     },
     {
@@ -4663,7 +4689,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1410,
+      "readme_linha": 1414,
       "tipo_fonte": "privado"
     },
     {
@@ -4727,7 +4753,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1416,
+      "readme_linha": 1420,
       "tipo_fonte": "ong"
     },
     {
@@ -4752,7 +4778,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1434,
+      "readme_linha": 1438,
       "tipo_fonte": "federal"
     },
     {
@@ -4777,7 +4803,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1438,
+      "readme_linha": 1442,
       "tipo_fonte": "federal"
     },
     {
@@ -4801,7 +4827,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1442,
+      "readme_linha": 1446,
       "tipo_fonte": "federal"
     },
     {
@@ -4824,7 +4850,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1446,
+      "readme_linha": 1450,
       "tipo_fonte": "federal"
     },
     {
@@ -4847,7 +4873,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1450,
+      "readme_linha": 1454,
       "tipo_fonte": "federal"
     },
     {
@@ -4876,7 +4902,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1454,
+      "readme_linha": 1458,
       "tipo_fonte": "privado"
     },
     {
@@ -4900,7 +4926,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1459,
+      "readme_linha": 1463,
       "tipo_fonte": "federal"
     },
     {
@@ -4923,7 +4949,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1463,
+      "readme_linha": 1467,
       "tipo_fonte": "federal"
     },
     {
@@ -4948,7 +4974,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1467,
+      "readme_linha": 1471,
       "tipo_fonte": "federal"
     },
     {
@@ -4974,7 +5000,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1475,
+      "readme_linha": 1479,
       "tipo_fonte": "federal"
     },
     {
@@ -4999,7 +5025,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1481,
+      "readme_linha": 1485,
       "tipo_fonte": "federal"
     },
     {
@@ -5024,7 +5050,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1487,
+      "readme_linha": 1491,
       "tipo_fonte": "federal"
     },
     {
@@ -5049,7 +5075,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1493,
+      "readme_linha": 1497,
       "tipo_fonte": "federal"
     },
     {
@@ -5073,7 +5099,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1500,
+      "readme_linha": 1504,
       "tipo_fonte": "federal"
     },
     {
@@ -5096,7 +5122,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1507,
+      "readme_linha": 1511,
       "tipo_fonte": "federal"
     },
     {
@@ -5123,7 +5149,7 @@
         "outorga",
         "radiofrequencia"
       ],
-      "readme_linha": 1514,
+      "readme_linha": 1518,
       "tipo_fonte": "federal"
     },
     {
@@ -5148,7 +5174,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1521,
+      "readme_linha": 1525,
       "tipo_fonte": "federal"
     },
     {
@@ -5171,7 +5197,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1528,
+      "readme_linha": 1532,
       "tipo_fonte": "federal"
     },
     {
@@ -5195,7 +5221,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1535,
+      "readme_linha": 1539,
       "tipo_fonte": "federal"
     },
     {
@@ -5219,7 +5245,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1542,
+      "readme_linha": 1546,
       "tipo_fonte": "federal"
     },
     {
@@ -5243,7 +5269,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1555,
+      "readme_linha": 1559,
       "tipo_fonte": "federal"
     },
     {
@@ -5268,7 +5294,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1561,
+      "readme_linha": 1565,
       "tipo_fonte": "ong"
     },
     {
@@ -5301,7 +5327,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1567,
+      "readme_linha": 1571,
       "tipo_fonte": "privado"
     },
     {
@@ -5329,7 +5355,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1578,
+      "readme_linha": 1582,
       "tipo_fonte": "ong"
     },
     {
@@ -5400,7 +5426,7 @@
         "erb",
         "operadora"
       ],
-      "readme_linha": 1587,
+      "readme_linha": 1591,
       "tipo_fonte": "privado"
     },
     {
@@ -5424,7 +5450,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1613,
+      "readme_linha": 1617,
       "tipo_fonte": "privado"
     },
     {
@@ -5450,7 +5476,7 @@
         "processo",
         "publicacao_academica"
       ],
-      "readme_linha": 1619,
+      "readme_linha": 1623,
       "tipo_fonte": "federal"
     },
     {
@@ -5474,7 +5500,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1625,
+      "readme_linha": 1629,
       "tipo_fonte": "privado"
     },
     {
@@ -5498,7 +5524,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1629,
+      "readme_linha": 1633,
       "tipo_fonte": "academico"
     },
     {
@@ -5522,7 +5548,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1633,
+      "readme_linha": 1637,
       "tipo_fonte": "academico"
     },
     {
@@ -5546,7 +5572,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1637,
+      "readme_linha": 1641,
       "tipo_fonte": "academico"
     },
     {
@@ -5570,7 +5596,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1641,
+      "readme_linha": 1645,
       "tipo_fonte": "academico"
     },
     {
@@ -5594,7 +5620,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1645,
+      "readme_linha": 1649,
       "tipo_fonte": "federal"
     },
     {
@@ -5618,7 +5644,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1649,
+      "readme_linha": 1653,
       "tipo_fonte": "privado"
     },
     {
@@ -5642,7 +5668,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1653,
+      "readme_linha": 1657,
       "tipo_fonte": "federal"
     },
     {
@@ -5666,7 +5692,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1657,
+      "readme_linha": 1661,
       "tipo_fonte": "ong"
     },
     {
@@ -5691,7 +5717,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1661,
+      "readme_linha": 1665,
       "tipo_fonte": "federal"
     },
     {
@@ -5717,7 +5743,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1665,
+      "readme_linha": 1669,
       "tipo_fonte": "federal"
     },
     {
@@ -5742,7 +5768,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 1669,
+      "readme_linha": 1673,
       "tipo_fonte": "federal"
     },
     {
@@ -5766,7 +5792,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1673,
+      "readme_linha": 1677,
       "tipo_fonte": "federal"
     },
     {
@@ -5790,7 +5816,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1677,
+      "readme_linha": 1681,
       "tipo_fonte": "federal"
     },
     {
@@ -5814,7 +5840,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1681,
+      "readme_linha": 1685,
       "tipo_fonte": "federal"
     },
     {
@@ -5954,7 +5980,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1690,
+      "readme_linha": 1694,
       "tipo_fonte": "privado"
     },
     {
@@ -5985,7 +6011,7 @@
         "area_rural",
         "mapa"
       ],
-      "readme_linha": 1724,
+      "readme_linha": 1728,
       "tipo_fonte": "federal"
     },
     {
@@ -6009,7 +6035,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1731,
+      "readme_linha": 1735,
       "tipo_fonte": "federal"
     },
     {
@@ -6038,7 +6064,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1737,
+      "readme_linha": 1741,
       "tipo_fonte": "federal"
     },
     {
@@ -6062,7 +6088,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1744,
+      "readme_linha": 1748,
       "tipo_fonte": "privado"
     },
     {
@@ -6103,7 +6129,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1748,
+      "readme_linha": 1752,
       "tipo_fonte": "internacional"
     },
     {
@@ -6132,7 +6158,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1760,
+      "readme_linha": 1764,
       "tipo_fonte": "federal"
     },
     {
@@ -6157,7 +6183,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1767,
+      "readme_linha": 1771,
       "tipo_fonte": "federal"
     },
     {
@@ -6181,7 +6207,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1773,
+      "readme_linha": 1777,
       "tipo_fonte": "federal"
     },
     {
@@ -6220,7 +6246,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1777,
+      "readme_linha": 1781,
       "tipo_fonte": "federal"
     },
     {
@@ -6244,7 +6270,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1789,
+      "readme_linha": 1793,
       "tipo_fonte": "federal"
     },
     {
@@ -6268,7 +6294,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1793,
+      "readme_linha": 1797,
       "tipo_fonte": "federal"
     },
     {
@@ -6293,7 +6319,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1803,
+      "readme_linha": 1807,
       "tipo_fonte": "federal"
     },
     {
@@ -6318,7 +6344,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1810,
+      "readme_linha": 1814,
       "tipo_fonte": "federal"
     },
     {
@@ -6345,7 +6371,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1817,
+      "readme_linha": 1821,
       "tipo_fonte": "federal"
     },
     {
@@ -6374,7 +6400,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1824,
+      "readme_linha": 1828,
       "tipo_fonte": "federal"
     },
     {
@@ -6400,7 +6426,7 @@
         "mapa",
         "sancao"
       ],
-      "readme_linha": 1831,
+      "readme_linha": 1835,
       "tipo_fonte": "federal"
     },
     {
@@ -6425,7 +6451,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1838,
+      "readme_linha": 1842,
       "tipo_fonte": "federal"
     },
     {
@@ -6452,7 +6478,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1845,
+      "readme_linha": 1849,
       "tipo_fonte": "federal"
     },
     {
@@ -6478,7 +6504,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1852,
+      "readme_linha": 1856,
       "tipo_fonte": "privado"
     },
     {
@@ -6503,7 +6529,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1859,
+      "readme_linha": 1863,
       "tipo_fonte": "federal"
     },
     {
@@ -6530,7 +6556,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1866,
+      "readme_linha": 1870,
       "tipo_fonte": "federal"
     },
     {
@@ -6555,7 +6581,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1873,
+      "readme_linha": 1877,
       "tipo_fonte": "federal"
     },
     {
@@ -6581,7 +6607,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1880,
+      "readme_linha": 1884,
       "tipo_fonte": "federal"
     },
     {
@@ -6607,7 +6633,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1887,
+      "readme_linha": 1891,
       "tipo_fonte": "federal"
     },
     {
@@ -6632,7 +6658,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1894,
+      "readme_linha": 1898,
       "tipo_fonte": "federal"
     },
     {
@@ -6659,7 +6685,7 @@
         "mapa",
         "processo"
       ],
-      "readme_linha": 1901,
+      "readme_linha": 1905,
       "tipo_fonte": "federal"
     },
     {
@@ -6686,7 +6712,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1908,
+      "readme_linha": 1912,
       "tipo_fonte": "federal"
     },
     {
@@ -6710,7 +6736,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1919,
+      "readme_linha": 1923,
       "tipo_fonte": "federal"
     },
     {
@@ -6734,7 +6760,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1925,
+      "readme_linha": 1929,
       "tipo_fonte": "federal"
     },
     {
@@ -6759,7 +6785,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1929,
+      "readme_linha": 1933,
       "tipo_fonte": "federal"
     },
     {
@@ -6783,7 +6809,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1933,
+      "readme_linha": 1937,
       "tipo_fonte": "federal"
     },
     {
@@ -6807,7 +6833,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1937,
+      "readme_linha": 1941,
       "tipo_fonte": "federal"
     },
     {
@@ -6831,7 +6857,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1941,
+      "readme_linha": 1945,
       "tipo_fonte": "federal"
     },
     {
@@ -6860,7 +6886,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1945,
+      "readme_linha": 1949,
       "tipo_fonte": "federal"
     },
     {
@@ -6885,7 +6911,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1950,
+      "readme_linha": 1954,
       "tipo_fonte": "ong"
     },
     {
@@ -6910,7 +6936,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1954,
+      "readme_linha": 1958,
       "tipo_fonte": "academico"
     },
     {
@@ -6934,7 +6960,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1958,
+      "readme_linha": 1962,
       "tipo_fonte": "academico"
     },
     {
@@ -6968,7 +6994,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1962,
+      "readme_linha": 1966,
       "tipo_fonte": "federal"
     },
     {
@@ -7006,7 +7032,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 1979,
+      "readme_linha": 1983,
       "tipo_fonte": "dork"
     },
     {
@@ -7034,7 +7060,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 1992,
+      "readme_linha": 1996,
       "tipo_fonte": "dork"
     },
     {
@@ -7062,7 +7088,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 1999,
+      "readme_linha": 2003,
       "tipo_fonte": "dork"
     },
     {
@@ -7095,7 +7121,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2008,
+      "readme_linha": 2012,
       "tipo_fonte": "dork"
     },
     {
@@ -7133,7 +7159,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2019,
+      "readme_linha": 2023,
       "tipo_fonte": "dork"
     },
     {
@@ -7172,7 +7198,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2032,
+      "readme_linha": 2036,
       "tipo_fonte": "dork"
     },
     {
@@ -7211,7 +7237,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2048,
+      "readme_linha": 2052,
       "tipo_fonte": "internacional"
     },
     {
@@ -7245,7 +7271,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2060,
+      "readme_linha": 2064,
       "tipo_fonte": "internacional"
     },
     {
@@ -7273,7 +7299,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2067,
+      "readme_linha": 2071,
       "tipo_fonte": "dork"
     },
     {
@@ -7321,7 +7347,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2074,
+      "readme_linha": 2078,
       "tipo_fonte": "dork"
     },
     {
@@ -7359,7 +7385,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2094,
+      "readme_linha": 2098,
       "tipo_fonte": "dork"
     },
     {
@@ -7398,7 +7424,7 @@
         "dork",
         "video_ao_vivo"
       ],
-      "readme_linha": 2109,
+      "readme_linha": 2113,
       "tipo_fonte": "dork"
     },
     {
@@ -7439,7 +7465,7 @@
         "dork",
         "operadora"
       ],
-      "readme_linha": 2124,
+      "readme_linha": 2128,
       "tipo_fonte": "dork"
     },
     {
@@ -7473,7 +7499,7 @@
         "dork",
         "publicacao_academica"
       ],
-      "readme_linha": 2139,
+      "readme_linha": 2143,
       "tipo_fonte": "dork"
     },
     {
@@ -7506,7 +7532,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2151,
+      "readme_linha": 2155,
       "tipo_fonte": "dork"
     },
     {
@@ -7534,7 +7560,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2163,
+      "readme_linha": 2167,
       "tipo_fonte": "dork"
     },
     {
@@ -7563,7 +7589,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2173,
+      "readme_linha": 2177,
       "tipo_fonte": "internacional"
     },
     {
@@ -7606,7 +7632,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2185,
+      "readme_linha": 2189,
       "tipo_fonte": "dork"
     },
     {
@@ -7631,7 +7657,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2209,
+      "readme_linha": 2213,
       "tipo_fonte": "internacional"
     },
     {
@@ -7666,7 +7692,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2215,
+      "readme_linha": 2219,
       "tipo_fonte": "internacional"
     },
     {
@@ -7696,7 +7722,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2226,
+      "readme_linha": 2230,
       "tipo_fonte": "internacional"
     },
     {
@@ -7721,7 +7747,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2234,
+      "readme_linha": 2238,
       "tipo_fonte": "internacional"
     },
     {
@@ -7747,7 +7773,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2240,
+      "readme_linha": 2244,
       "tipo_fonte": "internacional"
     },
     {
@@ -7773,7 +7799,7 @@
         "estatistica",
         "perfil_social"
       ],
-      "readme_linha": 2246,
+      "readme_linha": 2250,
       "tipo_fonte": "internacional"
     },
     {
@@ -7798,7 +7824,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2252,
+      "readme_linha": 2256,
       "tipo_fonte": "internacional"
     },
     {
@@ -7823,7 +7849,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2258,
+      "readme_linha": 2262,
       "tipo_fonte": "internacional"
     },
     {
@@ -7848,7 +7874,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2262,
+      "readme_linha": 2266,
       "tipo_fonte": "internacional"
     },
     {
@@ -7873,7 +7899,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2266,
+      "readme_linha": 2270,
       "tipo_fonte": "internacional"
     },
     {
@@ -7898,7 +7924,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2270,
+      "readme_linha": 2274,
       "tipo_fonte": "internacional"
     },
     {
@@ -7923,7 +7949,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2274,
+      "readme_linha": 2278,
       "tipo_fonte": "internacional"
     },
     {
@@ -7948,7 +7974,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2278,
+      "readme_linha": 2282,
       "tipo_fonte": "internacional"
     },
     {
@@ -7974,7 +8000,7 @@
         "mandado_prisao",
         "perfil_social"
       ],
-      "readme_linha": 2284,
+      "readme_linha": 2288,
       "tipo_fonte": "privado"
     },
     {
@@ -8004,7 +8030,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2290,
+      "readme_linha": 2294,
       "tipo_fonte": "privado"
     },
     {
@@ -8034,7 +8060,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2297,
+      "readme_linha": 2301,
       "tipo_fonte": "internacional"
     },
     {
@@ -8060,7 +8086,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2303,
+      "readme_linha": 2307,
       "tipo_fonte": "internacional"
     },
     {
@@ -8085,7 +8111,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2310,
+      "readme_linha": 2314,
       "tipo_fonte": "privado"
     },
     {
@@ -8110,7 +8136,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2316,
+      "readme_linha": 2320,
       "tipo_fonte": "internacional"
     },
     {
@@ -8193,7 +8219,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2329,
+      "readme_linha": 2333,
       "tipo_fonte": "privado"
     },
     {
@@ -8256,7 +8282,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2354,
+      "readme_linha": 2358,
       "tipo_fonte": "privado"
     },
     {
@@ -8279,7 +8305,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2381,
+      "readme_linha": 2385,
       "tipo_fonte": "federal"
     },
     {
@@ -8302,7 +8328,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2387,
+      "readme_linha": 2391,
       "tipo_fonte": "privado"
     },
     {
@@ -8325,7 +8351,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2393,
+      "readme_linha": 2397,
       "tipo_fonte": "federal"
     },
     {
@@ -8348,7 +8374,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2399,
+      "readme_linha": 2403,
       "tipo_fonte": "privado"
     },
     {
@@ -8371,7 +8397,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2405,
+      "readme_linha": 2409,
       "tipo_fonte": "federal"
     },
     {
@@ -8394,7 +8420,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2411,
+      "readme_linha": 2415,
       "tipo_fonte": "federal"
     },
     {
@@ -8417,7 +8443,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2417,
+      "readme_linha": 2421,
       "tipo_fonte": "federal"
     },
     {
@@ -8441,7 +8467,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2423,
+      "readme_linha": 2427,
       "tipo_fonte": "federal"
     },
     {
@@ -8470,7 +8496,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 2427,
+      "readme_linha": 2431,
       "tipo_fonte": "federal"
     },
     {
@@ -8493,7 +8519,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2434,
+      "readme_linha": 2438,
       "tipo_fonte": "federal"
     },
     {
@@ -8516,7 +8542,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2438,
+      "readme_linha": 2442,
       "tipo_fonte": "federal"
     },
     {
@@ -8540,7 +8566,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2444,
+      "readme_linha": 2448,
       "tipo_fonte": "federal"
     },
     {
@@ -8563,7 +8589,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2450,
+      "readme_linha": 2454,
       "tipo_fonte": "estadual"
     },
     {
@@ -8587,7 +8613,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2456,
+      "readme_linha": 2460,
       "tipo_fonte": "estadual"
     },
     {
@@ -8611,7 +8637,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2462,
+      "readme_linha": 2466,
       "tipo_fonte": "federal"
     },
     {
@@ -8634,7 +8660,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2468,
+      "readme_linha": 2472,
       "tipo_fonte": "federal"
     },
     {
@@ -8657,7 +8683,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2474,
+      "readme_linha": 2478,
       "tipo_fonte": "estadual"
     },
     {
@@ -8681,7 +8707,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2480,
+      "readme_linha": 2484,
       "tipo_fonte": "federal"
     },
     {
@@ -8704,7 +8730,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2486,
+      "readme_linha": 2490,
       "tipo_fonte": "estadual"
     },
     {
@@ -8727,7 +8753,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2492,
+      "readme_linha": 2496,
       "tipo_fonte": "estadual"
     },
     {
@@ -8750,7 +8776,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2498,
+      "readme_linha": 2502,
       "tipo_fonte": "federal"
     },
     {
@@ -8773,7 +8799,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2504,
+      "readme_linha": 2508,
       "tipo_fonte": "estadual"
     },
     {
@@ -8796,7 +8822,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2510,
+      "readme_linha": 2514,
       "tipo_fonte": "estadual"
     },
     {
@@ -8819,7 +8845,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2514,
+      "readme_linha": 2518,
       "tipo_fonte": "federal"
     },
     {
@@ -8842,7 +8868,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2520,
+      "readme_linha": 2524,
       "tipo_fonte": "federal"
     },
     {
@@ -8865,7 +8891,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2526,
+      "readme_linha": 2530,
       "tipo_fonte": "estadual"
     },
     {
@@ -8888,7 +8914,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2532,
+      "readme_linha": 2536,
       "tipo_fonte": "federal"
     },
     {
@@ -8916,7 +8942,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2538,
+      "readme_linha": 2542,
       "tipo_fonte": "federal"
     },
     {
@@ -8941,7 +8967,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2545,
+      "readme_linha": 2549,
       "tipo_fonte": "estadual"
     },
     {
@@ -8964,7 +8990,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2549,
+      "readme_linha": 2553,
       "tipo_fonte": "federal"
     },
     {
@@ -8988,7 +9014,7 @@
         "dataset",
         "diario_oficial"
       ],
-      "readme_linha": 2553,
+      "readme_linha": 2557,
       "tipo_fonte": "ong"
     },
     {
@@ -9011,7 +9037,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2559,
+      "readme_linha": 2563,
       "tipo_fonte": "ong"
     },
     {
@@ -9034,7 +9060,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2563,
+      "readme_linha": 2567,
       "tipo_fonte": "federal"
     },
     {
@@ -9057,7 +9083,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2567,
+      "readme_linha": 2571,
       "tipo_fonte": "federal"
     },
     {
@@ -9080,7 +9106,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2571,
+      "readme_linha": 2575,
       "tipo_fonte": "privado"
     },
     {
@@ -9103,7 +9129,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2575,
+      "readme_linha": 2579,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9126,7 +9152,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2579,
+      "readme_linha": 2583,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9150,7 +9176,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2583,
+      "readme_linha": 2587,
       "tipo_fonte": "federal"
     },
     {
@@ -9173,7 +9199,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2587,
+      "readme_linha": 2591,
       "tipo_fonte": "federal"
     },
     {
@@ -9197,7 +9223,7 @@
         "dataset",
         "endereco"
       ],
-      "readme_linha": 2591,
+      "readme_linha": 2595,
       "tipo_fonte": "privado"
     },
     {
@@ -9222,7 +9248,7 @@
         "beneficio",
         "remuneracao"
       ],
-      "readme_linha": 2601,
+      "readme_linha": 2605,
       "tipo_fonte": "ong"
     },
     {
@@ -9246,7 +9272,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2609,
+      "readme_linha": 2613,
       "tipo_fonte": "estadual"
     },
     {
@@ -9270,7 +9296,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2613,
+      "readme_linha": 2617,
       "tipo_fonte": "estadual"
     },
     {
@@ -9369,7 +9395,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2619,
+      "readme_linha": 2623,
       "tipo_fonte": "privado"
     },
     {
@@ -9428,7 +9454,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2642,
+      "readme_linha": 2646,
       "tipo_fonte": "ong"
     },
     {
@@ -9457,7 +9483,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2657,
+      "readme_linha": 2661,
       "tipo_fonte": "privado"
     },
     {
@@ -9481,7 +9507,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2664,
+      "readme_linha": 2668,
       "tipo_fonte": "privado"
     },
     {
@@ -9505,7 +9531,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2670,
+      "readme_linha": 2674,
       "tipo_fonte": "federal"
     },
     {
@@ -9529,7 +9555,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2676,
+      "readme_linha": 2680,
       "tipo_fonte": "federal"
     },
     {
@@ -9554,7 +9580,7 @@
         "veiculo",
         "video_ao_vivo"
       ],
-      "readme_linha": 2682,
+      "readme_linha": 2686,
       "tipo_fonte": "internacional"
     },
     {
@@ -9578,7 +9604,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2686,
+      "readme_linha": 2690,
       "tipo_fonte": "internacional"
     },
     {
@@ -9603,7 +9629,7 @@
         "multa",
         "veiculo"
       ],
-      "readme_linha": 2690,
+      "readme_linha": 2694,
       "tipo_fonte": "federal"
     },
     {
@@ -9629,7 +9655,7 @@
         "dados_cadastrais",
         "veiculo"
       ],
-      "readme_linha": 2694,
+      "readme_linha": 2698,
       "tipo_fonte": "federal"
     },
     {
@@ -9653,7 +9679,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2698,
+      "readme_linha": 2702,
       "tipo_fonte": "federal"
     },
     {
@@ -9677,7 +9703,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2702,
+      "readme_linha": 2706,
       "tipo_fonte": "privado"
     },
     {
@@ -9701,7 +9727,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2708,
+      "readme_linha": 2712,
       "tipo_fonte": "federal"
     },
     {
@@ -9725,7 +9751,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2714,
+      "readme_linha": 2718,
       "tipo_fonte": "federal"
     },
     {
@@ -9750,7 +9776,7 @@
         "dataset",
         "veiculo"
       ],
-      "readme_linha": 2720,
+      "readme_linha": 2724,
       "tipo_fonte": "federal"
     },
     {
@@ -9779,7 +9805,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2726,
+      "readme_linha": 2730,
       "tipo_fonte": "estadual"
     },
     {
@@ -9808,7 +9834,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2733,
+      "readme_linha": 2737,
       "tipo_fonte": "estadual"
     },
     {
@@ -9977,7 +10003,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2740,
+      "readme_linha": 2744,
       "tipo_fonte": "estadual"
     },
     {
@@ -10001,7 +10027,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 2810,
+      "readme_linha": 2814,
       "tipo_fonte": "privado"
     },
     {
@@ -10024,7 +10050,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2816,
+      "readme_linha": 2820,
       "tipo_fonte": "privado"
     },
     {
@@ -10067,7 +10093,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2822,
+      "readme_linha": 2826,
       "tipo_fonte": "estadual"
     },
     {
@@ -10090,7 +10116,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2842,
+      "readme_linha": 2846,
       "tipo_fonte": "privado"
     },
     {
@@ -10113,7 +10139,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2848,
+      "readme_linha": 2852,
       "tipo_fonte": "privado"
     },
     {
@@ -10136,7 +10162,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2854,
+      "readme_linha": 2858,
       "tipo_fonte": "privado"
     },
     {
@@ -10161,7 +10187,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 2866,
+      "readme_linha": 2870,
       "tipo_fonte": "federal"
     },
     {
@@ -10187,7 +10213,7 @@
         "estatistica",
         "multa"
       ],
-      "readme_linha": 2870,
+      "readme_linha": 2874,
       "tipo_fonte": "privado"
     },
     {
@@ -10210,7 +10236,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2874,
+      "readme_linha": 2878,
       "tipo_fonte": "federal"
     },
     {
@@ -10233,7 +10259,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2878,
+      "readme_linha": 2882,
       "tipo_fonte": "federal"
     },
     {
@@ -10256,7 +10282,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2882,
+      "readme_linha": 2886,
       "tipo_fonte": "federal"
     },
     {
@@ -10279,7 +10305,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2886,
+      "readme_linha": 2890,
       "tipo_fonte": "federal"
     },
     {
@@ -10307,7 +10333,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2890,
+      "readme_linha": 2894,
       "tipo_fonte": "internacional"
     },
     {
@@ -10330,7 +10356,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2895,
+      "readme_linha": 2899,
       "tipo_fonte": "privado"
     },
     {
@@ -10353,7 +10379,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2899,
+      "readme_linha": 2903,
       "tipo_fonte": "privado"
     },
     {
@@ -10376,7 +10402,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2903,
+      "readme_linha": 2907,
       "tipo_fonte": "privado"
     },
     {
@@ -10399,7 +10425,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2913,
+      "readme_linha": 2917,
       "tipo_fonte": "federal"
     },
     {
@@ -10425,7 +10451,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 2919,
+      "readme_linha": 2923,
       "tipo_fonte": "privado"
     },
     {
@@ -10448,7 +10474,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2925,
+      "readme_linha": 2929,
       "tipo_fonte": "federal"
     },
     {
@@ -10473,7 +10499,7 @@
         "dados_cadastrais",
         "multa"
       ],
-      "readme_linha": 2931,
+      "readme_linha": 2935,
       "tipo_fonte": "federal"
     },
     {
@@ -10551,7 +10577,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2935,
+      "readme_linha": 2939,
       "tipo_fonte": "federal"
     },
     {
@@ -10574,7 +10600,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2963,
+      "readme_linha": 2967,
       "tipo_fonte": "estadual"
     },
     {
@@ -10597,7 +10623,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2969,
+      "readme_linha": 2973,
       "tipo_fonte": "privado"
     },
     {
@@ -10620,7 +10646,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2973,
+      "readme_linha": 2977,
       "tipo_fonte": "estadual"
     },
     {
@@ -10643,7 +10669,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2977,
+      "readme_linha": 2981,
       "tipo_fonte": "internacional"
     },
     {
@@ -10686,7 +10712,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2981,
+      "readme_linha": 2985,
       "tipo_fonte": "privado"
     },
     {
@@ -10734,7 +10760,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2996,
+      "readme_linha": 3000,
       "tipo_fonte": "privado"
     },
     {
@@ -10837,7 +10863,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3010,
+      "readme_linha": 3014,
       "tipo_fonte": "privado"
     },
     {
@@ -10860,7 +10886,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3051,
+      "readme_linha": 3055,
       "tipo_fonte": "privado"
     },
     {
@@ -10908,7 +10934,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3055,
+      "readme_linha": 3059,
       "tipo_fonte": "estadual"
     },
     {
@@ -11231,7 +11257,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3069,
+      "readme_linha": 3073,
       "tipo_fonte": "privado"
     },
     {
@@ -11254,7 +11280,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3144,
+      "readme_linha": 3148,
       "tipo_fonte": "privado"
     },
     {
@@ -11277,7 +11303,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3148,
+      "readme_linha": 3152,
       "tipo_fonte": "privado"
     },
     {
@@ -11300,7 +11326,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3152,
+      "readme_linha": 3156,
       "tipo_fonte": "estadual"
     },
     {
@@ -11323,7 +11349,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3156,
+      "readme_linha": 3160,
       "tipo_fonte": "federal"
     },
     {
@@ -11352,7 +11378,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3160,
+      "readme_linha": 3164,
       "tipo_fonte": "internacional"
     },
     {
@@ -11376,7 +11402,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3165,
+      "readme_linha": 3169,
       "tipo_fonte": "internacional"
     },
     {
@@ -11400,7 +11426,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3169,
+      "readme_linha": 3173,
       "tipo_fonte": "internacional"
     },
     {
@@ -11424,7 +11450,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3173,
+      "readme_linha": 3177,
       "tipo_fonte": "internacional"
     },
     {
@@ -11448,7 +11474,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3177,
+      "readme_linha": 3181,
       "tipo_fonte": "internacional"
     },
     {
@@ -11472,7 +11498,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3181,
+      "readme_linha": 3185,
       "tipo_fonte": "internacional"
     },
     {
@@ -11496,7 +11522,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3185,
+      "readme_linha": 3189,
       "tipo_fonte": "internacional"
     },
     {
@@ -11520,7 +11546,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3189,
+      "readme_linha": 3193,
       "tipo_fonte": "internacional"
     },
     {
@@ -11543,7 +11569,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3193,
+      "readme_linha": 3197,
       "tipo_fonte": "estadual"
     },
     {
@@ -11617,7 +11643,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3203,
+      "readme_linha": 3207,
       "tipo_fonte": "ministerio_publico"
     },
     {
@@ -11677,7 +11703,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3244,
+      "readme_linha": 3248,
       "tipo_fonte": "defensoria"
     },
     {
@@ -11711,7 +11737,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3276,
+      "readme_linha": 3280,
       "tipo_fonte": "ong"
     },
     {
@@ -11740,7 +11766,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3293,
+      "readme_linha": 3297,
       "tipo_fonte": "estadual"
     },
     {
@@ -11769,7 +11795,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3313,
+      "readme_linha": 3317,
       "tipo_fonte": "privado"
     },
     {
@@ -11818,7 +11844,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3318,
+      "readme_linha": 3322,
       "tipo_fonte": "estadual"
     },
     {
@@ -11843,7 +11869,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 3337,
+      "readme_linha": 3341,
       "tipo_fonte": "federal"
     },
     {
@@ -11868,7 +11894,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3341,
+      "readme_linha": 3345,
       "tipo_fonte": "ong"
     },
     {
@@ -11893,7 +11919,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3345,
+      "readme_linha": 3349,
       "tipo_fonte": "federal"
     },
     {
@@ -11916,7 +11942,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3349,
+      "readme_linha": 3353,
       "tipo_fonte": "privado"
     },
     {
@@ -11941,7 +11967,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3353,
+      "readme_linha": 3357,
       "tipo_fonte": "federal"
     },
     {
@@ -11964,7 +11990,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3357,
+      "readme_linha": 3361,
       "tipo_fonte": "federal"
     },
     {
@@ -11985,7 +12011,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3361,
+      "readme_linha": 3365,
       "tipo_fonte": "federal"
     },
     {
@@ -12013,7 +12039,7 @@
         "mandado_prisao",
         "veiculo"
       ],
-      "readme_linha": 3365,
+      "readme_linha": 3369,
       "tipo_fonte": "federal"
     },
     {
@@ -12054,7 +12080,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3374,
+      "readme_linha": 3378,
       "tipo_fonte": "privado"
     },
     {
@@ -12085,7 +12111,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3393,
+      "readme_linha": 3397,
       "tipo_fonte": "privado"
     },
     {
@@ -12114,7 +12140,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3407,
+      "readme_linha": 3411,
       "tipo_fonte": "privado"
     },
     {
@@ -12142,7 +12168,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3434,
+      "readme_linha": 3438,
       "tipo_fonte": "privado"
     },
     {
@@ -12172,7 +12198,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3456,
+      "readme_linha": 3460,
       "tipo_fonte": "privado"
     },
     {
@@ -12199,7 +12225,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3480,
+      "readme_linha": 3484,
       "tipo_fonte": "federal"
     },
     {
@@ -12226,7 +12252,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3503,
+      "readme_linha": 3507,
       "tipo_fonte": "federal"
     },
     {
@@ -12256,7 +12282,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3507,
+      "readme_linha": 3511,
       "tipo_fonte": "ong"
     },
     {
@@ -12282,7 +12308,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3530,
+      "readme_linha": 3534,
       "tipo_fonte": "federal"
     },
     {
@@ -12306,7 +12332,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3534,
+      "readme_linha": 3538,
       "tipo_fonte": "federal"
     },
     {
@@ -12329,7 +12355,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3544,
+      "readme_linha": 3548,
       "tipo_fonte": "federal"
     },
     {
@@ -12352,7 +12378,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3548,
+      "readme_linha": 3552,
       "tipo_fonte": "federal"
     },
     {
@@ -12381,7 +12407,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3552,
+      "readme_linha": 3556,
       "tipo_fonte": "federal"
     },
     {
@@ -12409,7 +12435,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3557,
+      "readme_linha": 3561,
       "tipo_fonte": "federal"
     },
     {
@@ -12432,7 +12458,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3562,
+      "readme_linha": 3566,
       "tipo_fonte": "federal"
     },
     {
@@ -12455,7 +12481,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3566,
+      "readme_linha": 3570,
       "tipo_fonte": "federal"
     },
     {
@@ -12484,7 +12510,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3576,
+      "readme_linha": 3580,
       "tipo_fonte": "federal"
     },
     {
@@ -12508,7 +12534,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3581,
+      "readme_linha": 3585,
       "tipo_fonte": "federal"
     },
     {
@@ -12532,7 +12558,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3585,
+      "readme_linha": 3589,
       "tipo_fonte": "federal"
     },
     {
@@ -12562,7 +12588,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3589,
+      "readme_linha": 3593,
       "tipo_fonte": "ong"
     },
     {
@@ -12592,7 +12618,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3594,
+      "readme_linha": 3598,
       "tipo_fonte": "federal"
     },
     {
@@ -12617,7 +12643,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3599,
+      "readme_linha": 3603,
       "tipo_fonte": "federal"
     },
     {
@@ -12641,7 +12667,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3603,
+      "readme_linha": 3607,
       "tipo_fonte": "federal"
     },
     {
@@ -12665,7 +12691,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3607,
+      "readme_linha": 3611,
       "tipo_fonte": "federal"
     },
     {
@@ -12720,7 +12746,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3617,
+      "readme_linha": 3621,
       "tipo_fonte": "ong"
     },
     {
@@ -12844,7 +12870,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3656,
+      "readme_linha": 3660,
       "tipo_fonte": "estadual"
     },
     {
@@ -12964,7 +12990,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3697,
+      "readme_linha": 3701,
       "tipo_fonte": "ong"
     },
     {
@@ -12998,7 +13024,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3726,
+      "readme_linha": 3730,
       "tipo_fonte": "estadual"
     },
     {
@@ -13024,7 +13050,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3738,
+      "readme_linha": 3742,
       "tipo_fonte": "estadual"
     },
     {
@@ -13050,7 +13076,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3742,
+      "readme_linha": 3746,
       "tipo_fonte": "estadual"
     },
     {
@@ -13074,7 +13100,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3746,
+      "readme_linha": 3750,
       "tipo_fonte": "estadual"
     },
     {
@@ -13097,7 +13123,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3756,
+      "readme_linha": 3760,
       "tipo_fonte": "ong"
     },
     {
@@ -13120,7 +13146,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3760,
+      "readme_linha": 3764,
       "tipo_fonte": "federal"
     },
     {
@@ -13144,7 +13170,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3764,
+      "readme_linha": 3768,
       "tipo_fonte": "ong"
     },
     {
@@ -13167,7 +13193,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3768,
+      "readme_linha": 3772,
       "tipo_fonte": "federal"
     },
     {
@@ -13190,7 +13216,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3772,
+      "readme_linha": 3776,
       "tipo_fonte": "federal"
     },
     {
@@ -13218,7 +13244,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3776,
+      "readme_linha": 3780,
       "tipo_fonte": "privado"
     },
     {
@@ -13306,7 +13332,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3788,
+      "readme_linha": 3792,
       "tipo_fonte": "privado"
     },
     {
@@ -13357,7 +13383,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3810,
+      "readme_linha": 3814,
       "tipo_fonte": "privado"
     },
     {
@@ -13380,7 +13406,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3823,
+      "readme_linha": 3827,
       "tipo_fonte": "estadual"
     },
     {
@@ -13413,7 +13439,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3829,
+      "readme_linha": 3833,
       "tipo_fonte": "privado"
     },
     {
@@ -13437,7 +13463,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3840,
+      "readme_linha": 3844,
       "tipo_fonte": "privado"
     },
     {
@@ -13460,7 +13486,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3844,
+      "readme_linha": 3848,
       "tipo_fonte": "federal"
     },
     {
@@ -13494,7 +13520,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3850,
+      "readme_linha": 3854,
       "tipo_fonte": "privado"
     },
     {
@@ -13580,7 +13606,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3860,
+      "readme_linha": 3864,
       "tipo_fonte": "privado"
     },
     {
@@ -13604,7 +13630,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3909,
+      "readme_linha": 3913,
       "tipo_fonte": "estadual"
     },
     {
@@ -13638,9 +13664,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4072,
+      "readme_linha": 4076,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 432
+  "total": 433
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -12576,6 +12576,32 @@
       "categoria": "APIs Públicas Brasileiras",
       "categoria_id": "apis-publicas-brasileiras",
       "classificacao": "override",
+      "descricao": "API pública do Conselho Nacional de Justiça para consulta de metadados e movimentações de processos de todos os tribunais, com documentação, exemplos e modelo de dados na wiki.",
+      "id": "apis-publicas-brasileiras/cnj-api-publica-datajud",
+      "input": [
+        "numero_processo"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://datajud-wiki.cnj.jus.br/api-publica/"
+        }
+      ],
+      "nome": "CNJ - API Pública DataJud",
+      "observacao": "Chave pública de acesso publicada na própria wiki.",
+      "output": [
+        "api_json",
+        "movimentacao",
+        "processo"
+      ],
+      "readme_linha": 3488,
+      "tipo_fonte": "judiciario"
+    },
+    {
+      "categoria": "APIs Públicas Brasileiras",
+      "categoria_id": "apis-publicas-brasileiras",
+      "classificacao": "override",
       "descricao": "API gratuita para consulta de informações cadastrais de empresas brasileiras.",
       "id": "apis-publicas-brasileiras/receitaws-api-cnpj",
       "input": [
@@ -12598,7 +12624,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3488,
+      "readme_linha": 3492,
       "tipo_fonte": "privado"
     },
     {
@@ -12626,7 +12652,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3515,
+      "readme_linha": 3519,
       "tipo_fonte": "privado"
     },
     {
@@ -12656,7 +12682,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3537,
+      "readme_linha": 3541,
       "tipo_fonte": "privado"
     },
     {
@@ -12683,7 +12709,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3561,
+      "readme_linha": 3565,
       "tipo_fonte": "federal"
     },
     {
@@ -12710,7 +12736,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3584,
+      "readme_linha": 3588,
       "tipo_fonte": "federal"
     },
     {
@@ -12740,7 +12766,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3588,
+      "readme_linha": 3592,
       "tipo_fonte": "ong"
     },
     {
@@ -12766,7 +12792,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3611,
+      "readme_linha": 3615,
       "tipo_fonte": "federal"
     },
     {
@@ -12790,7 +12816,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3615,
+      "readme_linha": 3619,
       "tipo_fonte": "federal"
     },
     {
@@ -12813,7 +12839,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3625,
+      "readme_linha": 3629,
       "tipo_fonte": "federal"
     },
     {
@@ -12836,7 +12862,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3629,
+      "readme_linha": 3633,
       "tipo_fonte": "federal"
     },
     {
@@ -12865,7 +12891,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3633,
+      "readme_linha": 3637,
       "tipo_fonte": "federal"
     },
     {
@@ -12893,7 +12919,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3638,
+      "readme_linha": 3642,
       "tipo_fonte": "federal"
     },
     {
@@ -12916,7 +12942,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3643,
+      "readme_linha": 3647,
       "tipo_fonte": "federal"
     },
     {
@@ -12939,7 +12965,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3647,
+      "readme_linha": 3651,
       "tipo_fonte": "federal"
     },
     {
@@ -12968,7 +12994,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3657,
+      "readme_linha": 3661,
       "tipo_fonte": "federal"
     },
     {
@@ -12992,7 +13018,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3662,
+      "readme_linha": 3666,
       "tipo_fonte": "federal"
     },
     {
@@ -13016,7 +13042,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3666,
+      "readme_linha": 3670,
       "tipo_fonte": "federal"
     },
     {
@@ -13046,7 +13072,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3670,
+      "readme_linha": 3674,
       "tipo_fonte": "ong"
     },
     {
@@ -13076,7 +13102,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3675,
+      "readme_linha": 3679,
       "tipo_fonte": "federal"
     },
     {
@@ -13101,7 +13127,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3680,
+      "readme_linha": 3684,
       "tipo_fonte": "federal"
     },
     {
@@ -13125,7 +13151,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3684,
+      "readme_linha": 3688,
       "tipo_fonte": "federal"
     },
     {
@@ -13149,7 +13175,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3688,
+      "readme_linha": 3692,
       "tipo_fonte": "federal"
     },
     {
@@ -13204,7 +13230,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3698,
+      "readme_linha": 3702,
       "tipo_fonte": "ong"
     },
     {
@@ -13328,7 +13354,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3737,
+      "readme_linha": 3741,
       "tipo_fonte": "estadual"
     },
     {
@@ -13448,7 +13474,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3778,
+      "readme_linha": 3782,
       "tipo_fonte": "ong"
     },
     {
@@ -13482,7 +13508,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3807,
+      "readme_linha": 3811,
       "tipo_fonte": "estadual"
     },
     {
@@ -13508,7 +13534,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3819,
+      "readme_linha": 3823,
       "tipo_fonte": "estadual"
     },
     {
@@ -13534,7 +13560,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3823,
+      "readme_linha": 3827,
       "tipo_fonte": "estadual"
     },
     {
@@ -13558,7 +13584,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3827,
+      "readme_linha": 3831,
       "tipo_fonte": "estadual"
     },
     {
@@ -13581,7 +13607,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3837,
+      "readme_linha": 3841,
       "tipo_fonte": "ong"
     },
     {
@@ -13604,7 +13630,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3841,
+      "readme_linha": 3845,
       "tipo_fonte": "federal"
     },
     {
@@ -13628,7 +13654,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3845,
+      "readme_linha": 3849,
       "tipo_fonte": "ong"
     },
     {
@@ -13651,7 +13677,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3849,
+      "readme_linha": 3853,
       "tipo_fonte": "federal"
     },
     {
@@ -13674,7 +13700,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3853,
+      "readme_linha": 3857,
       "tipo_fonte": "federal"
     },
     {
@@ -13702,7 +13728,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3857,
+      "readme_linha": 3861,
       "tipo_fonte": "privado"
     },
     {
@@ -13790,7 +13816,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3869,
+      "readme_linha": 3873,
       "tipo_fonte": "privado"
     },
     {
@@ -13841,7 +13867,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3891,
+      "readme_linha": 3895,
       "tipo_fonte": "privado"
     },
     {
@@ -13864,7 +13890,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3904,
+      "readme_linha": 3908,
       "tipo_fonte": "estadual"
     },
     {
@@ -13897,7 +13923,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3910,
+      "readme_linha": 3914,
       "tipo_fonte": "privado"
     },
     {
@@ -13921,7 +13947,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3921,
+      "readme_linha": 3925,
       "tipo_fonte": "privado"
     },
     {
@@ -13944,7 +13970,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3925,
+      "readme_linha": 3929,
       "tipo_fonte": "federal"
     },
     {
@@ -13978,7 +14004,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3931,
+      "readme_linha": 3935,
       "tipo_fonte": "privado"
     },
     {
@@ -14064,7 +14090,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3941,
+      "readme_linha": 3945,
       "tipo_fonte": "privado"
     },
     {
@@ -14088,7 +14114,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3990,
+      "readme_linha": 3994,
       "tipo_fonte": "estadual"
     },
     {
@@ -14122,9 +14148,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4153,
+      "readme_linha": 4157,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 449
+  "total": 450
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -2103,6 +2103,86 @@
       "tipo_fonte": "federal"
     },
     {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "classificacao": "override",
+      "descricao": "Consulta pública de devedores inscritos em dívida ativa da União e do FGTS em situação irregular. Pesquisa por CPF, CNPJ, nome ou razão social, com filtros por natureza e valor da dívida e exportação dos resultados.",
+      "id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/pgfn-divida-aberta",
+      "input": [
+        "cnpj",
+        "cpf",
+        "nome",
+        "razao_social"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://www.dividaaberta.pgfn.gov.br/consultar-devedores"
+        }
+      ],
+      "nome": "PGFN - Dívida Aberta",
+      "observacao": "Sem cadastro. Lista apenas dívidas em situação irregular; permite exportar resultados.",
+      "output": [
+        "dados_cadastrais",
+        "debito"
+      ],
+      "readme_linha": 736,
+      "tipo_fonte": "federal"
+    },
+    {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "classificacao": "override",
+      "descricao": "Emissão de certidão que informa se a pessoa física ou jurídica consta no Banco Nacional de Devedores Trabalhistas. Para consulta é necessário apenas o CPF ou CNPJ.",
+      "id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/tst-certidao-negativa-de-debitos-trabalhistas-cndt",
+      "input": [
+        "cnpj",
+        "cpf"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://cndt-certidao.tst.jus.br/inicio.faces"
+        }
+      ],
+      "nome": "TST - Certidão Negativa de Débitos Trabalhistas (CNDT)",
+      "observacao": "Sem cadastro. Certidão positiva ou negativa emitida na hora.",
+      "output": [
+        "certidao",
+        "debito"
+      ],
+      "readme_linha": 740,
+      "tipo_fonte": "judiciario"
+    },
+    {
+      "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
+      "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
+      "classificacao": "override",
+      "descricao": "Consulta do Certificado de Regularidade do FGTS do empregador. Para consulta é necessário o CNPJ ou CEI e a UF.",
+      "id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/caixa-consulta-regularidade-do-empregador-crf",
+      "input": [
+        "cnpj",
+        "uf"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://consulta-crf.caixa.gov.br/consultacrf/pages/consultaEmpregador.jsf"
+        }
+      ],
+      "nome": "Caixa - Consulta Regularidade do Empregador (CRF)",
+      "observacao": "Sem cadastro. Aceita CNPJ ou CEI.",
+      "output": [
+        "certidao",
+        "situacao_cadastral"
+      ],
+      "readme_linha": 744,
+      "tipo_fonte": "federal"
+    },
+    {
       "categoria": "Estatísticas Segurança Pública",
       "categoria_id": "estatisticas-seguranca-publica",
       "classificacao": "heuristica",
@@ -2127,7 +2207,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 745,
+      "readme_linha": 757,
       "tipo_fonte": "federal"
     },
     {
@@ -2235,7 +2315,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 757,
+      "readme_linha": 769,
       "tipo_fonte": "estadual"
     },
     {
@@ -2263,7 +2343,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 818,
+      "readme_linha": 830,
       "tipo_fonte": "ong"
     },
     {
@@ -2286,7 +2366,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 823,
+      "readme_linha": 835,
       "tipo_fonte": "privado"
     },
     {
@@ -2309,7 +2389,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 827,
+      "readme_linha": 839,
       "tipo_fonte": "ong"
     },
     {
@@ -2333,7 +2413,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 831,
+      "readme_linha": 843,
       "tipo_fonte": "privado"
     },
     {
@@ -2358,7 +2438,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 841,
+      "readme_linha": 853,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2383,7 +2463,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 845,
+      "readme_linha": 857,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2408,7 +2488,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 849,
+      "readme_linha": 861,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2433,7 +2513,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 853,
+      "readme_linha": 865,
       "tipo_fonte": "legislativo"
     },
     {
@@ -2458,7 +2538,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 857,
+      "readme_linha": 869,
       "tipo_fonte": "legislativo"
     },
     {
@@ -2484,7 +2564,7 @@
         "dados_cadastrais",
         "dataset"
       ],
-      "readme_linha": 861,
+      "readme_linha": 873,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2510,7 +2590,7 @@
         "dados_cadastrais",
         "dataset"
       ],
-      "readme_linha": 865,
+      "readme_linha": 877,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2536,7 +2616,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 869,
+      "readme_linha": 881,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2561,7 +2641,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 873,
+      "readme_linha": 885,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2587,7 +2667,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 877,
+      "readme_linha": 889,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2613,7 +2693,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 881,
+      "readme_linha": 893,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2641,7 +2721,7 @@
         "debito",
         "multa"
       ],
-      "readme_linha": 885,
+      "readme_linha": 897,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2666,7 +2746,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 889,
+      "readme_linha": 901,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2692,7 +2772,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 893,
+      "readme_linha": 905,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2717,7 +2797,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 897,
+      "readme_linha": 909,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2745,7 +2825,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 901,
+      "readme_linha": 913,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2770,7 +2850,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 905,
+      "readme_linha": 917,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2795,7 +2875,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 910,
+      "readme_linha": 922,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2821,7 +2901,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 914,
+      "readme_linha": 926,
       "tipo_fonte": "ong"
     },
     {
@@ -2845,7 +2925,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 924,
+      "readme_linha": 936,
       "tipo_fonte": "ong"
     },
     {
@@ -2869,7 +2949,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 928,
+      "readme_linha": 940,
       "tipo_fonte": "estadual"
     },
     {
@@ -2893,7 +2973,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 932,
+      "readme_linha": 944,
       "tipo_fonte": "municipal"
     },
     {
@@ -2917,7 +2997,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 936,
+      "readme_linha": 948,
       "tipo_fonte": "federal"
     },
     {
@@ -2941,7 +3021,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 940,
+      "readme_linha": 952,
       "tipo_fonte": "federal"
     },
     {
@@ -2967,7 +3047,7 @@
         "certidao",
         "imovel"
       ],
-      "readme_linha": 944,
+      "readme_linha": 956,
       "tipo_fonte": "ong"
     },
     {
@@ -2991,7 +3071,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 954,
+      "readme_linha": 966,
       "tipo_fonte": "federal"
     },
     {
@@ -3015,7 +3095,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 958,
+      "readme_linha": 970,
       "tipo_fonte": "federal"
     },
     {
@@ -3039,7 +3119,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 962,
+      "readme_linha": 974,
       "tipo_fonte": "federal"
     },
     {
@@ -3063,7 +3143,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 966,
+      "readme_linha": 978,
       "tipo_fonte": "estadual"
     },
     {
@@ -3088,7 +3168,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 970,
+      "readme_linha": 982,
       "tipo_fonte": "ong"
     },
     {
@@ -3113,7 +3193,7 @@
         "estatistica",
         "licenca_ambiental"
       ],
-      "readme_linha": 974,
+      "readme_linha": 986,
       "tipo_fonte": "ong"
     },
     {
@@ -3138,7 +3218,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 978,
+      "readme_linha": 990,
       "tipo_fonte": "ong"
     },
     {
@@ -3161,7 +3241,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 988,
+      "readme_linha": 1000,
       "tipo_fonte": "federal"
     },
     {
@@ -3184,7 +3264,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 992,
+      "readme_linha": 1004,
       "tipo_fonte": "federal"
     },
     {
@@ -3207,7 +3287,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 996,
+      "readme_linha": 1008,
       "tipo_fonte": "federal"
     },
     {
@@ -3230,7 +3310,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1000,
+      "readme_linha": 1012,
       "tipo_fonte": "federal"
     },
     {
@@ -3254,7 +3334,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1010,
+      "readme_linha": 1022,
       "tipo_fonte": "federal"
     },
     {
@@ -3278,7 +3358,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1014,
+      "readme_linha": 1026,
       "tipo_fonte": "federal"
     },
     {
@@ -3302,7 +3382,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1018,
+      "readme_linha": 1030,
       "tipo_fonte": "federal"
     },
     {
@@ -3328,7 +3408,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1028,
+      "readme_linha": 1040,
       "tipo_fonte": "federal"
     },
     {
@@ -3354,7 +3434,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1032,
+      "readme_linha": 1044,
       "tipo_fonte": "federal"
     },
     {
@@ -3386,7 +3466,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1036,
+      "readme_linha": 1048,
       "tipo_fonte": "federal"
     },
     {
@@ -3413,7 +3493,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1077,
+      "readme_linha": 1089,
       "tipo_fonte": "federal"
     },
     {
@@ -3440,7 +3520,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1081,
+      "readme_linha": 1093,
       "tipo_fonte": "federal"
     },
     {
@@ -3466,7 +3546,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1085,
+      "readme_linha": 1097,
       "tipo_fonte": "federal"
     },
     {
@@ -3492,7 +3572,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1089,
+      "readme_linha": 1101,
       "tipo_fonte": "federal"
     },
     {
@@ -3520,7 +3600,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1093,
+      "readme_linha": 1105,
       "tipo_fonte": "federal"
     },
     {
@@ -3546,7 +3626,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1097,
+      "readme_linha": 1109,
       "tipo_fonte": "federal"
     },
     {
@@ -3613,7 +3693,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1101,
+      "readme_linha": 1113,
       "tipo_fonte": "federal"
     },
     {
@@ -3639,7 +3719,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1118,
+      "readme_linha": 1130,
       "tipo_fonte": "federal"
     },
     {
@@ -3665,7 +3745,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1122,
+      "readme_linha": 1134,
       "tipo_fonte": "federal"
     },
     {
@@ -3691,7 +3771,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1126,
+      "readme_linha": 1138,
       "tipo_fonte": "federal"
     },
     {
@@ -3717,7 +3797,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1130,
+      "readme_linha": 1142,
       "tipo_fonte": "federal"
     },
     {
@@ -3743,7 +3823,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1134,
+      "readme_linha": 1146,
       "tipo_fonte": "federal"
     },
     {
@@ -3769,7 +3849,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1138,
+      "readme_linha": 1150,
       "tipo_fonte": "federal"
     },
     {
@@ -3795,7 +3875,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1142,
+      "readme_linha": 1154,
       "tipo_fonte": "federal"
     },
     {
@@ -3822,7 +3902,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1146,
+      "readme_linha": 1158,
       "tipo_fonte": "federal"
     },
     {
@@ -3848,7 +3928,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1150,
+      "readme_linha": 1162,
       "tipo_fonte": "estadual"
     },
     {
@@ -3875,7 +3955,7 @@
         "remuneracao",
         "sancao"
       ],
-      "readme_linha": 1154,
+      "readme_linha": 1166,
       "tipo_fonte": "estadual"
     },
     {
@@ -3901,7 +3981,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1158,
+      "readme_linha": 1170,
       "tipo_fonte": "federal"
     },
     {
@@ -3972,7 +4052,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1162,
+      "readme_linha": 1174,
       "tipo_fonte": "estadual"
     },
     {
@@ -3998,7 +4078,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1206,
+      "readme_linha": 1218,
       "tipo_fonte": "federal"
     },
     {
@@ -4164,7 +4244,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1210,
+      "readme_linha": 1222,
       "tipo_fonte": "estadual"
     },
     {
@@ -4188,7 +4268,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1279,
+      "readme_linha": 1291,
       "tipo_fonte": "federal"
     },
     {
@@ -4212,7 +4292,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1283,
+      "readme_linha": 1295,
       "tipo_fonte": "federal"
     },
     {
@@ -4236,7 +4316,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1287,
+      "readme_linha": 1299,
       "tipo_fonte": "ong"
     },
     {
@@ -4390,7 +4470,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1291,
+      "readme_linha": 1303,
       "tipo_fonte": "estadual"
     },
     {
@@ -4416,7 +4496,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 1356,
+      "readme_linha": 1368,
       "tipo_fonte": "federal"
     },
     {
@@ -4440,7 +4520,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1360,
+      "readme_linha": 1372,
       "tipo_fonte": "federal"
     },
     {
@@ -4464,7 +4544,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1364,
+      "readme_linha": 1376,
       "tipo_fonte": "federal"
     },
     {
@@ -4488,7 +4568,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1368,
+      "readme_linha": 1380,
       "tipo_fonte": "federal"
     },
     {
@@ -4512,7 +4592,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1372,
+      "readme_linha": 1384,
       "tipo_fonte": "federal"
     },
     {
@@ -4536,7 +4616,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1376,
+      "readme_linha": 1388,
       "tipo_fonte": "federal"
     },
     {
@@ -4560,7 +4640,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1380,
+      "readme_linha": 1392,
       "tipo_fonte": "federal"
     },
     {
@@ -4584,7 +4664,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1384,
+      "readme_linha": 1396,
       "tipo_fonte": "federal"
     },
     {
@@ -4608,7 +4688,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1388,
+      "readme_linha": 1400,
       "tipo_fonte": "federal"
     },
     {
@@ -4632,7 +4712,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1392,
+      "readme_linha": 1404,
       "tipo_fonte": "federal"
     },
     {
@@ -4666,7 +4746,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1401,
+      "readme_linha": 1413,
       "tipo_fonte": "privado"
     },
     {
@@ -4694,7 +4774,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1414,
+      "readme_linha": 1426,
       "tipo_fonte": "privado"
     },
     {
@@ -4732,7 +4812,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1419,
+      "readme_linha": 1431,
       "tipo_fonte": "privado"
     },
     {
@@ -4756,7 +4836,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1431,
+      "readme_linha": 1443,
       "tipo_fonte": "privado"
     },
     {
@@ -4820,7 +4900,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1437,
+      "readme_linha": 1449,
       "tipo_fonte": "ong"
     },
     {
@@ -4845,7 +4925,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1455,
+      "readme_linha": 1467,
       "tipo_fonte": "federal"
     },
     {
@@ -4870,7 +4950,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1459,
+      "readme_linha": 1471,
       "tipo_fonte": "federal"
     },
     {
@@ -4894,7 +4974,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1463,
+      "readme_linha": 1475,
       "tipo_fonte": "federal"
     },
     {
@@ -4917,7 +4997,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1467,
+      "readme_linha": 1479,
       "tipo_fonte": "federal"
     },
     {
@@ -4940,7 +5020,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1471,
+      "readme_linha": 1483,
       "tipo_fonte": "federal"
     },
     {
@@ -4969,7 +5049,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1475,
+      "readme_linha": 1487,
       "tipo_fonte": "privado"
     },
     {
@@ -4993,7 +5073,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1480,
+      "readme_linha": 1492,
       "tipo_fonte": "federal"
     },
     {
@@ -5016,7 +5096,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1484,
+      "readme_linha": 1496,
       "tipo_fonte": "federal"
     },
     {
@@ -5041,7 +5121,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1488,
+      "readme_linha": 1500,
       "tipo_fonte": "federal"
     },
     {
@@ -5067,7 +5147,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1496,
+      "readme_linha": 1508,
       "tipo_fonte": "federal"
     },
     {
@@ -5092,7 +5172,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1502,
+      "readme_linha": 1514,
       "tipo_fonte": "federal"
     },
     {
@@ -5117,7 +5197,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1508,
+      "readme_linha": 1520,
       "tipo_fonte": "federal"
     },
     {
@@ -5142,7 +5222,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1514,
+      "readme_linha": 1526,
       "tipo_fonte": "federal"
     },
     {
@@ -5166,7 +5246,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1521,
+      "readme_linha": 1533,
       "tipo_fonte": "federal"
     },
     {
@@ -5189,7 +5269,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1528,
+      "readme_linha": 1540,
       "tipo_fonte": "federal"
     },
     {
@@ -5216,7 +5296,7 @@
         "outorga",
         "radiofrequencia"
       ],
-      "readme_linha": 1535,
+      "readme_linha": 1547,
       "tipo_fonte": "federal"
     },
     {
@@ -5241,7 +5321,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1542,
+      "readme_linha": 1554,
       "tipo_fonte": "federal"
     },
     {
@@ -5264,7 +5344,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1549,
+      "readme_linha": 1561,
       "tipo_fonte": "federal"
     },
     {
@@ -5288,7 +5368,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1556,
+      "readme_linha": 1568,
       "tipo_fonte": "federal"
     },
     {
@@ -5312,7 +5392,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1563,
+      "readme_linha": 1575,
       "tipo_fonte": "federal"
     },
     {
@@ -5336,7 +5416,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1576,
+      "readme_linha": 1588,
       "tipo_fonte": "federal"
     },
     {
@@ -5361,7 +5441,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1582,
+      "readme_linha": 1594,
       "tipo_fonte": "ong"
     },
     {
@@ -5394,7 +5474,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1588,
+      "readme_linha": 1600,
       "tipo_fonte": "privado"
     },
     {
@@ -5422,7 +5502,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1599,
+      "readme_linha": 1611,
       "tipo_fonte": "ong"
     },
     {
@@ -5493,7 +5573,7 @@
         "erb",
         "operadora"
       ],
-      "readme_linha": 1608,
+      "readme_linha": 1620,
       "tipo_fonte": "privado"
     },
     {
@@ -5517,7 +5597,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1634,
+      "readme_linha": 1646,
       "tipo_fonte": "privado"
     },
     {
@@ -5543,7 +5623,7 @@
         "processo",
         "publicacao_academica"
       ],
-      "readme_linha": 1640,
+      "readme_linha": 1652,
       "tipo_fonte": "federal"
     },
     {
@@ -5567,7 +5647,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1646,
+      "readme_linha": 1658,
       "tipo_fonte": "privado"
     },
     {
@@ -5591,7 +5671,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1650,
+      "readme_linha": 1662,
       "tipo_fonte": "academico"
     },
     {
@@ -5615,7 +5695,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1654,
+      "readme_linha": 1666,
       "tipo_fonte": "academico"
     },
     {
@@ -5639,7 +5719,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1658,
+      "readme_linha": 1670,
       "tipo_fonte": "academico"
     },
     {
@@ -5663,7 +5743,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1662,
+      "readme_linha": 1674,
       "tipo_fonte": "academico"
     },
     {
@@ -5687,7 +5767,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1666,
+      "readme_linha": 1678,
       "tipo_fonte": "federal"
     },
     {
@@ -5711,7 +5791,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1670,
+      "readme_linha": 1682,
       "tipo_fonte": "privado"
     },
     {
@@ -5735,7 +5815,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1674,
+      "readme_linha": 1686,
       "tipo_fonte": "federal"
     },
     {
@@ -5759,7 +5839,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1678,
+      "readme_linha": 1690,
       "tipo_fonte": "ong"
     },
     {
@@ -5784,7 +5864,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1682,
+      "readme_linha": 1694,
       "tipo_fonte": "federal"
     },
     {
@@ -5810,7 +5890,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1686,
+      "readme_linha": 1698,
       "tipo_fonte": "federal"
     },
     {
@@ -5835,7 +5915,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 1690,
+      "readme_linha": 1702,
       "tipo_fonte": "federal"
     },
     {
@@ -5859,7 +5939,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1694,
+      "readme_linha": 1706,
       "tipo_fonte": "federal"
     },
     {
@@ -5883,7 +5963,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1698,
+      "readme_linha": 1710,
       "tipo_fonte": "federal"
     },
     {
@@ -5907,7 +5987,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1702,
+      "readme_linha": 1714,
       "tipo_fonte": "federal"
     },
     {
@@ -6047,7 +6127,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1711,
+      "readme_linha": 1723,
       "tipo_fonte": "privado"
     },
     {
@@ -6078,7 +6158,7 @@
         "area_rural",
         "mapa"
       ],
-      "readme_linha": 1745,
+      "readme_linha": 1757,
       "tipo_fonte": "federal"
     },
     {
@@ -6102,7 +6182,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1752,
+      "readme_linha": 1764,
       "tipo_fonte": "federal"
     },
     {
@@ -6131,7 +6211,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1758,
+      "readme_linha": 1770,
       "tipo_fonte": "federal"
     },
     {
@@ -6155,7 +6235,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1765,
+      "readme_linha": 1777,
       "tipo_fonte": "privado"
     },
     {
@@ -6196,7 +6276,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1769,
+      "readme_linha": 1781,
       "tipo_fonte": "internacional"
     },
     {
@@ -6225,7 +6305,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1781,
+      "readme_linha": 1793,
       "tipo_fonte": "federal"
     },
     {
@@ -6250,7 +6330,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1788,
+      "readme_linha": 1800,
       "tipo_fonte": "federal"
     },
     {
@@ -6274,7 +6354,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1794,
+      "readme_linha": 1806,
       "tipo_fonte": "federal"
     },
     {
@@ -6313,7 +6393,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1798,
+      "readme_linha": 1810,
       "tipo_fonte": "federal"
     },
     {
@@ -6337,7 +6417,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1810,
+      "readme_linha": 1822,
       "tipo_fonte": "federal"
     },
     {
@@ -6361,7 +6441,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1814,
+      "readme_linha": 1826,
       "tipo_fonte": "federal"
     },
     {
@@ -6386,7 +6466,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1824,
+      "readme_linha": 1836,
       "tipo_fonte": "federal"
     },
     {
@@ -6411,7 +6491,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1831,
+      "readme_linha": 1843,
       "tipo_fonte": "federal"
     },
     {
@@ -6438,7 +6518,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1838,
+      "readme_linha": 1850,
       "tipo_fonte": "federal"
     },
     {
@@ -6467,7 +6547,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1845,
+      "readme_linha": 1857,
       "tipo_fonte": "federal"
     },
     {
@@ -6493,7 +6573,7 @@
         "mapa",
         "sancao"
       ],
-      "readme_linha": 1852,
+      "readme_linha": 1864,
       "tipo_fonte": "federal"
     },
     {
@@ -6518,7 +6598,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1859,
+      "readme_linha": 1871,
       "tipo_fonte": "federal"
     },
     {
@@ -6545,7 +6625,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1866,
+      "readme_linha": 1878,
       "tipo_fonte": "federal"
     },
     {
@@ -6571,7 +6651,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1873,
+      "readme_linha": 1885,
       "tipo_fonte": "privado"
     },
     {
@@ -6596,7 +6676,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1880,
+      "readme_linha": 1892,
       "tipo_fonte": "federal"
     },
     {
@@ -6623,7 +6703,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1887,
+      "readme_linha": 1899,
       "tipo_fonte": "federal"
     },
     {
@@ -6648,7 +6728,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1894,
+      "readme_linha": 1906,
       "tipo_fonte": "federal"
     },
     {
@@ -6674,7 +6754,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1901,
+      "readme_linha": 1913,
       "tipo_fonte": "federal"
     },
     {
@@ -6700,7 +6780,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1908,
+      "readme_linha": 1920,
       "tipo_fonte": "federal"
     },
     {
@@ -6725,7 +6805,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1915,
+      "readme_linha": 1927,
       "tipo_fonte": "federal"
     },
     {
@@ -6752,7 +6832,7 @@
         "mapa",
         "processo"
       ],
-      "readme_linha": 1922,
+      "readme_linha": 1934,
       "tipo_fonte": "federal"
     },
     {
@@ -6779,7 +6859,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1929,
+      "readme_linha": 1941,
       "tipo_fonte": "federal"
     },
     {
@@ -6803,7 +6883,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1940,
+      "readme_linha": 1952,
       "tipo_fonte": "federal"
     },
     {
@@ -6827,7 +6907,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1946,
+      "readme_linha": 1958,
       "tipo_fonte": "federal"
     },
     {
@@ -6852,7 +6932,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1950,
+      "readme_linha": 1962,
       "tipo_fonte": "federal"
     },
     {
@@ -6876,7 +6956,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1954,
+      "readme_linha": 1966,
       "tipo_fonte": "federal"
     },
     {
@@ -6900,7 +6980,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1958,
+      "readme_linha": 1970,
       "tipo_fonte": "federal"
     },
     {
@@ -6924,7 +7004,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1962,
+      "readme_linha": 1974,
       "tipo_fonte": "federal"
     },
     {
@@ -6953,7 +7033,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1966,
+      "readme_linha": 1978,
       "tipo_fonte": "federal"
     },
     {
@@ -6978,7 +7058,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1971,
+      "readme_linha": 1983,
       "tipo_fonte": "ong"
     },
     {
@@ -7003,7 +7083,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1975,
+      "readme_linha": 1987,
       "tipo_fonte": "academico"
     },
     {
@@ -7027,7 +7107,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1979,
+      "readme_linha": 1991,
       "tipo_fonte": "academico"
     },
     {
@@ -7061,7 +7141,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1983,
+      "readme_linha": 1995,
       "tipo_fonte": "federal"
     },
     {
@@ -7099,7 +7179,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2000,
+      "readme_linha": 2012,
       "tipo_fonte": "dork"
     },
     {
@@ -7127,7 +7207,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2013,
+      "readme_linha": 2025,
       "tipo_fonte": "dork"
     },
     {
@@ -7155,7 +7235,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2020,
+      "readme_linha": 2032,
       "tipo_fonte": "dork"
     },
     {
@@ -7188,7 +7268,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2029,
+      "readme_linha": 2041,
       "tipo_fonte": "dork"
     },
     {
@@ -7226,7 +7306,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2040,
+      "readme_linha": 2052,
       "tipo_fonte": "dork"
     },
     {
@@ -7265,7 +7345,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2053,
+      "readme_linha": 2065,
       "tipo_fonte": "dork"
     },
     {
@@ -7304,7 +7384,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2069,
+      "readme_linha": 2081,
       "tipo_fonte": "internacional"
     },
     {
@@ -7338,7 +7418,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2081,
+      "readme_linha": 2093,
       "tipo_fonte": "internacional"
     },
     {
@@ -7366,7 +7446,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2088,
+      "readme_linha": 2100,
       "tipo_fonte": "dork"
     },
     {
@@ -7414,7 +7494,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2095,
+      "readme_linha": 2107,
       "tipo_fonte": "dork"
     },
     {
@@ -7452,7 +7532,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2115,
+      "readme_linha": 2127,
       "tipo_fonte": "dork"
     },
     {
@@ -7491,7 +7571,7 @@
         "dork",
         "video_ao_vivo"
       ],
-      "readme_linha": 2130,
+      "readme_linha": 2142,
       "tipo_fonte": "dork"
     },
     {
@@ -7532,7 +7612,7 @@
         "dork",
         "operadora"
       ],
-      "readme_linha": 2145,
+      "readme_linha": 2157,
       "tipo_fonte": "dork"
     },
     {
@@ -7566,7 +7646,7 @@
         "dork",
         "publicacao_academica"
       ],
-      "readme_linha": 2160,
+      "readme_linha": 2172,
       "tipo_fonte": "dork"
     },
     {
@@ -7599,7 +7679,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2172,
+      "readme_linha": 2184,
       "tipo_fonte": "dork"
     },
     {
@@ -7627,7 +7707,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2184,
+      "readme_linha": 2196,
       "tipo_fonte": "dork"
     },
     {
@@ -7656,7 +7736,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2194,
+      "readme_linha": 2206,
       "tipo_fonte": "internacional"
     },
     {
@@ -7699,7 +7779,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2206,
+      "readme_linha": 2218,
       "tipo_fonte": "dork"
     },
     {
@@ -7724,7 +7804,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2230,
+      "readme_linha": 2242,
       "tipo_fonte": "internacional"
     },
     {
@@ -7759,7 +7839,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2236,
+      "readme_linha": 2248,
       "tipo_fonte": "internacional"
     },
     {
@@ -7789,7 +7869,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2247,
+      "readme_linha": 2259,
       "tipo_fonte": "internacional"
     },
     {
@@ -7814,7 +7894,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2255,
+      "readme_linha": 2267,
       "tipo_fonte": "internacional"
     },
     {
@@ -7840,7 +7920,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2261,
+      "readme_linha": 2273,
       "tipo_fonte": "internacional"
     },
     {
@@ -7866,7 +7946,7 @@
         "estatistica",
         "perfil_social"
       ],
-      "readme_linha": 2267,
+      "readme_linha": 2279,
       "tipo_fonte": "internacional"
     },
     {
@@ -7891,7 +7971,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2273,
+      "readme_linha": 2285,
       "tipo_fonte": "internacional"
     },
     {
@@ -7916,7 +7996,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2279,
+      "readme_linha": 2291,
       "tipo_fonte": "internacional"
     },
     {
@@ -7941,7 +8021,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2283,
+      "readme_linha": 2295,
       "tipo_fonte": "internacional"
     },
     {
@@ -7966,7 +8046,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2287,
+      "readme_linha": 2299,
       "tipo_fonte": "internacional"
     },
     {
@@ -7991,7 +8071,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2291,
+      "readme_linha": 2303,
       "tipo_fonte": "internacional"
     },
     {
@@ -8016,7 +8096,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2295,
+      "readme_linha": 2307,
       "tipo_fonte": "internacional"
     },
     {
@@ -8041,7 +8121,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2299,
+      "readme_linha": 2311,
       "tipo_fonte": "internacional"
     },
     {
@@ -8067,7 +8147,7 @@
         "mandado_prisao",
         "perfil_social"
       ],
-      "readme_linha": 2305,
+      "readme_linha": 2317,
       "tipo_fonte": "privado"
     },
     {
@@ -8097,7 +8177,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2311,
+      "readme_linha": 2323,
       "tipo_fonte": "privado"
     },
     {
@@ -8127,7 +8207,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2318,
+      "readme_linha": 2330,
       "tipo_fonte": "internacional"
     },
     {
@@ -8153,7 +8233,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2324,
+      "readme_linha": 2336,
       "tipo_fonte": "internacional"
     },
     {
@@ -8178,7 +8258,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2331,
+      "readme_linha": 2343,
       "tipo_fonte": "privado"
     },
     {
@@ -8203,7 +8283,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2337,
+      "readme_linha": 2349,
       "tipo_fonte": "internacional"
     },
     {
@@ -8286,7 +8366,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2350,
+      "readme_linha": 2362,
       "tipo_fonte": "privado"
     },
     {
@@ -8349,7 +8429,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2375,
+      "readme_linha": 2387,
       "tipo_fonte": "privado"
     },
     {
@@ -8372,7 +8452,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2402,
+      "readme_linha": 2414,
       "tipo_fonte": "federal"
     },
     {
@@ -8395,7 +8475,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2408,
+      "readme_linha": 2420,
       "tipo_fonte": "privado"
     },
     {
@@ -8418,7 +8498,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2414,
+      "readme_linha": 2426,
       "tipo_fonte": "federal"
     },
     {
@@ -8441,7 +8521,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2420,
+      "readme_linha": 2432,
       "tipo_fonte": "privado"
     },
     {
@@ -8464,7 +8544,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2426,
+      "readme_linha": 2438,
       "tipo_fonte": "federal"
     },
     {
@@ -8487,7 +8567,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2432,
+      "readme_linha": 2444,
       "tipo_fonte": "federal"
     },
     {
@@ -8510,7 +8590,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2438,
+      "readme_linha": 2450,
       "tipo_fonte": "federal"
     },
     {
@@ -8534,7 +8614,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2444,
+      "readme_linha": 2456,
       "tipo_fonte": "federal"
     },
     {
@@ -8563,7 +8643,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 2448,
+      "readme_linha": 2460,
       "tipo_fonte": "federal"
     },
     {
@@ -8586,7 +8666,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2455,
+      "readme_linha": 2467,
       "tipo_fonte": "federal"
     },
     {
@@ -8609,7 +8689,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2459,
+      "readme_linha": 2471,
       "tipo_fonte": "federal"
     },
     {
@@ -8633,7 +8713,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2465,
+      "readme_linha": 2477,
       "tipo_fonte": "federal"
     },
     {
@@ -8656,7 +8736,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2471,
+      "readme_linha": 2483,
       "tipo_fonte": "estadual"
     },
     {
@@ -8680,7 +8760,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2477,
+      "readme_linha": 2489,
       "tipo_fonte": "estadual"
     },
     {
@@ -8704,7 +8784,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2483,
+      "readme_linha": 2495,
       "tipo_fonte": "federal"
     },
     {
@@ -8727,7 +8807,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2489,
+      "readme_linha": 2501,
       "tipo_fonte": "federal"
     },
     {
@@ -8750,7 +8830,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2495,
+      "readme_linha": 2507,
       "tipo_fonte": "estadual"
     },
     {
@@ -8774,7 +8854,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2501,
+      "readme_linha": 2513,
       "tipo_fonte": "federal"
     },
     {
@@ -8797,7 +8877,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2507,
+      "readme_linha": 2519,
       "tipo_fonte": "estadual"
     },
     {
@@ -8820,7 +8900,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2513,
+      "readme_linha": 2525,
       "tipo_fonte": "estadual"
     },
     {
@@ -8843,7 +8923,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2519,
+      "readme_linha": 2531,
       "tipo_fonte": "federal"
     },
     {
@@ -8866,7 +8946,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2525,
+      "readme_linha": 2537,
       "tipo_fonte": "estadual"
     },
     {
@@ -8889,7 +8969,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2531,
+      "readme_linha": 2543,
       "tipo_fonte": "estadual"
     },
     {
@@ -8912,7 +8992,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2535,
+      "readme_linha": 2547,
       "tipo_fonte": "federal"
     },
     {
@@ -8935,7 +9015,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2541,
+      "readme_linha": 2553,
       "tipo_fonte": "federal"
     },
     {
@@ -8958,7 +9038,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2547,
+      "readme_linha": 2559,
       "tipo_fonte": "estadual"
     },
     {
@@ -8981,7 +9061,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2553,
+      "readme_linha": 2565,
       "tipo_fonte": "federal"
     },
     {
@@ -9009,7 +9089,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2559,
+      "readme_linha": 2571,
       "tipo_fonte": "federal"
     },
     {
@@ -9034,7 +9114,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2566,
+      "readme_linha": 2578,
       "tipo_fonte": "estadual"
     },
     {
@@ -9057,7 +9137,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2570,
+      "readme_linha": 2582,
       "tipo_fonte": "federal"
     },
     {
@@ -9081,7 +9161,7 @@
         "dataset",
         "diario_oficial"
       ],
-      "readme_linha": 2574,
+      "readme_linha": 2586,
       "tipo_fonte": "ong"
     },
     {
@@ -9104,7 +9184,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2580,
+      "readme_linha": 2592,
       "tipo_fonte": "ong"
     },
     {
@@ -9127,7 +9207,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2584,
+      "readme_linha": 2596,
       "tipo_fonte": "federal"
     },
     {
@@ -9150,7 +9230,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2588,
+      "readme_linha": 2600,
       "tipo_fonte": "federal"
     },
     {
@@ -9173,7 +9253,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2592,
+      "readme_linha": 2604,
       "tipo_fonte": "privado"
     },
     {
@@ -9196,7 +9276,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2596,
+      "readme_linha": 2608,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9219,7 +9299,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2600,
+      "readme_linha": 2612,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9243,7 +9323,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2604,
+      "readme_linha": 2616,
       "tipo_fonte": "federal"
     },
     {
@@ -9266,7 +9346,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2608,
+      "readme_linha": 2620,
       "tipo_fonte": "federal"
     },
     {
@@ -9290,7 +9370,7 @@
         "dataset",
         "endereco"
       ],
-      "readme_linha": 2612,
+      "readme_linha": 2624,
       "tipo_fonte": "privado"
     },
     {
@@ -9315,7 +9395,7 @@
         "beneficio",
         "remuneracao"
       ],
-      "readme_linha": 2622,
+      "readme_linha": 2634,
       "tipo_fonte": "ong"
     },
     {
@@ -9339,7 +9419,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2630,
+      "readme_linha": 2642,
       "tipo_fonte": "estadual"
     },
     {
@@ -9363,7 +9443,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2634,
+      "readme_linha": 2646,
       "tipo_fonte": "estadual"
     },
     {
@@ -9462,7 +9542,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2640,
+      "readme_linha": 2652,
       "tipo_fonte": "privado"
     },
     {
@@ -9521,7 +9601,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2663,
+      "readme_linha": 2675,
       "tipo_fonte": "ong"
     },
     {
@@ -9550,7 +9630,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2678,
+      "readme_linha": 2690,
       "tipo_fonte": "privado"
     },
     {
@@ -9574,7 +9654,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2685,
+      "readme_linha": 2697,
       "tipo_fonte": "privado"
     },
     {
@@ -9598,7 +9678,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2691,
+      "readme_linha": 2703,
       "tipo_fonte": "federal"
     },
     {
@@ -9622,7 +9702,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2697,
+      "readme_linha": 2709,
       "tipo_fonte": "federal"
     },
     {
@@ -9647,7 +9727,7 @@
         "veiculo",
         "video_ao_vivo"
       ],
-      "readme_linha": 2703,
+      "readme_linha": 2715,
       "tipo_fonte": "internacional"
     },
     {
@@ -9671,7 +9751,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2707,
+      "readme_linha": 2719,
       "tipo_fonte": "internacional"
     },
     {
@@ -9696,7 +9776,7 @@
         "multa",
         "veiculo"
       ],
-      "readme_linha": 2711,
+      "readme_linha": 2723,
       "tipo_fonte": "federal"
     },
     {
@@ -9722,7 +9802,7 @@
         "dados_cadastrais",
         "veiculo"
       ],
-      "readme_linha": 2715,
+      "readme_linha": 2727,
       "tipo_fonte": "federal"
     },
     {
@@ -9746,7 +9826,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2719,
+      "readme_linha": 2731,
       "tipo_fonte": "federal"
     },
     {
@@ -9770,7 +9850,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2723,
+      "readme_linha": 2735,
       "tipo_fonte": "privado"
     },
     {
@@ -9794,7 +9874,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2729,
+      "readme_linha": 2741,
       "tipo_fonte": "federal"
     },
     {
@@ -9818,7 +9898,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2735,
+      "readme_linha": 2747,
       "tipo_fonte": "federal"
     },
     {
@@ -9843,7 +9923,7 @@
         "dataset",
         "veiculo"
       ],
-      "readme_linha": 2741,
+      "readme_linha": 2753,
       "tipo_fonte": "federal"
     },
     {
@@ -9872,7 +9952,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2747,
+      "readme_linha": 2759,
       "tipo_fonte": "estadual"
     },
     {
@@ -9901,7 +9981,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2754,
+      "readme_linha": 2766,
       "tipo_fonte": "estadual"
     },
     {
@@ -10070,7 +10150,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2761,
+      "readme_linha": 2773,
       "tipo_fonte": "estadual"
     },
     {
@@ -10094,7 +10174,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 2831,
+      "readme_linha": 2843,
       "tipo_fonte": "privado"
     },
     {
@@ -10117,7 +10197,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2837,
+      "readme_linha": 2849,
       "tipo_fonte": "privado"
     },
     {
@@ -10160,7 +10240,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2843,
+      "readme_linha": 2855,
       "tipo_fonte": "estadual"
     },
     {
@@ -10183,7 +10263,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2863,
+      "readme_linha": 2875,
       "tipo_fonte": "privado"
     },
     {
@@ -10206,7 +10286,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2869,
+      "readme_linha": 2881,
       "tipo_fonte": "privado"
     },
     {
@@ -10229,7 +10309,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2875,
+      "readme_linha": 2887,
       "tipo_fonte": "privado"
     },
     {
@@ -10254,7 +10334,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 2887,
+      "readme_linha": 2899,
       "tipo_fonte": "federal"
     },
     {
@@ -10280,7 +10360,7 @@
         "estatistica",
         "multa"
       ],
-      "readme_linha": 2891,
+      "readme_linha": 2903,
       "tipo_fonte": "privado"
     },
     {
@@ -10303,7 +10383,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2895,
+      "readme_linha": 2907,
       "tipo_fonte": "federal"
     },
     {
@@ -10326,7 +10406,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2899,
+      "readme_linha": 2911,
       "tipo_fonte": "federal"
     },
     {
@@ -10349,7 +10429,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2903,
+      "readme_linha": 2915,
       "tipo_fonte": "federal"
     },
     {
@@ -10372,7 +10452,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2907,
+      "readme_linha": 2919,
       "tipo_fonte": "federal"
     },
     {
@@ -10400,7 +10480,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2911,
+      "readme_linha": 2923,
       "tipo_fonte": "internacional"
     },
     {
@@ -10423,7 +10503,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2916,
+      "readme_linha": 2928,
       "tipo_fonte": "privado"
     },
     {
@@ -10446,7 +10526,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2920,
+      "readme_linha": 2932,
       "tipo_fonte": "privado"
     },
     {
@@ -10469,7 +10549,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2924,
+      "readme_linha": 2936,
       "tipo_fonte": "privado"
     },
     {
@@ -10492,7 +10572,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2934,
+      "readme_linha": 2946,
       "tipo_fonte": "federal"
     },
     {
@@ -10518,7 +10598,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 2940,
+      "readme_linha": 2952,
       "tipo_fonte": "privado"
     },
     {
@@ -10541,7 +10621,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2946,
+      "readme_linha": 2958,
       "tipo_fonte": "federal"
     },
     {
@@ -10566,7 +10646,7 @@
         "dados_cadastrais",
         "multa"
       ],
-      "readme_linha": 2952,
+      "readme_linha": 2964,
       "tipo_fonte": "federal"
     },
     {
@@ -10644,7 +10724,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2956,
+      "readme_linha": 2968,
       "tipo_fonte": "federal"
     },
     {
@@ -10667,7 +10747,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2984,
+      "readme_linha": 2996,
       "tipo_fonte": "estadual"
     },
     {
@@ -10690,7 +10770,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2990,
+      "readme_linha": 3002,
       "tipo_fonte": "privado"
     },
     {
@@ -10713,7 +10793,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2994,
+      "readme_linha": 3006,
       "tipo_fonte": "estadual"
     },
     {
@@ -10736,7 +10816,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2998,
+      "readme_linha": 3010,
       "tipo_fonte": "internacional"
     },
     {
@@ -10779,7 +10859,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3002,
+      "readme_linha": 3014,
       "tipo_fonte": "privado"
     },
     {
@@ -10827,7 +10907,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3017,
+      "readme_linha": 3029,
       "tipo_fonte": "privado"
     },
     {
@@ -10930,7 +11010,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3031,
+      "readme_linha": 3043,
       "tipo_fonte": "privado"
     },
     {
@@ -10953,7 +11033,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3072,
+      "readme_linha": 3084,
       "tipo_fonte": "privado"
     },
     {
@@ -11001,7 +11081,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3076,
+      "readme_linha": 3088,
       "tipo_fonte": "estadual"
     },
     {
@@ -11324,7 +11404,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3090,
+      "readme_linha": 3102,
       "tipo_fonte": "privado"
     },
     {
@@ -11347,7 +11427,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3165,
+      "readme_linha": 3177,
       "tipo_fonte": "privado"
     },
     {
@@ -11370,7 +11450,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3169,
+      "readme_linha": 3181,
       "tipo_fonte": "privado"
     },
     {
@@ -11393,7 +11473,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3173,
+      "readme_linha": 3185,
       "tipo_fonte": "estadual"
     },
     {
@@ -11416,7 +11496,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3177,
+      "readme_linha": 3189,
       "tipo_fonte": "federal"
     },
     {
@@ -11445,7 +11525,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3181,
+      "readme_linha": 3193,
       "tipo_fonte": "internacional"
     },
     {
@@ -11469,7 +11549,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3186,
+      "readme_linha": 3198,
       "tipo_fonte": "internacional"
     },
     {
@@ -11493,7 +11573,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3190,
+      "readme_linha": 3202,
       "tipo_fonte": "internacional"
     },
     {
@@ -11517,7 +11597,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3194,
+      "readme_linha": 3206,
       "tipo_fonte": "internacional"
     },
     {
@@ -11541,7 +11621,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3198,
+      "readme_linha": 3210,
       "tipo_fonte": "internacional"
     },
     {
@@ -11565,7 +11645,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3202,
+      "readme_linha": 3214,
       "tipo_fonte": "internacional"
     },
     {
@@ -11589,7 +11669,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3206,
+      "readme_linha": 3218,
       "tipo_fonte": "internacional"
     },
     {
@@ -11613,7 +11693,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3210,
+      "readme_linha": 3222,
       "tipo_fonte": "internacional"
     },
     {
@@ -11636,7 +11716,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3214,
+      "readme_linha": 3226,
       "tipo_fonte": "estadual"
     },
     {
@@ -11710,7 +11790,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3224,
+      "readme_linha": 3236,
       "tipo_fonte": "ministerio_publico"
     },
     {
@@ -11770,7 +11850,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3265,
+      "readme_linha": 3277,
       "tipo_fonte": "defensoria"
     },
     {
@@ -11804,7 +11884,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3297,
+      "readme_linha": 3309,
       "tipo_fonte": "ong"
     },
     {
@@ -11833,7 +11913,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3314,
+      "readme_linha": 3326,
       "tipo_fonte": "estadual"
     },
     {
@@ -11862,7 +11942,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3334,
+      "readme_linha": 3346,
       "tipo_fonte": "privado"
     },
     {
@@ -11911,7 +11991,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3339,
+      "readme_linha": 3351,
       "tipo_fonte": "estadual"
     },
     {
@@ -11936,7 +12016,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 3358,
+      "readme_linha": 3370,
       "tipo_fonte": "federal"
     },
     {
@@ -11961,7 +12041,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3362,
+      "readme_linha": 3374,
       "tipo_fonte": "ong"
     },
     {
@@ -11986,7 +12066,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3366,
+      "readme_linha": 3378,
       "tipo_fonte": "federal"
     },
     {
@@ -12009,7 +12089,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3370,
+      "readme_linha": 3382,
       "tipo_fonte": "privado"
     },
     {
@@ -12034,7 +12114,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3374,
+      "readme_linha": 3386,
       "tipo_fonte": "federal"
     },
     {
@@ -12057,7 +12137,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3378,
+      "readme_linha": 3390,
       "tipo_fonte": "federal"
     },
     {
@@ -12078,7 +12158,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3382,
+      "readme_linha": 3394,
       "tipo_fonte": "federal"
     },
     {
@@ -12106,7 +12186,7 @@
         "mandado_prisao",
         "veiculo"
       ],
-      "readme_linha": 3386,
+      "readme_linha": 3398,
       "tipo_fonte": "federal"
     },
     {
@@ -12147,7 +12227,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3395,
+      "readme_linha": 3407,
       "tipo_fonte": "privado"
     },
     {
@@ -12178,7 +12258,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3414,
+      "readme_linha": 3426,
       "tipo_fonte": "privado"
     },
     {
@@ -12207,7 +12287,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3428,
+      "readme_linha": 3440,
       "tipo_fonte": "privado"
     },
     {
@@ -12235,7 +12315,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3455,
+      "readme_linha": 3467,
       "tipo_fonte": "privado"
     },
     {
@@ -12265,7 +12345,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3477,
+      "readme_linha": 3489,
       "tipo_fonte": "privado"
     },
     {
@@ -12292,7 +12372,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3501,
+      "readme_linha": 3513,
       "tipo_fonte": "federal"
     },
     {
@@ -12319,7 +12399,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3524,
+      "readme_linha": 3536,
       "tipo_fonte": "federal"
     },
     {
@@ -12349,7 +12429,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3528,
+      "readme_linha": 3540,
       "tipo_fonte": "ong"
     },
     {
@@ -12375,7 +12455,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3551,
+      "readme_linha": 3563,
       "tipo_fonte": "federal"
     },
     {
@@ -12399,7 +12479,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3555,
+      "readme_linha": 3567,
       "tipo_fonte": "federal"
     },
     {
@@ -12422,7 +12502,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3565,
+      "readme_linha": 3577,
       "tipo_fonte": "federal"
     },
     {
@@ -12445,7 +12525,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3569,
+      "readme_linha": 3581,
       "tipo_fonte": "federal"
     },
     {
@@ -12474,7 +12554,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3573,
+      "readme_linha": 3585,
       "tipo_fonte": "federal"
     },
     {
@@ -12502,7 +12582,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3578,
+      "readme_linha": 3590,
       "tipo_fonte": "federal"
     },
     {
@@ -12525,7 +12605,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3583,
+      "readme_linha": 3595,
       "tipo_fonte": "federal"
     },
     {
@@ -12548,7 +12628,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3587,
+      "readme_linha": 3599,
       "tipo_fonte": "federal"
     },
     {
@@ -12577,7 +12657,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3597,
+      "readme_linha": 3609,
       "tipo_fonte": "federal"
     },
     {
@@ -12601,7 +12681,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3602,
+      "readme_linha": 3614,
       "tipo_fonte": "federal"
     },
     {
@@ -12625,7 +12705,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3606,
+      "readme_linha": 3618,
       "tipo_fonte": "federal"
     },
     {
@@ -12655,7 +12735,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3610,
+      "readme_linha": 3622,
       "tipo_fonte": "ong"
     },
     {
@@ -12685,7 +12765,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3615,
+      "readme_linha": 3627,
       "tipo_fonte": "federal"
     },
     {
@@ -12710,7 +12790,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3620,
+      "readme_linha": 3632,
       "tipo_fonte": "federal"
     },
     {
@@ -12734,7 +12814,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3624,
+      "readme_linha": 3636,
       "tipo_fonte": "federal"
     },
     {
@@ -12758,7 +12838,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3628,
+      "readme_linha": 3640,
       "tipo_fonte": "federal"
     },
     {
@@ -12813,7 +12893,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3638,
+      "readme_linha": 3650,
       "tipo_fonte": "ong"
     },
     {
@@ -12937,7 +13017,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3677,
+      "readme_linha": 3689,
       "tipo_fonte": "estadual"
     },
     {
@@ -13057,7 +13137,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3718,
+      "readme_linha": 3730,
       "tipo_fonte": "ong"
     },
     {
@@ -13091,7 +13171,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3747,
+      "readme_linha": 3759,
       "tipo_fonte": "estadual"
     },
     {
@@ -13117,7 +13197,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3759,
+      "readme_linha": 3771,
       "tipo_fonte": "estadual"
     },
     {
@@ -13143,7 +13223,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3763,
+      "readme_linha": 3775,
       "tipo_fonte": "estadual"
     },
     {
@@ -13167,7 +13247,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3767,
+      "readme_linha": 3779,
       "tipo_fonte": "estadual"
     },
     {
@@ -13190,7 +13270,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3777,
+      "readme_linha": 3789,
       "tipo_fonte": "ong"
     },
     {
@@ -13213,7 +13293,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3781,
+      "readme_linha": 3793,
       "tipo_fonte": "federal"
     },
     {
@@ -13237,7 +13317,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3785,
+      "readme_linha": 3797,
       "tipo_fonte": "ong"
     },
     {
@@ -13260,7 +13340,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3789,
+      "readme_linha": 3801,
       "tipo_fonte": "federal"
     },
     {
@@ -13283,7 +13363,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3793,
+      "readme_linha": 3805,
       "tipo_fonte": "federal"
     },
     {
@@ -13311,7 +13391,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3797,
+      "readme_linha": 3809,
       "tipo_fonte": "privado"
     },
     {
@@ -13399,7 +13479,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3809,
+      "readme_linha": 3821,
       "tipo_fonte": "privado"
     },
     {
@@ -13450,7 +13530,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3831,
+      "readme_linha": 3843,
       "tipo_fonte": "privado"
     },
     {
@@ -13473,7 +13553,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3844,
+      "readme_linha": 3856,
       "tipo_fonte": "estadual"
     },
     {
@@ -13506,7 +13586,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3850,
+      "readme_linha": 3862,
       "tipo_fonte": "privado"
     },
     {
@@ -13530,7 +13610,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3861,
+      "readme_linha": 3873,
       "tipo_fonte": "privado"
     },
     {
@@ -13553,7 +13633,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3865,
+      "readme_linha": 3877,
       "tipo_fonte": "federal"
     },
     {
@@ -13587,7 +13667,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3871,
+      "readme_linha": 3883,
       "tipo_fonte": "privado"
     },
     {
@@ -13673,7 +13753,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3881,
+      "readme_linha": 3893,
       "tipo_fonte": "privado"
     },
     {
@@ -13697,7 +13777,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3930,
+      "readme_linha": 3942,
       "tipo_fonte": "estadual"
     },
     {
@@ -13731,9 +13811,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4093,
+      "readme_linha": 4105,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 434
+  "total": 437
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -3311,6 +3311,31 @@
     {
       "categoria": "Registros Ambientais",
       "categoria_id": "registros-ambientais",
+      "classificacao": "override",
+      "descricao": "Consulta da regularidade de pessoas físicas e jurídicas no Cadastro Técnico Federal de Atividades Potencialmente Poluidoras. Para consulta é necessário apenas o CPF ou CNPJ.",
+      "id": "registros-ambientais/ibama-certificado-de-regularidade-ctf",
+      "input": [
+        "cnpj",
+        "cpf"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://servicos.ibama.gov.br/ctf/publico/certificado_regularidade_consulta.php"
+        }
+      ],
+      "nome": "IBAMA - Certificado de Regularidade (CTF)",
+      "output": [
+        "certidao",
+        "situacao_cadastral"
+      ],
+      "readme_linha": 1006,
+      "tipo_fonte": "federal"
+    },
+    {
+      "categoria": "Registros Ambientais",
+      "categoria_id": "registros-ambientais",
       "classificacao": "heuristica",
       "descricao": "Consulta de licenças ambientais do Estado de São Paulo.",
       "id": "registros-ambientais/cetesb-licenciamento-ambiental-sao-paulo",
@@ -3329,7 +3354,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 1006,
+      "readme_linha": 1010,
       "tipo_fonte": "estadual"
     },
     {
@@ -3354,7 +3379,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 1010,
+      "readme_linha": 1014,
       "tipo_fonte": "ong"
     },
     {
@@ -3379,7 +3404,7 @@
         "estatistica",
         "licenca_ambiental"
       ],
-      "readme_linha": 1014,
+      "readme_linha": 1018,
       "tipo_fonte": "ong"
     },
     {
@@ -3404,7 +3429,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 1018,
+      "readme_linha": 1022,
       "tipo_fonte": "ong"
     },
     {
@@ -3427,7 +3452,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1028,
+      "readme_linha": 1032,
       "tipo_fonte": "federal"
     },
     {
@@ -3450,7 +3475,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1032,
+      "readme_linha": 1036,
       "tipo_fonte": "federal"
     },
     {
@@ -3473,7 +3498,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1036,
+      "readme_linha": 1040,
       "tipo_fonte": "federal"
     },
     {
@@ -3496,7 +3521,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1040,
+      "readme_linha": 1044,
       "tipo_fonte": "federal"
     },
     {
@@ -3520,7 +3545,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1050,
+      "readme_linha": 1054,
       "tipo_fonte": "federal"
     },
     {
@@ -3544,7 +3569,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1054,
+      "readme_linha": 1058,
       "tipo_fonte": "federal"
     },
     {
@@ -3568,7 +3593,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1058,
+      "readme_linha": 1062,
       "tipo_fonte": "federal"
     },
     {
@@ -3594,7 +3619,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1068,
+      "readme_linha": 1072,
       "tipo_fonte": "federal"
     },
     {
@@ -3620,7 +3645,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1072,
+      "readme_linha": 1076,
       "tipo_fonte": "federal"
     },
     {
@@ -3652,7 +3677,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1076,
+      "readme_linha": 1080,
       "tipo_fonte": "federal"
     },
     {
@@ -3679,7 +3704,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1117,
+      "readme_linha": 1121,
       "tipo_fonte": "federal"
     },
     {
@@ -3706,7 +3731,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1121,
+      "readme_linha": 1125,
       "tipo_fonte": "federal"
     },
     {
@@ -3732,7 +3757,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1125,
+      "readme_linha": 1129,
       "tipo_fonte": "federal"
     },
     {
@@ -3758,7 +3783,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1129,
+      "readme_linha": 1133,
       "tipo_fonte": "federal"
     },
     {
@@ -3784,7 +3809,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 1133,
+      "readme_linha": 1137,
       "tipo_fonte": "federal"
     },
     {
@@ -3812,7 +3837,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1137,
+      "readme_linha": 1141,
       "tipo_fonte": "federal"
     },
     {
@@ -3838,7 +3863,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1141,
+      "readme_linha": 1145,
       "tipo_fonte": "federal"
     },
     {
@@ -3905,7 +3930,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1145,
+      "readme_linha": 1149,
       "tipo_fonte": "federal"
     },
     {
@@ -3931,7 +3956,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1162,
+      "readme_linha": 1166,
       "tipo_fonte": "federal"
     },
     {
@@ -3957,7 +3982,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1166,
+      "readme_linha": 1170,
       "tipo_fonte": "federal"
     },
     {
@@ -3983,7 +4008,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1170,
+      "readme_linha": 1174,
       "tipo_fonte": "federal"
     },
     {
@@ -4009,7 +4034,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1174,
+      "readme_linha": 1178,
       "tipo_fonte": "federal"
     },
     {
@@ -4035,7 +4060,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1178,
+      "readme_linha": 1182,
       "tipo_fonte": "federal"
     },
     {
@@ -4061,7 +4086,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1182,
+      "readme_linha": 1186,
       "tipo_fonte": "federal"
     },
     {
@@ -4087,7 +4112,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1186,
+      "readme_linha": 1190,
       "tipo_fonte": "federal"
     },
     {
@@ -4114,7 +4139,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1190,
+      "readme_linha": 1194,
       "tipo_fonte": "federal"
     },
     {
@@ -4140,7 +4165,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1194,
+      "readme_linha": 1198,
       "tipo_fonte": "estadual"
     },
     {
@@ -4167,7 +4192,7 @@
         "remuneracao",
         "sancao"
       ],
-      "readme_linha": 1198,
+      "readme_linha": 1202,
       "tipo_fonte": "estadual"
     },
     {
@@ -4193,7 +4218,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1202,
+      "readme_linha": 1206,
       "tipo_fonte": "federal"
     },
     {
@@ -4264,7 +4289,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1206,
+      "readme_linha": 1210,
       "tipo_fonte": "estadual"
     },
     {
@@ -4290,7 +4315,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1250,
+      "readme_linha": 1254,
       "tipo_fonte": "federal"
     },
     {
@@ -4456,7 +4481,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1254,
+      "readme_linha": 1258,
       "tipo_fonte": "estadual"
     },
     {
@@ -4480,7 +4505,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1323,
+      "readme_linha": 1327,
       "tipo_fonte": "federal"
     },
     {
@@ -4504,7 +4529,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1327,
+      "readme_linha": 1331,
       "tipo_fonte": "federal"
     },
     {
@@ -4528,7 +4553,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1331,
+      "readme_linha": 1335,
       "tipo_fonte": "ong"
     },
     {
@@ -4682,7 +4707,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1335,
+      "readme_linha": 1339,
       "tipo_fonte": "estadual"
     },
     {
@@ -4708,7 +4733,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 1400,
+      "readme_linha": 1404,
       "tipo_fonte": "federal"
     },
     {
@@ -4732,7 +4757,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1404,
+      "readme_linha": 1408,
       "tipo_fonte": "federal"
     },
     {
@@ -4756,7 +4781,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1408,
+      "readme_linha": 1412,
       "tipo_fonte": "federal"
     },
     {
@@ -4780,7 +4805,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1412,
+      "readme_linha": 1416,
       "tipo_fonte": "federal"
     },
     {
@@ -4804,7 +4829,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1416,
+      "readme_linha": 1420,
       "tipo_fonte": "federal"
     },
     {
@@ -4828,7 +4853,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1420,
+      "readme_linha": 1424,
       "tipo_fonte": "federal"
     },
     {
@@ -4852,7 +4877,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1424,
+      "readme_linha": 1428,
       "tipo_fonte": "federal"
     },
     {
@@ -4876,7 +4901,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1428,
+      "readme_linha": 1432,
       "tipo_fonte": "federal"
     },
     {
@@ -4900,7 +4925,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1432,
+      "readme_linha": 1436,
       "tipo_fonte": "federal"
     },
     {
@@ -4924,7 +4949,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1436,
+      "readme_linha": 1440,
       "tipo_fonte": "federal"
     },
     {
@@ -4958,7 +4983,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1445,
+      "readme_linha": 1449,
       "tipo_fonte": "privado"
     },
     {
@@ -4986,7 +5011,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1458,
+      "readme_linha": 1462,
       "tipo_fonte": "privado"
     },
     {
@@ -5024,7 +5049,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1463,
+      "readme_linha": 1467,
       "tipo_fonte": "privado"
     },
     {
@@ -5048,7 +5073,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1475,
+      "readme_linha": 1479,
       "tipo_fonte": "privado"
     },
     {
@@ -5112,7 +5137,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1481,
+      "readme_linha": 1485,
       "tipo_fonte": "ong"
     },
     {
@@ -5137,7 +5162,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1499,
+      "readme_linha": 1503,
       "tipo_fonte": "federal"
     },
     {
@@ -5162,7 +5187,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1503,
+      "readme_linha": 1507,
       "tipo_fonte": "federal"
     },
     {
@@ -5186,7 +5211,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1507,
+      "readme_linha": 1511,
       "tipo_fonte": "federal"
     },
     {
@@ -5209,7 +5234,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1511,
+      "readme_linha": 1515,
       "tipo_fonte": "federal"
     },
     {
@@ -5232,7 +5257,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1515,
+      "readme_linha": 1519,
       "tipo_fonte": "federal"
     },
     {
@@ -5261,7 +5286,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1519,
+      "readme_linha": 1523,
       "tipo_fonte": "privado"
     },
     {
@@ -5285,7 +5310,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1524,
+      "readme_linha": 1528,
       "tipo_fonte": "federal"
     },
     {
@@ -5308,7 +5333,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1528,
+      "readme_linha": 1532,
       "tipo_fonte": "federal"
     },
     {
@@ -5333,7 +5358,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1532,
+      "readme_linha": 1536,
       "tipo_fonte": "federal"
     },
     {
@@ -5359,7 +5384,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1540,
+      "readme_linha": 1544,
       "tipo_fonte": "federal"
     },
     {
@@ -5384,7 +5409,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1546,
+      "readme_linha": 1550,
       "tipo_fonte": "federal"
     },
     {
@@ -5409,7 +5434,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1552,
+      "readme_linha": 1556,
       "tipo_fonte": "federal"
     },
     {
@@ -5434,7 +5459,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1558,
+      "readme_linha": 1562,
       "tipo_fonte": "federal"
     },
     {
@@ -5458,7 +5483,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1565,
+      "readme_linha": 1569,
       "tipo_fonte": "federal"
     },
     {
@@ -5481,7 +5506,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1572,
+      "readme_linha": 1576,
       "tipo_fonte": "federal"
     },
     {
@@ -5508,7 +5533,7 @@
         "outorga",
         "radiofrequencia"
       ],
-      "readme_linha": 1579,
+      "readme_linha": 1583,
       "tipo_fonte": "federal"
     },
     {
@@ -5533,7 +5558,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1586,
+      "readme_linha": 1590,
       "tipo_fonte": "federal"
     },
     {
@@ -5556,7 +5581,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1593,
+      "readme_linha": 1597,
       "tipo_fonte": "federal"
     },
     {
@@ -5580,7 +5605,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1600,
+      "readme_linha": 1604,
       "tipo_fonte": "federal"
     },
     {
@@ -5604,7 +5629,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1607,
+      "readme_linha": 1611,
       "tipo_fonte": "federal"
     },
     {
@@ -5628,7 +5653,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1620,
+      "readme_linha": 1624,
       "tipo_fonte": "federal"
     },
     {
@@ -5653,7 +5678,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1626,
+      "readme_linha": 1630,
       "tipo_fonte": "ong"
     },
     {
@@ -5686,7 +5711,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1632,
+      "readme_linha": 1636,
       "tipo_fonte": "privado"
     },
     {
@@ -5714,7 +5739,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1643,
+      "readme_linha": 1647,
       "tipo_fonte": "ong"
     },
     {
@@ -5785,7 +5810,7 @@
         "erb",
         "operadora"
       ],
-      "readme_linha": 1652,
+      "readme_linha": 1656,
       "tipo_fonte": "privado"
     },
     {
@@ -5809,7 +5834,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1678,
+      "readme_linha": 1682,
       "tipo_fonte": "privado"
     },
     {
@@ -5835,7 +5860,7 @@
         "processo",
         "publicacao_academica"
       ],
-      "readme_linha": 1684,
+      "readme_linha": 1688,
       "tipo_fonte": "federal"
     },
     {
@@ -5859,7 +5884,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1690,
+      "readme_linha": 1694,
       "tipo_fonte": "privado"
     },
     {
@@ -5883,7 +5908,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1694,
+      "readme_linha": 1698,
       "tipo_fonte": "academico"
     },
     {
@@ -5907,7 +5932,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1698,
+      "readme_linha": 1702,
       "tipo_fonte": "academico"
     },
     {
@@ -5931,7 +5956,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1702,
+      "readme_linha": 1706,
       "tipo_fonte": "academico"
     },
     {
@@ -5955,7 +5980,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1706,
+      "readme_linha": 1710,
       "tipo_fonte": "academico"
     },
     {
@@ -5979,7 +6004,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1710,
+      "readme_linha": 1714,
       "tipo_fonte": "federal"
     },
     {
@@ -6003,7 +6028,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1714,
+      "readme_linha": 1718,
       "tipo_fonte": "privado"
     },
     {
@@ -6027,7 +6052,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1718,
+      "readme_linha": 1722,
       "tipo_fonte": "federal"
     },
     {
@@ -6051,7 +6076,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1722,
+      "readme_linha": 1726,
       "tipo_fonte": "ong"
     },
     {
@@ -6076,7 +6101,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1726,
+      "readme_linha": 1730,
       "tipo_fonte": "federal"
     },
     {
@@ -6102,7 +6127,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1730,
+      "readme_linha": 1734,
       "tipo_fonte": "federal"
     },
     {
@@ -6127,7 +6152,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 1734,
+      "readme_linha": 1738,
       "tipo_fonte": "federal"
     },
     {
@@ -6151,7 +6176,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1738,
+      "readme_linha": 1742,
       "tipo_fonte": "federal"
     },
     {
@@ -6175,7 +6200,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1742,
+      "readme_linha": 1746,
       "tipo_fonte": "federal"
     },
     {
@@ -6199,7 +6224,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1746,
+      "readme_linha": 1750,
       "tipo_fonte": "federal"
     },
     {
@@ -6339,7 +6364,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1755,
+      "readme_linha": 1759,
       "tipo_fonte": "privado"
     },
     {
@@ -6370,7 +6395,7 @@
         "area_rural",
         "mapa"
       ],
-      "readme_linha": 1789,
+      "readme_linha": 1793,
       "tipo_fonte": "federal"
     },
     {
@@ -6394,7 +6419,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1796,
+      "readme_linha": 1800,
       "tipo_fonte": "federal"
     },
     {
@@ -6423,7 +6448,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1802,
+      "readme_linha": 1806,
       "tipo_fonte": "federal"
     },
     {
@@ -6447,7 +6472,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1809,
+      "readme_linha": 1813,
       "tipo_fonte": "privado"
     },
     {
@@ -6488,7 +6513,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1813,
+      "readme_linha": 1817,
       "tipo_fonte": "internacional"
     },
     {
@@ -6517,7 +6542,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1825,
+      "readme_linha": 1829,
       "tipo_fonte": "federal"
     },
     {
@@ -6542,7 +6567,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1832,
+      "readme_linha": 1836,
       "tipo_fonte": "federal"
     },
     {
@@ -6566,7 +6591,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1838,
+      "readme_linha": 1842,
       "tipo_fonte": "federal"
     },
     {
@@ -6605,7 +6630,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1842,
+      "readme_linha": 1846,
       "tipo_fonte": "federal"
     },
     {
@@ -6629,7 +6654,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1854,
+      "readme_linha": 1858,
       "tipo_fonte": "federal"
     },
     {
@@ -6653,7 +6678,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1858,
+      "readme_linha": 1862,
       "tipo_fonte": "federal"
     },
     {
@@ -6678,7 +6703,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1868,
+      "readme_linha": 1872,
       "tipo_fonte": "federal"
     },
     {
@@ -6703,7 +6728,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1875,
+      "readme_linha": 1879,
       "tipo_fonte": "federal"
     },
     {
@@ -6730,7 +6755,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1882,
+      "readme_linha": 1886,
       "tipo_fonte": "federal"
     },
     {
@@ -6759,7 +6784,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1889,
+      "readme_linha": 1893,
       "tipo_fonte": "federal"
     },
     {
@@ -6785,7 +6810,7 @@
         "mapa",
         "sancao"
       ],
-      "readme_linha": 1896,
+      "readme_linha": 1900,
       "tipo_fonte": "federal"
     },
     {
@@ -6810,7 +6835,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1903,
+      "readme_linha": 1907,
       "tipo_fonte": "federal"
     },
     {
@@ -6837,7 +6862,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1910,
+      "readme_linha": 1914,
       "tipo_fonte": "federal"
     },
     {
@@ -6863,7 +6888,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1917,
+      "readme_linha": 1921,
       "tipo_fonte": "privado"
     },
     {
@@ -6888,7 +6913,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1924,
+      "readme_linha": 1928,
       "tipo_fonte": "federal"
     },
     {
@@ -6915,7 +6940,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1931,
+      "readme_linha": 1935,
       "tipo_fonte": "federal"
     },
     {
@@ -6940,7 +6965,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1938,
+      "readme_linha": 1942,
       "tipo_fonte": "federal"
     },
     {
@@ -6966,7 +6991,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1945,
+      "readme_linha": 1949,
       "tipo_fonte": "federal"
     },
     {
@@ -6992,7 +7017,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1952,
+      "readme_linha": 1956,
       "tipo_fonte": "federal"
     },
     {
@@ -7017,7 +7042,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1959,
+      "readme_linha": 1963,
       "tipo_fonte": "federal"
     },
     {
@@ -7044,7 +7069,7 @@
         "mapa",
         "processo"
       ],
-      "readme_linha": 1966,
+      "readme_linha": 1970,
       "tipo_fonte": "federal"
     },
     {
@@ -7071,7 +7096,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1973,
+      "readme_linha": 1977,
       "tipo_fonte": "federal"
     },
     {
@@ -7095,7 +7120,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1984,
+      "readme_linha": 1988,
       "tipo_fonte": "federal"
     },
     {
@@ -7119,7 +7144,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1990,
+      "readme_linha": 1994,
       "tipo_fonte": "federal"
     },
     {
@@ -7144,7 +7169,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1994,
+      "readme_linha": 1998,
       "tipo_fonte": "federal"
     },
     {
@@ -7168,7 +7193,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1998,
+      "readme_linha": 2002,
       "tipo_fonte": "federal"
     },
     {
@@ -7192,7 +7217,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2002,
+      "readme_linha": 2006,
       "tipo_fonte": "federal"
     },
     {
@@ -7216,7 +7241,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2006,
+      "readme_linha": 2010,
       "tipo_fonte": "federal"
     },
     {
@@ -7245,7 +7270,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2010,
+      "readme_linha": 2014,
       "tipo_fonte": "federal"
     },
     {
@@ -7270,7 +7295,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 2015,
+      "readme_linha": 2019,
       "tipo_fonte": "ong"
     },
     {
@@ -7295,7 +7320,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 2019,
+      "readme_linha": 2023,
       "tipo_fonte": "academico"
     },
     {
@@ -7319,7 +7344,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2023,
+      "readme_linha": 2027,
       "tipo_fonte": "academico"
     },
     {
@@ -7353,7 +7378,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2027,
+      "readme_linha": 2031,
       "tipo_fonte": "federal"
     },
     {
@@ -7391,7 +7416,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2044,
+      "readme_linha": 2048,
       "tipo_fonte": "dork"
     },
     {
@@ -7419,7 +7444,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2057,
+      "readme_linha": 2061,
       "tipo_fonte": "dork"
     },
     {
@@ -7447,7 +7472,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2064,
+      "readme_linha": 2068,
       "tipo_fonte": "dork"
     },
     {
@@ -7480,7 +7505,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2073,
+      "readme_linha": 2077,
       "tipo_fonte": "dork"
     },
     {
@@ -7518,7 +7543,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2084,
+      "readme_linha": 2088,
       "tipo_fonte": "dork"
     },
     {
@@ -7557,7 +7582,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2097,
+      "readme_linha": 2101,
       "tipo_fonte": "dork"
     },
     {
@@ -7596,7 +7621,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2113,
+      "readme_linha": 2117,
       "tipo_fonte": "internacional"
     },
     {
@@ -7630,7 +7655,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2125,
+      "readme_linha": 2129,
       "tipo_fonte": "internacional"
     },
     {
@@ -7658,7 +7683,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2132,
+      "readme_linha": 2136,
       "tipo_fonte": "dork"
     },
     {
@@ -7706,7 +7731,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2139,
+      "readme_linha": 2143,
       "tipo_fonte": "dork"
     },
     {
@@ -7744,7 +7769,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2159,
+      "readme_linha": 2163,
       "tipo_fonte": "dork"
     },
     {
@@ -7783,7 +7808,7 @@
         "dork",
         "video_ao_vivo"
       ],
-      "readme_linha": 2174,
+      "readme_linha": 2178,
       "tipo_fonte": "dork"
     },
     {
@@ -7824,7 +7849,7 @@
         "dork",
         "operadora"
       ],
-      "readme_linha": 2189,
+      "readme_linha": 2193,
       "tipo_fonte": "dork"
     },
     {
@@ -7858,7 +7883,7 @@
         "dork",
         "publicacao_academica"
       ],
-      "readme_linha": 2204,
+      "readme_linha": 2208,
       "tipo_fonte": "dork"
     },
     {
@@ -7891,7 +7916,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2216,
+      "readme_linha": 2220,
       "tipo_fonte": "dork"
     },
     {
@@ -7919,7 +7944,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2228,
+      "readme_linha": 2232,
       "tipo_fonte": "dork"
     },
     {
@@ -7948,7 +7973,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2238,
+      "readme_linha": 2242,
       "tipo_fonte": "internacional"
     },
     {
@@ -7991,7 +8016,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2250,
+      "readme_linha": 2254,
       "tipo_fonte": "dork"
     },
     {
@@ -8016,7 +8041,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2274,
+      "readme_linha": 2278,
       "tipo_fonte": "internacional"
     },
     {
@@ -8051,7 +8076,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2280,
+      "readme_linha": 2284,
       "tipo_fonte": "internacional"
     },
     {
@@ -8081,7 +8106,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2291,
+      "readme_linha": 2295,
       "tipo_fonte": "internacional"
     },
     {
@@ -8106,7 +8131,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2299,
+      "readme_linha": 2303,
       "tipo_fonte": "internacional"
     },
     {
@@ -8132,7 +8157,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2305,
+      "readme_linha": 2309,
       "tipo_fonte": "internacional"
     },
     {
@@ -8158,7 +8183,7 @@
         "estatistica",
         "perfil_social"
       ],
-      "readme_linha": 2311,
+      "readme_linha": 2315,
       "tipo_fonte": "internacional"
     },
     {
@@ -8183,7 +8208,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2317,
+      "readme_linha": 2321,
       "tipo_fonte": "internacional"
     },
     {
@@ -8208,7 +8233,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2323,
+      "readme_linha": 2327,
       "tipo_fonte": "internacional"
     },
     {
@@ -8233,7 +8258,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2327,
+      "readme_linha": 2331,
       "tipo_fonte": "internacional"
     },
     {
@@ -8258,7 +8283,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2331,
+      "readme_linha": 2335,
       "tipo_fonte": "internacional"
     },
     {
@@ -8283,7 +8308,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2335,
+      "readme_linha": 2339,
       "tipo_fonte": "internacional"
     },
     {
@@ -8308,7 +8333,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2339,
+      "readme_linha": 2343,
       "tipo_fonte": "internacional"
     },
     {
@@ -8333,7 +8358,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2343,
+      "readme_linha": 2347,
       "tipo_fonte": "internacional"
     },
     {
@@ -8359,7 +8384,7 @@
         "mandado_prisao",
         "perfil_social"
       ],
-      "readme_linha": 2349,
+      "readme_linha": 2353,
       "tipo_fonte": "privado"
     },
     {
@@ -8389,7 +8414,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2355,
+      "readme_linha": 2359,
       "tipo_fonte": "privado"
     },
     {
@@ -8419,7 +8444,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2362,
+      "readme_linha": 2366,
       "tipo_fonte": "internacional"
     },
     {
@@ -8445,7 +8470,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2368,
+      "readme_linha": 2372,
       "tipo_fonte": "internacional"
     },
     {
@@ -8470,7 +8495,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2375,
+      "readme_linha": 2379,
       "tipo_fonte": "privado"
     },
     {
@@ -8495,7 +8520,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2381,
+      "readme_linha": 2385,
       "tipo_fonte": "internacional"
     },
     {
@@ -8578,7 +8603,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2394,
+      "readme_linha": 2398,
       "tipo_fonte": "privado"
     },
     {
@@ -8641,7 +8666,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2419,
+      "readme_linha": 2423,
       "tipo_fonte": "privado"
     },
     {
@@ -8664,7 +8689,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2446,
+      "readme_linha": 2450,
       "tipo_fonte": "federal"
     },
     {
@@ -8687,7 +8712,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2452,
+      "readme_linha": 2456,
       "tipo_fonte": "privado"
     },
     {
@@ -8710,7 +8735,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2458,
+      "readme_linha": 2462,
       "tipo_fonte": "federal"
     },
     {
@@ -8733,7 +8758,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2464,
+      "readme_linha": 2468,
       "tipo_fonte": "privado"
     },
     {
@@ -8756,7 +8781,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2470,
+      "readme_linha": 2474,
       "tipo_fonte": "federal"
     },
     {
@@ -8779,7 +8804,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2476,
+      "readme_linha": 2480,
       "tipo_fonte": "federal"
     },
     {
@@ -8802,7 +8827,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2482,
+      "readme_linha": 2486,
       "tipo_fonte": "federal"
     },
     {
@@ -8826,7 +8851,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2488,
+      "readme_linha": 2492,
       "tipo_fonte": "federal"
     },
     {
@@ -8855,7 +8880,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 2492,
+      "readme_linha": 2496,
       "tipo_fonte": "federal"
     },
     {
@@ -8878,7 +8903,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2499,
+      "readme_linha": 2503,
       "tipo_fonte": "federal"
     },
     {
@@ -8901,7 +8926,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2503,
+      "readme_linha": 2507,
       "tipo_fonte": "federal"
     },
     {
@@ -8925,7 +8950,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2509,
+      "readme_linha": 2513,
       "tipo_fonte": "federal"
     },
     {
@@ -8948,7 +8973,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2515,
+      "readme_linha": 2519,
       "tipo_fonte": "estadual"
     },
     {
@@ -8972,7 +8997,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2521,
+      "readme_linha": 2525,
       "tipo_fonte": "estadual"
     },
     {
@@ -8996,7 +9021,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2527,
+      "readme_linha": 2531,
       "tipo_fonte": "federal"
     },
     {
@@ -9019,7 +9044,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2533,
+      "readme_linha": 2537,
       "tipo_fonte": "federal"
     },
     {
@@ -9042,7 +9067,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2539,
+      "readme_linha": 2543,
       "tipo_fonte": "estadual"
     },
     {
@@ -9066,7 +9091,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2545,
+      "readme_linha": 2549,
       "tipo_fonte": "federal"
     },
     {
@@ -9089,7 +9114,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2551,
+      "readme_linha": 2555,
       "tipo_fonte": "estadual"
     },
     {
@@ -9112,7 +9137,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2557,
+      "readme_linha": 2561,
       "tipo_fonte": "estadual"
     },
     {
@@ -9135,7 +9160,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2563,
+      "readme_linha": 2567,
       "tipo_fonte": "federal"
     },
     {
@@ -9158,7 +9183,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2569,
+      "readme_linha": 2573,
       "tipo_fonte": "estadual"
     },
     {
@@ -9181,7 +9206,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2575,
+      "readme_linha": 2579,
       "tipo_fonte": "estadual"
     },
     {
@@ -9204,7 +9229,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2579,
+      "readme_linha": 2583,
       "tipo_fonte": "federal"
     },
     {
@@ -9227,7 +9252,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2585,
+      "readme_linha": 2589,
       "tipo_fonte": "federal"
     },
     {
@@ -9250,7 +9275,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2591,
+      "readme_linha": 2595,
       "tipo_fonte": "estadual"
     },
     {
@@ -9273,7 +9298,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2597,
+      "readme_linha": 2601,
       "tipo_fonte": "federal"
     },
     {
@@ -9301,7 +9326,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2603,
+      "readme_linha": 2607,
       "tipo_fonte": "federal"
     },
     {
@@ -9326,7 +9351,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2610,
+      "readme_linha": 2614,
       "tipo_fonte": "estadual"
     },
     {
@@ -9349,7 +9374,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2614,
+      "readme_linha": 2618,
       "tipo_fonte": "federal"
     },
     {
@@ -9373,7 +9398,7 @@
         "dataset",
         "diario_oficial"
       ],
-      "readme_linha": 2618,
+      "readme_linha": 2622,
       "tipo_fonte": "ong"
     },
     {
@@ -9396,7 +9421,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2624,
+      "readme_linha": 2628,
       "tipo_fonte": "ong"
     },
     {
@@ -9419,7 +9444,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2628,
+      "readme_linha": 2632,
       "tipo_fonte": "federal"
     },
     {
@@ -9442,7 +9467,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2632,
+      "readme_linha": 2636,
       "tipo_fonte": "federal"
     },
     {
@@ -9465,7 +9490,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2636,
+      "readme_linha": 2640,
       "tipo_fonte": "privado"
     },
     {
@@ -9488,7 +9513,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2640,
+      "readme_linha": 2644,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9511,7 +9536,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2644,
+      "readme_linha": 2648,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9535,7 +9560,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2648,
+      "readme_linha": 2652,
       "tipo_fonte": "federal"
     },
     {
@@ -9558,7 +9583,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2652,
+      "readme_linha": 2656,
       "tipo_fonte": "federal"
     },
     {
@@ -9582,7 +9607,7 @@
         "dataset",
         "endereco"
       ],
-      "readme_linha": 2656,
+      "readme_linha": 2660,
       "tipo_fonte": "privado"
     },
     {
@@ -9607,7 +9632,7 @@
         "beneficio",
         "remuneracao"
       ],
-      "readme_linha": 2666,
+      "readme_linha": 2670,
       "tipo_fonte": "ong"
     },
     {
@@ -9631,7 +9656,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2674,
+      "readme_linha": 2678,
       "tipo_fonte": "estadual"
     },
     {
@@ -9655,7 +9680,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2678,
+      "readme_linha": 2682,
       "tipo_fonte": "estadual"
     },
     {
@@ -9754,7 +9779,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2684,
+      "readme_linha": 2688,
       "tipo_fonte": "privado"
     },
     {
@@ -9813,7 +9838,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2707,
+      "readme_linha": 2711,
       "tipo_fonte": "ong"
     },
     {
@@ -9842,7 +9867,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2722,
+      "readme_linha": 2726,
       "tipo_fonte": "privado"
     },
     {
@@ -9866,7 +9891,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2729,
+      "readme_linha": 2733,
       "tipo_fonte": "privado"
     },
     {
@@ -9890,7 +9915,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2735,
+      "readme_linha": 2739,
       "tipo_fonte": "federal"
     },
     {
@@ -9914,7 +9939,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2741,
+      "readme_linha": 2745,
       "tipo_fonte": "federal"
     },
     {
@@ -9939,7 +9964,7 @@
         "veiculo",
         "video_ao_vivo"
       ],
-      "readme_linha": 2747,
+      "readme_linha": 2751,
       "tipo_fonte": "internacional"
     },
     {
@@ -9963,7 +9988,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2751,
+      "readme_linha": 2755,
       "tipo_fonte": "internacional"
     },
     {
@@ -9988,7 +10013,7 @@
         "multa",
         "veiculo"
       ],
-      "readme_linha": 2755,
+      "readme_linha": 2759,
       "tipo_fonte": "federal"
     },
     {
@@ -10014,7 +10039,7 @@
         "dados_cadastrais",
         "veiculo"
       ],
-      "readme_linha": 2759,
+      "readme_linha": 2763,
       "tipo_fonte": "federal"
     },
     {
@@ -10038,7 +10063,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2763,
+      "readme_linha": 2767,
       "tipo_fonte": "federal"
     },
     {
@@ -10062,7 +10087,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2767,
+      "readme_linha": 2771,
       "tipo_fonte": "privado"
     },
     {
@@ -10086,7 +10111,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2773,
+      "readme_linha": 2777,
       "tipo_fonte": "federal"
     },
     {
@@ -10110,7 +10135,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2779,
+      "readme_linha": 2783,
       "tipo_fonte": "federal"
     },
     {
@@ -10135,7 +10160,7 @@
         "dataset",
         "veiculo"
       ],
-      "readme_linha": 2785,
+      "readme_linha": 2789,
       "tipo_fonte": "federal"
     },
     {
@@ -10164,7 +10189,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2791,
+      "readme_linha": 2795,
       "tipo_fonte": "estadual"
     },
     {
@@ -10193,7 +10218,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2798,
+      "readme_linha": 2802,
       "tipo_fonte": "estadual"
     },
     {
@@ -10362,7 +10387,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2805,
+      "readme_linha": 2809,
       "tipo_fonte": "estadual"
     },
     {
@@ -10386,7 +10411,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 2875,
+      "readme_linha": 2879,
       "tipo_fonte": "privado"
     },
     {
@@ -10409,7 +10434,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2881,
+      "readme_linha": 2885,
       "tipo_fonte": "privado"
     },
     {
@@ -10452,7 +10477,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2887,
+      "readme_linha": 2891,
       "tipo_fonte": "estadual"
     },
     {
@@ -10475,7 +10500,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2907,
+      "readme_linha": 2911,
       "tipo_fonte": "privado"
     },
     {
@@ -10498,7 +10523,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2913,
+      "readme_linha": 2917,
       "tipo_fonte": "privado"
     },
     {
@@ -10521,7 +10546,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2919,
+      "readme_linha": 2923,
       "tipo_fonte": "privado"
     },
     {
@@ -10546,7 +10571,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 2931,
+      "readme_linha": 2935,
       "tipo_fonte": "federal"
     },
     {
@@ -10572,7 +10597,7 @@
         "estatistica",
         "multa"
       ],
-      "readme_linha": 2935,
+      "readme_linha": 2939,
       "tipo_fonte": "privado"
     },
     {
@@ -10595,7 +10620,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2939,
+      "readme_linha": 2943,
       "tipo_fonte": "federal"
     },
     {
@@ -10618,7 +10643,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2943,
+      "readme_linha": 2947,
       "tipo_fonte": "federal"
     },
     {
@@ -10641,7 +10666,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2947,
+      "readme_linha": 2951,
       "tipo_fonte": "federal"
     },
     {
@@ -10664,7 +10689,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2951,
+      "readme_linha": 2955,
       "tipo_fonte": "federal"
     },
     {
@@ -10692,7 +10717,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2955,
+      "readme_linha": 2959,
       "tipo_fonte": "internacional"
     },
     {
@@ -10715,7 +10740,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2960,
+      "readme_linha": 2964,
       "tipo_fonte": "privado"
     },
     {
@@ -10738,7 +10763,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2964,
+      "readme_linha": 2968,
       "tipo_fonte": "privado"
     },
     {
@@ -10761,7 +10786,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2968,
+      "readme_linha": 2972,
       "tipo_fonte": "privado"
     },
     {
@@ -10784,7 +10809,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2978,
+      "readme_linha": 2982,
       "tipo_fonte": "federal"
     },
     {
@@ -10810,7 +10835,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 2984,
+      "readme_linha": 2988,
       "tipo_fonte": "privado"
     },
     {
@@ -10833,7 +10858,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2990,
+      "readme_linha": 2994,
       "tipo_fonte": "federal"
     },
     {
@@ -10858,7 +10883,7 @@
         "dados_cadastrais",
         "multa"
       ],
-      "readme_linha": 2996,
+      "readme_linha": 3000,
       "tipo_fonte": "federal"
     },
     {
@@ -10936,7 +10961,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3000,
+      "readme_linha": 3004,
       "tipo_fonte": "federal"
     },
     {
@@ -10959,7 +10984,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3028,
+      "readme_linha": 3032,
       "tipo_fonte": "estadual"
     },
     {
@@ -10982,7 +11007,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3034,
+      "readme_linha": 3038,
       "tipo_fonte": "privado"
     },
     {
@@ -11005,7 +11030,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3038,
+      "readme_linha": 3042,
       "tipo_fonte": "estadual"
     },
     {
@@ -11028,7 +11053,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3042,
+      "readme_linha": 3046,
       "tipo_fonte": "internacional"
     },
     {
@@ -11071,7 +11096,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3046,
+      "readme_linha": 3050,
       "tipo_fonte": "privado"
     },
     {
@@ -11119,7 +11144,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3061,
+      "readme_linha": 3065,
       "tipo_fonte": "privado"
     },
     {
@@ -11222,7 +11247,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3075,
+      "readme_linha": 3079,
       "tipo_fonte": "privado"
     },
     {
@@ -11245,7 +11270,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3116,
+      "readme_linha": 3120,
       "tipo_fonte": "privado"
     },
     {
@@ -11293,7 +11318,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3120,
+      "readme_linha": 3124,
       "tipo_fonte": "estadual"
     },
     {
@@ -11616,7 +11641,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3134,
+      "readme_linha": 3138,
       "tipo_fonte": "privado"
     },
     {
@@ -11639,7 +11664,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3209,
+      "readme_linha": 3213,
       "tipo_fonte": "privado"
     },
     {
@@ -11662,7 +11687,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3213,
+      "readme_linha": 3217,
       "tipo_fonte": "privado"
     },
     {
@@ -11685,7 +11710,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3217,
+      "readme_linha": 3221,
       "tipo_fonte": "estadual"
     },
     {
@@ -11708,7 +11733,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3221,
+      "readme_linha": 3225,
       "tipo_fonte": "federal"
     },
     {
@@ -11737,7 +11762,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3225,
+      "readme_linha": 3229,
       "tipo_fonte": "internacional"
     },
     {
@@ -11761,7 +11786,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3230,
+      "readme_linha": 3234,
       "tipo_fonte": "internacional"
     },
     {
@@ -11785,7 +11810,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3234,
+      "readme_linha": 3238,
       "tipo_fonte": "internacional"
     },
     {
@@ -11809,7 +11834,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3238,
+      "readme_linha": 3242,
       "tipo_fonte": "internacional"
     },
     {
@@ -11833,7 +11858,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3242,
+      "readme_linha": 3246,
       "tipo_fonte": "internacional"
     },
     {
@@ -11857,7 +11882,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3246,
+      "readme_linha": 3250,
       "tipo_fonte": "internacional"
     },
     {
@@ -11881,7 +11906,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3250,
+      "readme_linha": 3254,
       "tipo_fonte": "internacional"
     },
     {
@@ -11905,7 +11930,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3254,
+      "readme_linha": 3258,
       "tipo_fonte": "internacional"
     },
     {
@@ -11928,7 +11953,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3258,
+      "readme_linha": 3262,
       "tipo_fonte": "estadual"
     },
     {
@@ -12002,7 +12027,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3268,
+      "readme_linha": 3272,
       "tipo_fonte": "ministerio_publico"
     },
     {
@@ -12062,7 +12087,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3309,
+      "readme_linha": 3313,
       "tipo_fonte": "defensoria"
     },
     {
@@ -12096,7 +12121,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3341,
+      "readme_linha": 3345,
       "tipo_fonte": "ong"
     },
     {
@@ -12125,7 +12150,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3358,
+      "readme_linha": 3362,
       "tipo_fonte": "estadual"
     },
     {
@@ -12154,7 +12179,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3378,
+      "readme_linha": 3382,
       "tipo_fonte": "privado"
     },
     {
@@ -12203,7 +12228,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3383,
+      "readme_linha": 3387,
       "tipo_fonte": "estadual"
     },
     {
@@ -12228,7 +12253,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 3402,
+      "readme_linha": 3406,
       "tipo_fonte": "federal"
     },
     {
@@ -12253,7 +12278,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3406,
+      "readme_linha": 3410,
       "tipo_fonte": "ong"
     },
     {
@@ -12278,7 +12303,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3410,
+      "readme_linha": 3414,
       "tipo_fonte": "federal"
     },
     {
@@ -12301,7 +12326,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3414,
+      "readme_linha": 3418,
       "tipo_fonte": "privado"
     },
     {
@@ -12326,7 +12351,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3418,
+      "readme_linha": 3422,
       "tipo_fonte": "federal"
     },
     {
@@ -12349,7 +12374,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3422,
+      "readme_linha": 3426,
       "tipo_fonte": "federal"
     },
     {
@@ -12370,7 +12395,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3426,
+      "readme_linha": 3430,
       "tipo_fonte": "federal"
     },
     {
@@ -12398,7 +12423,7 @@
         "mandado_prisao",
         "veiculo"
       ],
-      "readme_linha": 3430,
+      "readme_linha": 3434,
       "tipo_fonte": "federal"
     },
     {
@@ -12439,7 +12464,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3439,
+      "readme_linha": 3443,
       "tipo_fonte": "privado"
     },
     {
@@ -12470,7 +12495,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3458,
+      "readme_linha": 3462,
       "tipo_fonte": "privado"
     },
     {
@@ -12499,7 +12524,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3472,
+      "readme_linha": 3476,
       "tipo_fonte": "privado"
     },
     {
@@ -12527,7 +12552,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3499,
+      "readme_linha": 3503,
       "tipo_fonte": "privado"
     },
     {
@@ -12557,7 +12582,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3521,
+      "readme_linha": 3525,
       "tipo_fonte": "privado"
     },
     {
@@ -12584,7 +12609,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3545,
+      "readme_linha": 3549,
       "tipo_fonte": "federal"
     },
     {
@@ -12611,7 +12636,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3568,
+      "readme_linha": 3572,
       "tipo_fonte": "federal"
     },
     {
@@ -12641,7 +12666,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3572,
+      "readme_linha": 3576,
       "tipo_fonte": "ong"
     },
     {
@@ -12667,7 +12692,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3595,
+      "readme_linha": 3599,
       "tipo_fonte": "federal"
     },
     {
@@ -12691,7 +12716,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3599,
+      "readme_linha": 3603,
       "tipo_fonte": "federal"
     },
     {
@@ -12714,7 +12739,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3609,
+      "readme_linha": 3613,
       "tipo_fonte": "federal"
     },
     {
@@ -12737,7 +12762,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3613,
+      "readme_linha": 3617,
       "tipo_fonte": "federal"
     },
     {
@@ -12766,7 +12791,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3617,
+      "readme_linha": 3621,
       "tipo_fonte": "federal"
     },
     {
@@ -12794,7 +12819,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3622,
+      "readme_linha": 3626,
       "tipo_fonte": "federal"
     },
     {
@@ -12817,7 +12842,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3627,
+      "readme_linha": 3631,
       "tipo_fonte": "federal"
     },
     {
@@ -12840,7 +12865,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3631,
+      "readme_linha": 3635,
       "tipo_fonte": "federal"
     },
     {
@@ -12869,7 +12894,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3641,
+      "readme_linha": 3645,
       "tipo_fonte": "federal"
     },
     {
@@ -12893,7 +12918,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3646,
+      "readme_linha": 3650,
       "tipo_fonte": "federal"
     },
     {
@@ -12917,7 +12942,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3650,
+      "readme_linha": 3654,
       "tipo_fonte": "federal"
     },
     {
@@ -12947,7 +12972,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3654,
+      "readme_linha": 3658,
       "tipo_fonte": "ong"
     },
     {
@@ -12977,7 +13002,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3659,
+      "readme_linha": 3663,
       "tipo_fonte": "federal"
     },
     {
@@ -13002,7 +13027,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3664,
+      "readme_linha": 3668,
       "tipo_fonte": "federal"
     },
     {
@@ -13026,7 +13051,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3668,
+      "readme_linha": 3672,
       "tipo_fonte": "federal"
     },
     {
@@ -13050,7 +13075,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3672,
+      "readme_linha": 3676,
       "tipo_fonte": "federal"
     },
     {
@@ -13105,7 +13130,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3682,
+      "readme_linha": 3686,
       "tipo_fonte": "ong"
     },
     {
@@ -13229,7 +13254,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3721,
+      "readme_linha": 3725,
       "tipo_fonte": "estadual"
     },
     {
@@ -13349,7 +13374,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3762,
+      "readme_linha": 3766,
       "tipo_fonte": "ong"
     },
     {
@@ -13383,7 +13408,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3791,
+      "readme_linha": 3795,
       "tipo_fonte": "estadual"
     },
     {
@@ -13409,7 +13434,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3803,
+      "readme_linha": 3807,
       "tipo_fonte": "estadual"
     },
     {
@@ -13435,7 +13460,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3807,
+      "readme_linha": 3811,
       "tipo_fonte": "estadual"
     },
     {
@@ -13459,7 +13484,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3811,
+      "readme_linha": 3815,
       "tipo_fonte": "estadual"
     },
     {
@@ -13482,7 +13507,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3821,
+      "readme_linha": 3825,
       "tipo_fonte": "ong"
     },
     {
@@ -13505,7 +13530,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3825,
+      "readme_linha": 3829,
       "tipo_fonte": "federal"
     },
     {
@@ -13529,7 +13554,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3829,
+      "readme_linha": 3833,
       "tipo_fonte": "ong"
     },
     {
@@ -13552,7 +13577,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3833,
+      "readme_linha": 3837,
       "tipo_fonte": "federal"
     },
     {
@@ -13575,7 +13600,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3837,
+      "readme_linha": 3841,
       "tipo_fonte": "federal"
     },
     {
@@ -13603,7 +13628,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3841,
+      "readme_linha": 3845,
       "tipo_fonte": "privado"
     },
     {
@@ -13691,7 +13716,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3853,
+      "readme_linha": 3857,
       "tipo_fonte": "privado"
     },
     {
@@ -13742,7 +13767,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3875,
+      "readme_linha": 3879,
       "tipo_fonte": "privado"
     },
     {
@@ -13765,7 +13790,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3888,
+      "readme_linha": 3892,
       "tipo_fonte": "estadual"
     },
     {
@@ -13798,7 +13823,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3894,
+      "readme_linha": 3898,
       "tipo_fonte": "privado"
     },
     {
@@ -13822,7 +13847,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3905,
+      "readme_linha": 3909,
       "tipo_fonte": "privado"
     },
     {
@@ -13845,7 +13870,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3909,
+      "readme_linha": 3913,
       "tipo_fonte": "federal"
     },
     {
@@ -13879,7 +13904,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3915,
+      "readme_linha": 3919,
       "tipo_fonte": "privado"
     },
     {
@@ -13965,7 +13990,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3925,
+      "readme_linha": 3929,
       "tipo_fonte": "privado"
     },
     {
@@ -13989,7 +14014,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3974,
+      "readme_linha": 3978,
       "tipo_fonte": "estadual"
     },
     {
@@ -14023,9 +14048,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4137,
+      "readme_linha": 4141,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 445
+  "total": 446
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -1821,13 +1821,11 @@
     {
       "categoria": "Busca de Informações via CPF/CNPJ/CRM/CNA",
       "categoria_id": "busca-de-informacoes-via-cpf-cnpj-crm-cna",
-      "classificacao": "heuristica",
+      "classificacao": "override",
       "descricao": "Nesta consulta serão exibidas informações (banco, agência e data de restituição) da Restituição do Imposto de Renda. Para consulta é necessário apenas o CPF e data de nascimento.",
       "id": "busca-de-informacoes-via-cpf-cnpj-crm-cna/consulta-restituicao-do-imposto-de-renda",
       "input": [
-        "cnpj",
-        "cpf",
-        "nome"
+        "cpf"
       ],
       "links": [
         {
@@ -1837,10 +1835,9 @@
         }
       ],
       "nome": "Consulta Restituição do Imposto de Renda",
+      "observacao": "Requer CPF e data de nascimento. Retorna banco, agência e data da restituição.",
       "output": [
-        "dados_cadastrais",
-        "debito",
-        "situacao_cadastral"
+        "debito"
       ],
       "readme_linha": 679,
       "tipo_fonte": "federal"
@@ -2753,13 +2750,12 @@
     {
       "categoria": "Registros Eleitorais e Políticos",
       "categoria_id": "registros-eleitorais-e-politicos",
-      "classificacao": "heuristica",
+      "classificacao": "override",
       "descricao": "Lista as zonas eleitorais e unidades da Justiça Eleitoral de cada estado.",
       "id": "registros-eleitorais-e-politicos/consultar-zonas-eleitorais-por-uf",
       "input": [
-        "cpf",
-        "nome",
-        "titulo_eleitor"
+        "municipio",
+        "uf"
       ],
       "links": [
         {
@@ -2770,7 +2766,8 @@
       ],
       "nome": "Consultar Zonas Eleitorais por UF",
       "output": [
-        "dados_cadastrais"
+        "dados_cadastrais",
+        "endereco"
       ],
       "readme_linha": 906,
       "tipo_fonte": "judiciario"
@@ -11827,10 +11824,12 @@
     {
       "categoria": "Outras Buscas",
       "categoria_id": "outras-buscas",
-      "classificacao": "indefinido",
+      "classificacao": "override",
       "descricao": "Portal oficial do Ministério com informações sobre políticas de ciência, tecnologia e inovação.",
       "id": "outras-buscas/mcti-ministerio-da-ciencia-tecnologia-e-inovacao",
-      "input": [],
+      "input": [
+        "nenhum"
+      ],
       "links": [
         {
           "label": "",
@@ -11839,17 +11838,23 @@
         }
       ],
       "nome": "MCTI - Ministério da Ciência, Tecnologia e Inovação",
-      "output": [],
+      "observacao": "Portal institucional; dados de CT&I ficam em painéis e bases vinculadas ao ministério.",
+      "output": [
+        "dataset",
+        "estatistica"
+      ],
       "readme_linha": 3337,
       "tipo_fonte": "federal"
     },
     {
       "categoria": "Outras Buscas",
       "categoria_id": "outras-buscas",
-      "classificacao": "indefinido",
+      "classificacao": "override",
       "descricao": "Consulta de unidades credenciadas da Empresa Brasileira de Pesquisa e Inovação Industrial.",
       "id": "outras-buscas/embrapii-unidades-de-pesquisa-e-inovacao",
-      "input": [],
+      "input": [
+        "nenhum"
+      ],
       "links": [
         {
           "label": "",
@@ -11858,17 +11863,23 @@
         }
       ],
       "nome": "Embrapii - Unidades de Pesquisa e Inovação",
-      "output": [],
+      "observacao": "Lista de unidades credenciadas, com localização e áreas de competência.",
+      "output": [
+        "dados_cadastrais",
+        "endereco"
+      ],
       "readme_linha": 3341,
       "tipo_fonte": "ong"
     },
     {
       "categoria": "Outras Buscas",
       "categoria_id": "outras-buscas",
-      "classificacao": "indefinido",
+      "classificacao": "override",
       "descricao": "Portal da agência de fomento à inovação com informações sobre editais, financiamentos e projetos.",
       "id": "outras-buscas/finep-financiadora-de-estudos-e-projetos",
-      "input": [],
+      "input": [
+        "nenhum"
+      ],
       "links": [
         {
           "label": "",
@@ -11877,7 +11888,11 @@
         }
       ],
       "nome": "Finep - Financiadora de Estudos e Projetos",
-      "output": [],
+      "observacao": "Editais, chamadas públicas e projetos financiados.",
+      "output": [
+        "contrato_publico",
+        "estatistica"
+      ],
       "readme_linha": 3345,
       "tipo_fonte": "federal"
     },
@@ -11907,10 +11922,12 @@
     {
       "categoria": "Outras Buscas",
       "categoria_id": "outras-buscas",
-      "classificacao": "indefinido",
+      "classificacao": "override",
       "descricao": "Portal oficial da Suframa com informações sobre a Zona Franca de Manaus, incentivos fiscais e projetos aprovados.",
       "id": "outras-buscas/suframa-superintendencia-da-zona-franca-de-manaus",
-      "input": [],
+      "input": [
+        "nenhum"
+      ],
       "links": [
         {
           "label": "",
@@ -11919,7 +11936,11 @@
         }
       ],
       "nome": "SUFRAMA - Superintendência da Zona Franca de Manaus",
-      "output": [],
+      "observacao": "Projetos industriais aprovados e indicadores da Zona Franca de Manaus.",
+      "output": [
+        "contrato_publico",
+        "estatistica"
+      ],
       "readme_linha": 3353,
       "tipo_fonte": "federal"
     },
@@ -11970,10 +11991,14 @@
     {
       "categoria": "Outras Buscas",
       "categoria_id": "outras-buscas",
-      "classificacao": "indefinido",
+      "classificacao": "override",
       "descricao": "",
       "id": "outras-buscas/sinesp-cidadao-site-a-app",
-      "input": [],
+      "input": [
+        "chassi",
+        "nome",
+        "placa"
+      ],
       "links": [
         {
           "label": "",
@@ -11982,7 +12007,12 @@
         }
       ],
       "nome": "Sinesp Cidadão (Site a APP)",
-      "output": [],
+      "observacao": "Exige cadastro gov.br. Consulta veículos, mandados de prisão, desaparecidos e procurados.",
+      "output": [
+        "dados_cadastrais",
+        "mandado_prisao",
+        "veiculo"
+      ],
       "readme_linha": 3365,
       "tipo_fonte": "federal"
     },
@@ -13282,10 +13312,13 @@
     {
       "categoria": "Outras Buscas",
       "categoria_id": "outras-buscas",
-      "classificacao": "indefinido",
+      "classificacao": "override",
       "descricao": "",
       "id": "outras-buscas/conhecimento-de-empreendimentos-por-dentro",
-      "input": [],
+      "input": [
+        "endereco",
+        "municipio"
+      ],
       "links": [
         {
           "label": "",
@@ -13319,7 +13352,11 @@
         }
       ],
       "nome": "Conhecimento de empreendimentos por dentro",
-      "output": [],
+      "observacao": "Plataformas de hospedagem e aluguel com fotos internas de imóveis e empreendimentos.",
+      "output": [
+        "endereco",
+        "imovel"
+      ],
       "readme_linha": 3810,
       "tipo_fonte": "privado"
     },

--- a/data/sources.json
+++ b/data/sources.json
@@ -22,7 +22,7 @@
       "output": [
         "beneficio"
       ],
-      "readme_linha": 202,
+      "readme_linha": 192,
       "tipo_fonte": "federal"
     },
     {
@@ -45,7 +45,7 @@
       "output": [
         "beneficio"
       ],
-      "readme_linha": 206,
+      "readme_linha": 196,
       "tipo_fonte": "federal"
     },
     {
@@ -61,7 +61,7 @@
         {
           "label": "",
           "uf": null,
-          "url": "https://solucoes.receita.fazenda.gov.br/servicos/cnpjreva/cnpjreva_solicitacao.asp"
+          "url": "https://solucoes.receita.fazenda.gov.br/Servicos/cnpjreva/"
         }
       ],
       "nome": "Comprovante Situação Cadastral de Pessoa Jurídica",
@@ -69,7 +69,7 @@
         "beneficio",
         "situacao_cadastral"
       ],
-      "readme_linha": 213,
+      "readme_linha": 203,
       "tipo_fonte": "federal"
     },
     {
@@ -86,7 +86,7 @@
       "output": [
         "beneficio"
       ],
-      "readme_linha": 219,
+      "readme_linha": 209,
       "tipo_fonte": "indefinido"
     },
     {
@@ -109,7 +109,7 @@
       "output": [
         "beneficio"
       ],
-      "readme_linha": 223,
+      "readme_linha": 213,
       "tipo_fonte": "federal"
     },
     {
@@ -137,7 +137,7 @@
       "output": [
         "beneficio"
       ],
-      "readme_linha": 227,
+      "readme_linha": 217,
       "tipo_fonte": "federal"
     },
     {
@@ -160,7 +160,7 @@
       "output": [
         "beneficio"
       ],
-      "readme_linha": 235,
+      "readme_linha": 225,
       "tipo_fonte": "federal"
     },
     {
@@ -278,7 +278,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 246,
+      "readme_linha": 236,
       "tipo_fonte": "estadual"
     },
     {
@@ -302,7 +302,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 276,
+      "readme_linha": 266,
       "tipo_fonte": "estadual"
     },
     {
@@ -326,7 +326,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 282,
+      "readme_linha": 272,
       "tipo_fonte": "estadual"
     },
     {
@@ -349,7 +349,7 @@
       "output": [
         "mandado_prisao"
       ],
-      "readme_linha": 294,
+      "readme_linha": 284,
       "tipo_fonte": "federal"
     },
     {
@@ -372,7 +372,7 @@
       "output": [
         "mandado_prisao"
       ],
-      "readme_linha": 299,
+      "readme_linha": 289,
       "tipo_fonte": "estadual"
     },
     {
@@ -395,7 +395,7 @@
       "output": [
         "mandado_prisao"
       ],
-      "readme_linha": 304,
+      "readme_linha": 294,
       "tipo_fonte": "estadual"
     },
     {
@@ -418,7 +418,7 @@
       "output": [
         "mandado_prisao"
       ],
-      "readme_linha": 309,
+      "readme_linha": 299,
       "tipo_fonte": "estadual"
     },
     {
@@ -441,7 +441,7 @@
       "output": [
         "mandado_prisao"
       ],
-      "readme_linha": 314,
+      "readme_linha": 304,
       "tipo_fonte": "internacional"
     },
     {
@@ -474,7 +474,7 @@
       "output": [
         "mandado_prisao"
       ],
-      "readme_linha": 319,
+      "readme_linha": 309,
       "tipo_fonte": "federal"
     },
     {
@@ -523,7 +523,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 333,
+      "readme_linha": 323,
       "tipo_fonte": "judiciario"
     },
     {
@@ -591,7 +591,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 348,
+      "readme_linha": 338,
       "tipo_fonte": "judiciario"
     },
     {
@@ -619,7 +619,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 382,
+      "readme_linha": 372,
       "tipo_fonte": "judiciario"
     },
     {
@@ -647,7 +647,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 386,
+      "readme_linha": 376,
       "tipo_fonte": "judiciario"
     },
     {
@@ -676,7 +676,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 390,
+      "readme_linha": 380,
       "tipo_fonte": "judiciario"
     },
     {
@@ -719,7 +719,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 396,
+      "readme_linha": 386,
       "tipo_fonte": "judiciario"
     },
     {
@@ -747,7 +747,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 411,
+      "readme_linha": 401,
       "tipo_fonte": "privado"
     },
     {
@@ -775,7 +775,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 417,
+      "readme_linha": 407,
       "tipo_fonte": "privado"
     },
     {
@@ -803,7 +803,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 423,
+      "readme_linha": 413,
       "tipo_fonte": "ong"
     },
     {
@@ -866,7 +866,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 429,
+      "readme_linha": 419,
       "tipo_fonte": "judiciario"
     },
     {
@@ -894,7 +894,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 445,
+      "readme_linha": 435,
       "tipo_fonte": "judiciario"
     },
     {
@@ -922,7 +922,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 449,
+      "readme_linha": 439,
       "tipo_fonte": "judiciario"
     },
     {
@@ -950,7 +950,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 453,
+      "readme_linha": 443,
       "tipo_fonte": "judiciario"
     },
     {
@@ -978,7 +978,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 457,
+      "readme_linha": 447,
       "tipo_fonte": "judiciario"
     },
     {
@@ -1081,7 +1081,7 @@
         "partes",
         "processo"
       ],
-      "readme_linha": 461,
+      "readme_linha": 451,
       "tipo_fonte": "judiciario"
     },
     {
@@ -1106,7 +1106,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 511,
+      "readme_linha": 501,
       "tipo_fonte": "federal"
     },
     {
@@ -1231,7 +1231,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 515,
+      "readme_linha": 505,
       "tipo_fonte": "federal"
     },
     {
@@ -1257,7 +1257,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 545,
+      "readme_linha": 535,
       "tipo_fonte": "federal"
     },
     {
@@ -1283,7 +1283,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 549,
+      "readme_linha": 539,
       "tipo_fonte": "internacional"
     },
     {
@@ -1308,7 +1308,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 555,
+      "readme_linha": 545,
       "tipo_fonte": "internacional"
     },
     {
@@ -1333,7 +1333,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 561,
+      "readme_linha": 551,
       "tipo_fonte": "privado"
     },
     {
@@ -1360,7 +1360,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 567,
+      "readme_linha": 557,
       "tipo_fonte": "judiciario"
     },
     {
@@ -1391,7 +1391,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 573,
+      "readme_linha": 563,
       "tipo_fonte": "privado"
     },
     {
@@ -1442,7 +1442,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 581,
+      "readme_linha": 571,
       "tipo_fonte": "estadual"
     },
     {
@@ -1469,7 +1469,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 605,
+      "readme_linha": 595,
       "tipo_fonte": "ong"
     },
     {
@@ -1495,7 +1495,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 612,
+      "readme_linha": 602,
       "tipo_fonte": "ong"
     },
     {
@@ -1521,7 +1521,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 619,
+      "readme_linha": 609,
       "tipo_fonte": "ong"
     },
     {
@@ -1547,7 +1547,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 626,
+      "readme_linha": 616,
       "tipo_fonte": "federal"
     },
     {
@@ -1573,7 +1573,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 630,
+      "readme_linha": 620,
       "tipo_fonte": "ong"
     },
     {
@@ -1599,7 +1599,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 634,
+      "readme_linha": 624,
       "tipo_fonte": "federal"
     },
     {
@@ -1625,7 +1625,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 638,
+      "readme_linha": 628,
       "tipo_fonte": "ong"
     },
     {
@@ -1651,7 +1651,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 642,
+      "readme_linha": 632,
       "tipo_fonte": "ong"
     },
     {
@@ -1681,7 +1681,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 651,
+      "readme_linha": 641,
       "tipo_fonte": "federal"
     },
     {
@@ -1807,7 +1807,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 658,
+      "readme_linha": 648,
       "tipo_fonte": "estadual"
     },
     {
@@ -1832,7 +1832,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 688,
+      "readme_linha": 678,
       "tipo_fonte": "federal"
     },
     {
@@ -1853,7 +1853,7 @@
         "debito",
         "situacao_cadastral"
       ],
-      "readme_linha": 693,
+      "readme_linha": 683,
       "tipo_fonte": "indefinido"
     },
     {
@@ -1878,7 +1878,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 697,
+      "readme_linha": 687,
       "tipo_fonte": "federal"
     },
     {
@@ -1906,7 +1906,7 @@
         "sancao",
         "situacao_cadastral"
       ],
-      "readme_linha": 701,
+      "readme_linha": 691,
       "tipo_fonte": "federal"
     },
     {
@@ -1932,7 +1932,7 @@
         "sancao",
         "situacao_cadastral"
       ],
-      "readme_linha": 705,
+      "readme_linha": 695,
       "tipo_fonte": "federal"
     },
     {
@@ -1959,7 +1959,7 @@
         "sancao",
         "situacao_cadastral"
       ],
-      "readme_linha": 709,
+      "readme_linha": 699,
       "tipo_fonte": "federal"
     },
     {
@@ -2006,7 +2006,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 714,
+      "readme_linha": 704,
       "tipo_fonte": "estadual"
     },
     {
@@ -2031,7 +2031,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 729,
+      "readme_linha": 719,
       "tipo_fonte": "federal"
     },
     {
@@ -2056,7 +2056,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 733,
+      "readme_linha": 723,
       "tipo_fonte": "federal"
     },
     {
@@ -2087,7 +2087,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 738,
+      "readme_linha": 728,
       "tipo_fonte": "federal"
     },
     {
@@ -2115,7 +2115,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 754,
+      "readme_linha": 744,
       "tipo_fonte": "federal"
     },
     {
@@ -2223,7 +2223,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 766,
+      "readme_linha": 756,
       "tipo_fonte": "estadual"
     },
     {
@@ -2251,7 +2251,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 827,
+      "readme_linha": 817,
       "tipo_fonte": "ong"
     },
     {
@@ -2274,7 +2274,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 832,
+      "readme_linha": 822,
       "tipo_fonte": "privado"
     },
     {
@@ -2297,7 +2297,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 836,
+      "readme_linha": 826,
       "tipo_fonte": "ong"
     },
     {
@@ -2321,7 +2321,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 840,
+      "readme_linha": 830,
       "tipo_fonte": "privado"
     },
     {
@@ -2346,7 +2346,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 850,
+      "readme_linha": 840,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2371,7 +2371,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 854,
+      "readme_linha": 844,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2396,7 +2396,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 858,
+      "readme_linha": 848,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2421,7 +2421,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 862,
+      "readme_linha": 852,
       "tipo_fonte": "legislativo"
     },
     {
@@ -2446,7 +2446,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 866,
+      "readme_linha": 856,
       "tipo_fonte": "legislativo"
     },
     {
@@ -2472,7 +2472,7 @@
         "dados_cadastrais",
         "dataset"
       ],
-      "readme_linha": 870,
+      "readme_linha": 860,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2498,7 +2498,7 @@
         "dados_cadastrais",
         "dataset"
       ],
-      "readme_linha": 874,
+      "readme_linha": 864,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2524,7 +2524,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 878,
+      "readme_linha": 868,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2549,7 +2549,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 882,
+      "readme_linha": 872,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2575,7 +2575,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 886,
+      "readme_linha": 876,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2601,7 +2601,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 890,
+      "readme_linha": 880,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2629,7 +2629,7 @@
         "debito",
         "multa"
       ],
-      "readme_linha": 894,
+      "readme_linha": 884,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2654,7 +2654,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 898,
+      "readme_linha": 888,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2680,7 +2680,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 902,
+      "readme_linha": 892,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2705,7 +2705,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 906,
+      "readme_linha": 896,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2733,7 +2733,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 910,
+      "readme_linha": 900,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2758,7 +2758,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 914,
+      "readme_linha": 904,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2777,7 +2777,7 @@
       ],
       "nome": "Consultar Zonas Eleitorais por UF",
       "output": [],
-      "readme_linha": 919,
+      "readme_linha": 909,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2800,7 +2800,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 922,
+      "readme_linha": 912,
       "tipo_fonte": "ong"
     },
     {
@@ -2824,7 +2824,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 932,
+      "readme_linha": 922,
       "tipo_fonte": "ong"
     },
     {
@@ -2848,7 +2848,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 936,
+      "readme_linha": 926,
       "tipo_fonte": "estadual"
     },
     {
@@ -2872,7 +2872,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 940,
+      "readme_linha": 930,
       "tipo_fonte": "municipal"
     },
     {
@@ -2896,7 +2896,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 944,
+      "readme_linha": 934,
       "tipo_fonte": "federal"
     },
     {
@@ -2920,7 +2920,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 948,
+      "readme_linha": 938,
       "tipo_fonte": "federal"
     },
     {
@@ -2946,7 +2946,7 @@
         "certidao",
         "imovel"
       ],
-      "readme_linha": 952,
+      "readme_linha": 942,
       "tipo_fonte": "ong"
     },
     {
@@ -2970,7 +2970,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 962,
+      "readme_linha": 952,
       "tipo_fonte": "federal"
     },
     {
@@ -2994,7 +2994,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 966,
+      "readme_linha": 956,
       "tipo_fonte": "federal"
     },
     {
@@ -3018,7 +3018,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 970,
+      "readme_linha": 960,
       "tipo_fonte": "federal"
     },
     {
@@ -3042,7 +3042,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 974,
+      "readme_linha": 964,
       "tipo_fonte": "estadual"
     },
     {
@@ -3067,7 +3067,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 978,
+      "readme_linha": 968,
       "tipo_fonte": "ong"
     },
     {
@@ -3092,7 +3092,7 @@
         "estatistica",
         "licenca_ambiental"
       ],
-      "readme_linha": 982,
+      "readme_linha": 972,
       "tipo_fonte": "ong"
     },
     {
@@ -3117,7 +3117,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 986,
+      "readme_linha": 976,
       "tipo_fonte": "ong"
     },
     {
@@ -3140,7 +3140,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 996,
+      "readme_linha": 986,
       "tipo_fonte": "federal"
     },
     {
@@ -3163,7 +3163,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1000,
+      "readme_linha": 990,
       "tipo_fonte": "federal"
     },
     {
@@ -3186,7 +3186,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1004,
+      "readme_linha": 994,
       "tipo_fonte": "federal"
     },
     {
@@ -3209,7 +3209,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1008,
+      "readme_linha": 998,
       "tipo_fonte": "federal"
     },
     {
@@ -3233,7 +3233,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1018,
+      "readme_linha": 1008,
       "tipo_fonte": "federal"
     },
     {
@@ -3257,7 +3257,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1022,
+      "readme_linha": 1012,
       "tipo_fonte": "federal"
     },
     {
@@ -3281,7 +3281,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1026,
+      "readme_linha": 1016,
       "tipo_fonte": "federal"
     },
     {
@@ -3307,7 +3307,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1036,
+      "readme_linha": 1026,
       "tipo_fonte": "federal"
     },
     {
@@ -3333,7 +3333,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1040,
+      "readme_linha": 1030,
       "tipo_fonte": "federal"
     },
     {
@@ -3360,7 +3360,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1044,
+      "readme_linha": 1034,
       "tipo_fonte": "federal"
     },
     {
@@ -3387,7 +3387,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1048,
+      "readme_linha": 1038,
       "tipo_fonte": "federal"
     },
     {
@@ -3414,7 +3414,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1052,
+      "readme_linha": 1042,
       "tipo_fonte": "federal"
     },
     {
@@ -3440,7 +3440,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1056,
+      "readme_linha": 1046,
       "tipo_fonte": "federal"
     },
     {
@@ -3466,7 +3466,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1060,
+      "readme_linha": 1050,
       "tipo_fonte": "federal"
     },
     {
@@ -3494,7 +3494,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1064,
+      "readme_linha": 1054,
       "tipo_fonte": "federal"
     },
     {
@@ -3525,7 +3525,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1068,
+      "readme_linha": 1058,
       "tipo_fonte": "federal"
     },
     {
@@ -3551,7 +3551,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1109,
+      "readme_linha": 1099,
       "tipo_fonte": "federal"
     },
     {
@@ -3577,7 +3577,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1113,
+      "readme_linha": 1103,
       "tipo_fonte": "federal"
     },
     {
@@ -3603,7 +3603,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1117,
+      "readme_linha": 1107,
       "tipo_fonte": "federal"
     },
     {
@@ -3629,7 +3629,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1121,
+      "readme_linha": 1111,
       "tipo_fonte": "federal"
     },
     {
@@ -3655,7 +3655,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1125,
+      "readme_linha": 1115,
       "tipo_fonte": "federal"
     },
     {
@@ -3681,7 +3681,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1129,
+      "readme_linha": 1119,
       "tipo_fonte": "federal"
     },
     {
@@ -3707,7 +3707,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1133,
+      "readme_linha": 1123,
       "tipo_fonte": "federal"
     },
     {
@@ -3734,7 +3734,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1137,
+      "readme_linha": 1127,
       "tipo_fonte": "federal"
     },
     {
@@ -3760,7 +3760,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1141,
+      "readme_linha": 1131,
       "tipo_fonte": "estadual"
     },
     {
@@ -3787,7 +3787,7 @@
         "remuneracao",
         "sancao"
       ],
-      "readme_linha": 1145,
+      "readme_linha": 1135,
       "tipo_fonte": "estadual"
     },
     {
@@ -3813,7 +3813,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1149,
+      "readme_linha": 1139,
       "tipo_fonte": "federal"
     },
     {
@@ -3884,7 +3884,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1153,
+      "readme_linha": 1143,
       "tipo_fonte": "estadual"
     },
     {
@@ -3910,7 +3910,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1197,
+      "readme_linha": 1187,
       "tipo_fonte": "federal"
     },
     {
@@ -4076,7 +4076,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1201,
+      "readme_linha": 1191,
       "tipo_fonte": "estadual"
     },
     {
@@ -4100,7 +4100,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1270,
+      "readme_linha": 1260,
       "tipo_fonte": "federal"
     },
     {
@@ -4124,7 +4124,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1274,
+      "readme_linha": 1264,
       "tipo_fonte": "federal"
     },
     {
@@ -4148,7 +4148,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1278,
+      "readme_linha": 1268,
       "tipo_fonte": "ong"
     },
     {
@@ -4302,7 +4302,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1282,
+      "readme_linha": 1272,
       "tipo_fonte": "estadual"
     },
     {
@@ -4328,7 +4328,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 1347,
+      "readme_linha": 1337,
       "tipo_fonte": "federal"
     },
     {
@@ -4352,7 +4352,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1351,
+      "readme_linha": 1341,
       "tipo_fonte": "federal"
     },
     {
@@ -4376,7 +4376,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1355,
+      "readme_linha": 1345,
       "tipo_fonte": "federal"
     },
     {
@@ -4400,7 +4400,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1359,
+      "readme_linha": 1349,
       "tipo_fonte": "federal"
     },
     {
@@ -4424,7 +4424,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1363,
+      "readme_linha": 1353,
       "tipo_fonte": "federal"
     },
     {
@@ -4448,7 +4448,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1367,
+      "readme_linha": 1357,
       "tipo_fonte": "federal"
     },
     {
@@ -4472,7 +4472,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1371,
+      "readme_linha": 1361,
       "tipo_fonte": "federal"
     },
     {
@@ -4496,7 +4496,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1375,
+      "readme_linha": 1365,
       "tipo_fonte": "federal"
     },
     {
@@ -4520,7 +4520,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1379,
+      "readme_linha": 1369,
       "tipo_fonte": "federal"
     },
     {
@@ -4544,7 +4544,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1383,
+      "readme_linha": 1373,
       "tipo_fonte": "federal"
     },
     {
@@ -4578,7 +4578,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1392,
+      "readme_linha": 1382,
       "tipo_fonte": "privado"
     },
     {
@@ -4606,7 +4606,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1405,
+      "readme_linha": 1395,
       "tipo_fonte": "privado"
     },
     {
@@ -4644,7 +4644,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1410,
+      "readme_linha": 1400,
       "tipo_fonte": "privado"
     },
     {
@@ -4668,7 +4668,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1422,
+      "readme_linha": 1412,
       "tipo_fonte": "privado"
     },
     {
@@ -4732,7 +4732,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1428,
+      "readme_linha": 1418,
       "tipo_fonte": "ong"
     },
     {
@@ -4757,7 +4757,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1446,
+      "readme_linha": 1436,
       "tipo_fonte": "federal"
     },
     {
@@ -4782,7 +4782,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1450,
+      "readme_linha": 1440,
       "tipo_fonte": "federal"
     },
     {
@@ -4806,7 +4806,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1454,
+      "readme_linha": 1444,
       "tipo_fonte": "federal"
     },
     {
@@ -4829,7 +4829,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1458,
+      "readme_linha": 1448,
       "tipo_fonte": "federal"
     },
     {
@@ -4852,7 +4852,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1462,
+      "readme_linha": 1452,
       "tipo_fonte": "federal"
     },
     {
@@ -4881,7 +4881,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1466,
+      "readme_linha": 1456,
       "tipo_fonte": "privado"
     },
     {
@@ -4905,7 +4905,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1471,
+      "readme_linha": 1461,
       "tipo_fonte": "federal"
     },
     {
@@ -4928,7 +4928,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1475,
+      "readme_linha": 1465,
       "tipo_fonte": "federal"
     },
     {
@@ -4953,7 +4953,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1479,
+      "readme_linha": 1469,
       "tipo_fonte": "federal"
     },
     {
@@ -4970,7 +4970,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1485,
+      "readme_linha": 1475,
       "tipo_fonte": "indefinido"
     },
     {
@@ -4996,7 +4996,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1487,
+      "readme_linha": 1477,
       "tipo_fonte": "federal"
     },
     {
@@ -5021,7 +5021,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1493,
+      "readme_linha": 1483,
       "tipo_fonte": "federal"
     },
     {
@@ -5046,7 +5046,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1499,
+      "readme_linha": 1489,
       "tipo_fonte": "federal"
     },
     {
@@ -5071,7 +5071,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1505,
+      "readme_linha": 1495,
       "tipo_fonte": "federal"
     },
     {
@@ -5095,7 +5095,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1512,
+      "readme_linha": 1502,
       "tipo_fonte": "federal"
     },
     {
@@ -5118,7 +5118,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1519,
+      "readme_linha": 1509,
       "tipo_fonte": "federal"
     },
     {
@@ -5145,7 +5145,7 @@
         "outorga",
         "radiofrequencia"
       ],
-      "readme_linha": 1526,
+      "readme_linha": 1516,
       "tipo_fonte": "federal"
     },
     {
@@ -5170,7 +5170,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1533,
+      "readme_linha": 1523,
       "tipo_fonte": "federal"
     },
     {
@@ -5193,7 +5193,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1540,
+      "readme_linha": 1530,
       "tipo_fonte": "federal"
     },
     {
@@ -5217,7 +5217,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1547,
+      "readme_linha": 1537,
       "tipo_fonte": "federal"
     },
     {
@@ -5241,7 +5241,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1554,
+      "readme_linha": 1544,
       "tipo_fonte": "federal"
     },
     {
@@ -5265,7 +5265,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1567,
+      "readme_linha": 1557,
       "tipo_fonte": "federal"
     },
     {
@@ -5290,7 +5290,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1573,
+      "readme_linha": 1563,
       "tipo_fonte": "ong"
     },
     {
@@ -5323,7 +5323,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1579,
+      "readme_linha": 1569,
       "tipo_fonte": "privado"
     },
     {
@@ -5351,7 +5351,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1590,
+      "readme_linha": 1580,
       "tipo_fonte": "ong"
     },
     {
@@ -5422,7 +5422,7 @@
         "erb",
         "operadora"
       ],
-      "readme_linha": 1599,
+      "readme_linha": 1589,
       "tipo_fonte": "privado"
     },
     {
@@ -5446,7 +5446,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1625,
+      "readme_linha": 1615,
       "tipo_fonte": "privado"
     },
     {
@@ -5472,7 +5472,7 @@
         "processo",
         "publicacao_academica"
       ],
-      "readme_linha": 1631,
+      "readme_linha": 1621,
       "tipo_fonte": "federal"
     },
     {
@@ -5496,7 +5496,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1637,
+      "readme_linha": 1627,
       "tipo_fonte": "privado"
     },
     {
@@ -5520,7 +5520,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1641,
+      "readme_linha": 1631,
       "tipo_fonte": "academico"
     },
     {
@@ -5544,7 +5544,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1645,
+      "readme_linha": 1635,
       "tipo_fonte": "academico"
     },
     {
@@ -5568,7 +5568,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1649,
+      "readme_linha": 1639,
       "tipo_fonte": "academico"
     },
     {
@@ -5592,7 +5592,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1653,
+      "readme_linha": 1643,
       "tipo_fonte": "academico"
     },
     {
@@ -5616,7 +5616,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1657,
+      "readme_linha": 1647,
       "tipo_fonte": "federal"
     },
     {
@@ -5640,7 +5640,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1661,
+      "readme_linha": 1651,
       "tipo_fonte": "privado"
     },
     {
@@ -5664,7 +5664,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1665,
+      "readme_linha": 1655,
       "tipo_fonte": "federal"
     },
     {
@@ -5688,7 +5688,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1669,
+      "readme_linha": 1659,
       "tipo_fonte": "ong"
     },
     {
@@ -5713,7 +5713,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1673,
+      "readme_linha": 1663,
       "tipo_fonte": "federal"
     },
     {
@@ -5739,7 +5739,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1677,
+      "readme_linha": 1667,
       "tipo_fonte": "federal"
     },
     {
@@ -5764,7 +5764,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 1681,
+      "readme_linha": 1671,
       "tipo_fonte": "federal"
     },
     {
@@ -5788,7 +5788,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1685,
+      "readme_linha": 1675,
       "tipo_fonte": "federal"
     },
     {
@@ -5812,7 +5812,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1689,
+      "readme_linha": 1679,
       "tipo_fonte": "federal"
     },
     {
@@ -5836,7 +5836,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1693,
+      "readme_linha": 1683,
       "tipo_fonte": "federal"
     },
     {
@@ -5976,7 +5976,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1702,
+      "readme_linha": 1692,
       "tipo_fonte": "privado"
     },
     {
@@ -6007,7 +6007,7 @@
         "area_rural",
         "mapa"
       ],
-      "readme_linha": 1736,
+      "readme_linha": 1726,
       "tipo_fonte": "federal"
     },
     {
@@ -6031,7 +6031,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1743,
+      "readme_linha": 1733,
       "tipo_fonte": "federal"
     },
     {
@@ -6060,7 +6060,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1749,
+      "readme_linha": 1739,
       "tipo_fonte": "federal"
     },
     {
@@ -6084,7 +6084,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1756,
+      "readme_linha": 1746,
       "tipo_fonte": "privado"
     },
     {
@@ -6125,7 +6125,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1760,
+      "readme_linha": 1750,
       "tipo_fonte": "internacional"
     },
     {
@@ -6154,7 +6154,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1772,
+      "readme_linha": 1762,
       "tipo_fonte": "federal"
     },
     {
@@ -6179,7 +6179,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1779,
+      "readme_linha": 1769,
       "tipo_fonte": "federal"
     },
     {
@@ -6203,7 +6203,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1785,
+      "readme_linha": 1775,
       "tipo_fonte": "federal"
     },
     {
@@ -6242,7 +6242,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1789,
+      "readme_linha": 1779,
       "tipo_fonte": "federal"
     },
     {
@@ -6266,7 +6266,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1801,
+      "readme_linha": 1791,
       "tipo_fonte": "federal"
     },
     {
@@ -6290,7 +6290,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1805,
+      "readme_linha": 1795,
       "tipo_fonte": "federal"
     },
     {
@@ -6315,7 +6315,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1815,
+      "readme_linha": 1805,
       "tipo_fonte": "federal"
     },
     {
@@ -6340,7 +6340,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1822,
+      "readme_linha": 1812,
       "tipo_fonte": "federal"
     },
     {
@@ -6367,7 +6367,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1829,
+      "readme_linha": 1819,
       "tipo_fonte": "federal"
     },
     {
@@ -6396,7 +6396,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1836,
+      "readme_linha": 1826,
       "tipo_fonte": "federal"
     },
     {
@@ -6422,7 +6422,7 @@
         "mapa",
         "sancao"
       ],
-      "readme_linha": 1843,
+      "readme_linha": 1833,
       "tipo_fonte": "federal"
     },
     {
@@ -6447,7 +6447,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1850,
+      "readme_linha": 1840,
       "tipo_fonte": "federal"
     },
     {
@@ -6474,7 +6474,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1857,
+      "readme_linha": 1847,
       "tipo_fonte": "federal"
     },
     {
@@ -6500,7 +6500,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1864,
+      "readme_linha": 1854,
       "tipo_fonte": "privado"
     },
     {
@@ -6525,7 +6525,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1871,
+      "readme_linha": 1861,
       "tipo_fonte": "federal"
     },
     {
@@ -6552,7 +6552,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1878,
+      "readme_linha": 1868,
       "tipo_fonte": "federal"
     },
     {
@@ -6577,7 +6577,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1885,
+      "readme_linha": 1875,
       "tipo_fonte": "federal"
     },
     {
@@ -6603,7 +6603,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1892,
+      "readme_linha": 1882,
       "tipo_fonte": "federal"
     },
     {
@@ -6629,7 +6629,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1899,
+      "readme_linha": 1889,
       "tipo_fonte": "federal"
     },
     {
@@ -6654,7 +6654,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1906,
+      "readme_linha": 1896,
       "tipo_fonte": "federal"
     },
     {
@@ -6681,7 +6681,7 @@
         "mapa",
         "processo"
       ],
-      "readme_linha": 1913,
+      "readme_linha": 1903,
       "tipo_fonte": "federal"
     },
     {
@@ -6708,7 +6708,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1920,
+      "readme_linha": 1910,
       "tipo_fonte": "federal"
     },
     {
@@ -6732,7 +6732,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1931,
+      "readme_linha": 1921,
       "tipo_fonte": "federal"
     },
     {
@@ -6756,7 +6756,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1937,
+      "readme_linha": 1927,
       "tipo_fonte": "federal"
     },
     {
@@ -6781,7 +6781,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1941,
+      "readme_linha": 1931,
       "tipo_fonte": "federal"
     },
     {
@@ -6805,7 +6805,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1945,
+      "readme_linha": 1935,
       "tipo_fonte": "federal"
     },
     {
@@ -6829,7 +6829,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1949,
+      "readme_linha": 1939,
       "tipo_fonte": "federal"
     },
     {
@@ -6853,7 +6853,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1953,
+      "readme_linha": 1943,
       "tipo_fonte": "federal"
     },
     {
@@ -6882,7 +6882,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1957,
+      "readme_linha": 1947,
       "tipo_fonte": "federal"
     },
     {
@@ -6907,7 +6907,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1962,
+      "readme_linha": 1952,
       "tipo_fonte": "ong"
     },
     {
@@ -6932,7 +6932,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1966,
+      "readme_linha": 1956,
       "tipo_fonte": "academico"
     },
     {
@@ -6956,7 +6956,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1970,
+      "readme_linha": 1960,
       "tipo_fonte": "academico"
     },
     {
@@ -6990,7 +6990,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1974,
+      "readme_linha": 1964,
       "tipo_fonte": "federal"
     },
     {
@@ -7028,7 +7028,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 1991,
+      "readme_linha": 1981,
       "tipo_fonte": "dork"
     },
     {
@@ -7056,7 +7056,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2004,
+      "readme_linha": 1994,
       "tipo_fonte": "dork"
     },
     {
@@ -7084,7 +7084,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2011,
+      "readme_linha": 2001,
       "tipo_fonte": "dork"
     },
     {
@@ -7117,7 +7117,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2020,
+      "readme_linha": 2010,
       "tipo_fonte": "dork"
     },
     {
@@ -7155,7 +7155,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2031,
+      "readme_linha": 2021,
       "tipo_fonte": "dork"
     },
     {
@@ -7194,7 +7194,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2044,
+      "readme_linha": 2034,
       "tipo_fonte": "dork"
     },
     {
@@ -7233,7 +7233,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2060,
+      "readme_linha": 2050,
       "tipo_fonte": "internacional"
     },
     {
@@ -7267,7 +7267,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2072,
+      "readme_linha": 2062,
       "tipo_fonte": "internacional"
     },
     {
@@ -7295,7 +7295,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2079,
+      "readme_linha": 2069,
       "tipo_fonte": "dork"
     },
     {
@@ -7343,7 +7343,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2086,
+      "readme_linha": 2076,
       "tipo_fonte": "dork"
     },
     {
@@ -7381,7 +7381,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2106,
+      "readme_linha": 2096,
       "tipo_fonte": "dork"
     },
     {
@@ -7420,7 +7420,7 @@
         "dork",
         "video_ao_vivo"
       ],
-      "readme_linha": 2121,
+      "readme_linha": 2111,
       "tipo_fonte": "dork"
     },
     {
@@ -7461,7 +7461,7 @@
         "dork",
         "operadora"
       ],
-      "readme_linha": 2136,
+      "readme_linha": 2126,
       "tipo_fonte": "dork"
     },
     {
@@ -7495,7 +7495,7 @@
         "dork",
         "publicacao_academica"
       ],
-      "readme_linha": 2151,
+      "readme_linha": 2141,
       "tipo_fonte": "dork"
     },
     {
@@ -7528,7 +7528,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2163,
+      "readme_linha": 2153,
       "tipo_fonte": "dork"
     },
     {
@@ -7556,7 +7556,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2175,
+      "readme_linha": 2165,
       "tipo_fonte": "dork"
     },
     {
@@ -7585,7 +7585,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2185,
+      "readme_linha": 2175,
       "tipo_fonte": "internacional"
     },
     {
@@ -7628,7 +7628,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2197,
+      "readme_linha": 2187,
       "tipo_fonte": "dork"
     },
     {
@@ -7653,7 +7653,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2221,
+      "readme_linha": 2211,
       "tipo_fonte": "internacional"
     },
     {
@@ -7688,7 +7688,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2227,
+      "readme_linha": 2217,
       "tipo_fonte": "internacional"
     },
     {
@@ -7718,7 +7718,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2238,
+      "readme_linha": 2228,
       "tipo_fonte": "internacional"
     },
     {
@@ -7743,7 +7743,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2246,
+      "readme_linha": 2236,
       "tipo_fonte": "internacional"
     },
     {
@@ -7769,7 +7769,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2252,
+      "readme_linha": 2242,
       "tipo_fonte": "internacional"
     },
     {
@@ -7795,7 +7795,7 @@
         "estatistica",
         "perfil_social"
       ],
-      "readme_linha": 2258,
+      "readme_linha": 2248,
       "tipo_fonte": "internacional"
     },
     {
@@ -7820,7 +7820,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2264,
+      "readme_linha": 2254,
       "tipo_fonte": "internacional"
     },
     {
@@ -7845,7 +7845,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2270,
+      "readme_linha": 2260,
       "tipo_fonte": "internacional"
     },
     {
@@ -7870,7 +7870,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2274,
+      "readme_linha": 2264,
       "tipo_fonte": "internacional"
     },
     {
@@ -7895,7 +7895,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2278,
+      "readme_linha": 2268,
       "tipo_fonte": "internacional"
     },
     {
@@ -7920,7 +7920,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2282,
+      "readme_linha": 2272,
       "tipo_fonte": "internacional"
     },
     {
@@ -7945,7 +7945,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2286,
+      "readme_linha": 2276,
       "tipo_fonte": "internacional"
     },
     {
@@ -7970,7 +7970,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2290,
+      "readme_linha": 2280,
       "tipo_fonte": "internacional"
     },
     {
@@ -7996,7 +7996,7 @@
         "mandado_prisao",
         "perfil_social"
       ],
-      "readme_linha": 2296,
+      "readme_linha": 2286,
       "tipo_fonte": "privado"
     },
     {
@@ -8026,7 +8026,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2302,
+      "readme_linha": 2292,
       "tipo_fonte": "privado"
     },
     {
@@ -8056,7 +8056,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2309,
+      "readme_linha": 2299,
       "tipo_fonte": "internacional"
     },
     {
@@ -8082,7 +8082,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2315,
+      "readme_linha": 2305,
       "tipo_fonte": "internacional"
     },
     {
@@ -8107,7 +8107,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2322,
+      "readme_linha": 2312,
       "tipo_fonte": "privado"
     },
     {
@@ -8132,7 +8132,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2328,
+      "readme_linha": 2318,
       "tipo_fonte": "internacional"
     },
     {
@@ -8215,7 +8215,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2341,
+      "readme_linha": 2331,
       "tipo_fonte": "privado"
     },
     {
@@ -8278,7 +8278,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2366,
+      "readme_linha": 2356,
       "tipo_fonte": "privado"
     },
     {
@@ -8301,7 +8301,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2393,
+      "readme_linha": 2383,
       "tipo_fonte": "federal"
     },
     {
@@ -8324,7 +8324,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2399,
+      "readme_linha": 2389,
       "tipo_fonte": "privado"
     },
     {
@@ -8347,7 +8347,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2405,
+      "readme_linha": 2395,
       "tipo_fonte": "federal"
     },
     {
@@ -8370,7 +8370,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2411,
+      "readme_linha": 2401,
       "tipo_fonte": "privado"
     },
     {
@@ -8393,7 +8393,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2417,
+      "readme_linha": 2407,
       "tipo_fonte": "federal"
     },
     {
@@ -8416,7 +8416,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2423,
+      "readme_linha": 2413,
       "tipo_fonte": "federal"
     },
     {
@@ -8439,7 +8439,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2429,
+      "readme_linha": 2419,
       "tipo_fonte": "federal"
     },
     {
@@ -8463,7 +8463,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2435,
+      "readme_linha": 2425,
       "tipo_fonte": "federal"
     },
     {
@@ -8492,7 +8492,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 2439,
+      "readme_linha": 2429,
       "tipo_fonte": "federal"
     },
     {
@@ -8515,7 +8515,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2446,
+      "readme_linha": 2436,
       "tipo_fonte": "federal"
     },
     {
@@ -8538,7 +8538,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2450,
+      "readme_linha": 2440,
       "tipo_fonte": "federal"
     },
     {
@@ -8562,7 +8562,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2456,
+      "readme_linha": 2446,
       "tipo_fonte": "federal"
     },
     {
@@ -8585,7 +8585,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2462,
+      "readme_linha": 2452,
       "tipo_fonte": "estadual"
     },
     {
@@ -8609,7 +8609,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2468,
+      "readme_linha": 2458,
       "tipo_fonte": "estadual"
     },
     {
@@ -8633,7 +8633,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2474,
+      "readme_linha": 2464,
       "tipo_fonte": "federal"
     },
     {
@@ -8656,7 +8656,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2480,
+      "readme_linha": 2470,
       "tipo_fonte": "federal"
     },
     {
@@ -8679,7 +8679,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2486,
+      "readme_linha": 2476,
       "tipo_fonte": "estadual"
     },
     {
@@ -8703,7 +8703,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2492,
+      "readme_linha": 2482,
       "tipo_fonte": "federal"
     },
     {
@@ -8726,7 +8726,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2498,
+      "readme_linha": 2488,
       "tipo_fonte": "estadual"
     },
     {
@@ -8749,7 +8749,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2504,
+      "readme_linha": 2494,
       "tipo_fonte": "estadual"
     },
     {
@@ -8772,7 +8772,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2510,
+      "readme_linha": 2500,
       "tipo_fonte": "federal"
     },
     {
@@ -8795,7 +8795,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2516,
+      "readme_linha": 2506,
       "tipo_fonte": "estadual"
     },
     {
@@ -8818,7 +8818,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2522,
+      "readme_linha": 2512,
       "tipo_fonte": "estadual"
     },
     {
@@ -8841,7 +8841,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2526,
+      "readme_linha": 2516,
       "tipo_fonte": "federal"
     },
     {
@@ -8864,7 +8864,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2532,
+      "readme_linha": 2522,
       "tipo_fonte": "federal"
     },
     {
@@ -8887,7 +8887,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2538,
+      "readme_linha": 2528,
       "tipo_fonte": "estadual"
     },
     {
@@ -8910,7 +8910,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2544,
+      "readme_linha": 2534,
       "tipo_fonte": "federal"
     },
     {
@@ -8938,7 +8938,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2550,
+      "readme_linha": 2540,
       "tipo_fonte": "federal"
     },
     {
@@ -8963,7 +8963,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2557,
+      "readme_linha": 2547,
       "tipo_fonte": "estadual"
     },
     {
@@ -8986,7 +8986,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2561,
+      "readme_linha": 2551,
       "tipo_fonte": "federal"
     },
     {
@@ -9010,7 +9010,7 @@
         "dataset",
         "diario_oficial"
       ],
-      "readme_linha": 2565,
+      "readme_linha": 2555,
       "tipo_fonte": "ong"
     },
     {
@@ -9033,7 +9033,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2571,
+      "readme_linha": 2561,
       "tipo_fonte": "ong"
     },
     {
@@ -9056,7 +9056,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2575,
+      "readme_linha": 2565,
       "tipo_fonte": "federal"
     },
     {
@@ -9079,7 +9079,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2579,
+      "readme_linha": 2569,
       "tipo_fonte": "federal"
     },
     {
@@ -9102,7 +9102,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2583,
+      "readme_linha": 2573,
       "tipo_fonte": "privado"
     },
     {
@@ -9125,7 +9125,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2587,
+      "readme_linha": 2577,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9148,7 +9148,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2591,
+      "readme_linha": 2581,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9172,7 +9172,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2595,
+      "readme_linha": 2585,
       "tipo_fonte": "federal"
     },
     {
@@ -9195,7 +9195,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2599,
+      "readme_linha": 2589,
       "tipo_fonte": "federal"
     },
     {
@@ -9219,7 +9219,7 @@
         "dataset",
         "endereco"
       ],
-      "readme_linha": 2603,
+      "readme_linha": 2593,
       "tipo_fonte": "privado"
     },
     {
@@ -9244,7 +9244,7 @@
         "beneficio",
         "remuneracao"
       ],
-      "readme_linha": 2613,
+      "readme_linha": 2603,
       "tipo_fonte": "ong"
     },
     {
@@ -9268,7 +9268,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2621,
+      "readme_linha": 2611,
       "tipo_fonte": "estadual"
     },
     {
@@ -9292,7 +9292,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2625,
+      "readme_linha": 2615,
       "tipo_fonte": "estadual"
     },
     {
@@ -9391,7 +9391,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2631,
+      "readme_linha": 2621,
       "tipo_fonte": "privado"
     },
     {
@@ -9450,7 +9450,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2654,
+      "readme_linha": 2644,
       "tipo_fonte": "ong"
     },
     {
@@ -9479,7 +9479,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2669,
+      "readme_linha": 2659,
       "tipo_fonte": "privado"
     },
     {
@@ -9503,7 +9503,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2676,
+      "readme_linha": 2666,
       "tipo_fonte": "privado"
     },
     {
@@ -9527,7 +9527,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2682,
+      "readme_linha": 2672,
       "tipo_fonte": "federal"
     },
     {
@@ -9551,7 +9551,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2688,
+      "readme_linha": 2678,
       "tipo_fonte": "federal"
     },
     {
@@ -9576,7 +9576,7 @@
         "veiculo",
         "video_ao_vivo"
       ],
-      "readme_linha": 2694,
+      "readme_linha": 2684,
       "tipo_fonte": "internacional"
     },
     {
@@ -9600,7 +9600,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2698,
+      "readme_linha": 2688,
       "tipo_fonte": "internacional"
     },
     {
@@ -9625,7 +9625,7 @@
         "multa",
         "veiculo"
       ],
-      "readme_linha": 2702,
+      "readme_linha": 2692,
       "tipo_fonte": "federal"
     },
     {
@@ -9651,7 +9651,7 @@
         "dados_cadastrais",
         "veiculo"
       ],
-      "readme_linha": 2706,
+      "readme_linha": 2696,
       "tipo_fonte": "federal"
     },
     {
@@ -9675,7 +9675,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2710,
+      "readme_linha": 2700,
       "tipo_fonte": "federal"
     },
     {
@@ -9699,7 +9699,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2714,
+      "readme_linha": 2704,
       "tipo_fonte": "privado"
     },
     {
@@ -9723,7 +9723,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2720,
+      "readme_linha": 2710,
       "tipo_fonte": "federal"
     },
     {
@@ -9747,7 +9747,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2726,
+      "readme_linha": 2716,
       "tipo_fonte": "federal"
     },
     {
@@ -9772,7 +9772,7 @@
         "dataset",
         "veiculo"
       ],
-      "readme_linha": 2732,
+      "readme_linha": 2722,
       "tipo_fonte": "federal"
     },
     {
@@ -9801,7 +9801,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2738,
+      "readme_linha": 2728,
       "tipo_fonte": "estadual"
     },
     {
@@ -9830,7 +9830,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2745,
+      "readme_linha": 2735,
       "tipo_fonte": "estadual"
     },
     {
@@ -9999,7 +9999,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2752,
+      "readme_linha": 2742,
       "tipo_fonte": "estadual"
     },
     {
@@ -10023,7 +10023,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 2822,
+      "readme_linha": 2812,
       "tipo_fonte": "privado"
     },
     {
@@ -10046,7 +10046,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2828,
+      "readme_linha": 2818,
       "tipo_fonte": "privado"
     },
     {
@@ -10089,7 +10089,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2834,
+      "readme_linha": 2824,
       "tipo_fonte": "estadual"
     },
     {
@@ -10112,7 +10112,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2854,
+      "readme_linha": 2844,
       "tipo_fonte": "privado"
     },
     {
@@ -10135,7 +10135,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2860,
+      "readme_linha": 2850,
       "tipo_fonte": "privado"
     },
     {
@@ -10158,7 +10158,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2866,
+      "readme_linha": 2856,
       "tipo_fonte": "privado"
     },
     {
@@ -10183,7 +10183,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 2878,
+      "readme_linha": 2868,
       "tipo_fonte": "federal"
     },
     {
@@ -10209,7 +10209,7 @@
         "estatistica",
         "multa"
       ],
-      "readme_linha": 2882,
+      "readme_linha": 2872,
       "tipo_fonte": "privado"
     },
     {
@@ -10232,7 +10232,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2886,
+      "readme_linha": 2876,
       "tipo_fonte": "federal"
     },
     {
@@ -10255,7 +10255,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2890,
+      "readme_linha": 2880,
       "tipo_fonte": "federal"
     },
     {
@@ -10278,7 +10278,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2894,
+      "readme_linha": 2884,
       "tipo_fonte": "federal"
     },
     {
@@ -10301,7 +10301,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2898,
+      "readme_linha": 2888,
       "tipo_fonte": "federal"
     },
     {
@@ -10329,7 +10329,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2902,
+      "readme_linha": 2892,
       "tipo_fonte": "internacional"
     },
     {
@@ -10352,7 +10352,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2907,
+      "readme_linha": 2897,
       "tipo_fonte": "privado"
     },
     {
@@ -10375,7 +10375,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2911,
+      "readme_linha": 2901,
       "tipo_fonte": "privado"
     },
     {
@@ -10398,7 +10398,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2915,
+      "readme_linha": 2905,
       "tipo_fonte": "privado"
     },
     {
@@ -10421,7 +10421,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2925,
+      "readme_linha": 2915,
       "tipo_fonte": "federal"
     },
     {
@@ -10447,7 +10447,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 2931,
+      "readme_linha": 2921,
       "tipo_fonte": "privado"
     },
     {
@@ -10470,7 +10470,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2937,
+      "readme_linha": 2927,
       "tipo_fonte": "federal"
     },
     {
@@ -10495,7 +10495,7 @@
         "dados_cadastrais",
         "multa"
       ],
-      "readme_linha": 2943,
+      "readme_linha": 2933,
       "tipo_fonte": "federal"
     },
     {
@@ -10573,7 +10573,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2947,
+      "readme_linha": 2937,
       "tipo_fonte": "federal"
     },
     {
@@ -10596,7 +10596,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2975,
+      "readme_linha": 2965,
       "tipo_fonte": "estadual"
     },
     {
@@ -10619,7 +10619,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2981,
+      "readme_linha": 2971,
       "tipo_fonte": "privado"
     },
     {
@@ -10642,7 +10642,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2985,
+      "readme_linha": 2975,
       "tipo_fonte": "estadual"
     },
     {
@@ -10665,7 +10665,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2989,
+      "readme_linha": 2979,
       "tipo_fonte": "internacional"
     },
     {
@@ -10708,7 +10708,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2993,
+      "readme_linha": 2983,
       "tipo_fonte": "privado"
     },
     {
@@ -10756,7 +10756,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3008,
+      "readme_linha": 2998,
       "tipo_fonte": "privado"
     },
     {
@@ -10859,7 +10859,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3022,
+      "readme_linha": 3012,
       "tipo_fonte": "privado"
     },
     {
@@ -10882,7 +10882,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3063,
+      "readme_linha": 3053,
       "tipo_fonte": "privado"
     },
     {
@@ -10930,7 +10930,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3067,
+      "readme_linha": 3057,
       "tipo_fonte": "estadual"
     },
     {
@@ -11253,7 +11253,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3081,
+      "readme_linha": 3071,
       "tipo_fonte": "privado"
     },
     {
@@ -11276,7 +11276,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3156,
+      "readme_linha": 3146,
       "tipo_fonte": "privado"
     },
     {
@@ -11299,7 +11299,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3160,
+      "readme_linha": 3150,
       "tipo_fonte": "privado"
     },
     {
@@ -11322,7 +11322,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3164,
+      "readme_linha": 3154,
       "tipo_fonte": "estadual"
     },
     {
@@ -11345,7 +11345,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3168,
+      "readme_linha": 3158,
       "tipo_fonte": "federal"
     },
     {
@@ -11374,7 +11374,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3172,
+      "readme_linha": 3162,
       "tipo_fonte": "internacional"
     },
     {
@@ -11398,7 +11398,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3177,
+      "readme_linha": 3167,
       "tipo_fonte": "internacional"
     },
     {
@@ -11422,7 +11422,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3181,
+      "readme_linha": 3171,
       "tipo_fonte": "internacional"
     },
     {
@@ -11446,7 +11446,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3185,
+      "readme_linha": 3175,
       "tipo_fonte": "internacional"
     },
     {
@@ -11470,7 +11470,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3189,
+      "readme_linha": 3179,
       "tipo_fonte": "internacional"
     },
     {
@@ -11494,7 +11494,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3193,
+      "readme_linha": 3183,
       "tipo_fonte": "internacional"
     },
     {
@@ -11512,7 +11512,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3197,
+      "readme_linha": 3187,
       "tipo_fonte": "indefinido"
     },
     {
@@ -11536,7 +11536,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3201,
+      "readme_linha": 3191,
       "tipo_fonte": "internacional"
     },
     {
@@ -11560,7 +11560,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3205,
+      "readme_linha": 3195,
       "tipo_fonte": "internacional"
     },
     {
@@ -11583,7 +11583,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3209,
+      "readme_linha": 3199,
       "tipo_fonte": "estadual"
     },
     {
@@ -11657,7 +11657,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3219,
+      "readme_linha": 3209,
       "tipo_fonte": "ministerio_publico"
     },
     {
@@ -11717,7 +11717,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3260,
+      "readme_linha": 3250,
       "tipo_fonte": "defensoria"
     },
     {
@@ -11751,7 +11751,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3292,
+      "readme_linha": 3282,
       "tipo_fonte": "ong"
     },
     {
@@ -11780,7 +11780,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3309,
+      "readme_linha": 3299,
       "tipo_fonte": "estadual"
     },
     {
@@ -11809,7 +11809,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3329,
+      "readme_linha": 3319,
       "tipo_fonte": "privado"
     },
     {
@@ -11858,7 +11858,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3334,
+      "readme_linha": 3324,
       "tipo_fonte": "estadual"
     },
     {
@@ -11877,7 +11877,7 @@
       ],
       "nome": "MCTI - Ministério da Ciência, Tecnologia e Inovação",
       "output": [],
-      "readme_linha": 3353,
+      "readme_linha": 3343,
       "tipo_fonte": "federal"
     },
     {
@@ -11896,7 +11896,7 @@
       ],
       "nome": "Embrapii - Unidades de Pesquisa e Inovação",
       "output": [],
-      "readme_linha": 3357,
+      "readme_linha": 3347,
       "tipo_fonte": "ong"
     },
     {
@@ -11915,7 +11915,7 @@
       ],
       "nome": "Finep - Financiadora de Estudos e Projetos",
       "output": [],
-      "readme_linha": 3361,
+      "readme_linha": 3351,
       "tipo_fonte": "federal"
     },
     {
@@ -11938,7 +11938,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3365,
+      "readme_linha": 3355,
       "tipo_fonte": "privado"
     },
     {
@@ -11957,7 +11957,7 @@
       ],
       "nome": "SUFRAMA - Superintendência da Zona Franca de Manaus",
       "output": [],
-      "readme_linha": 3369,
+      "readme_linha": 3359,
       "tipo_fonte": "federal"
     },
     {
@@ -11980,7 +11980,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3373,
+      "readme_linha": 3363,
       "tipo_fonte": "federal"
     },
     {
@@ -12001,7 +12001,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3377,
+      "readme_linha": 3367,
       "tipo_fonte": "federal"
     },
     {
@@ -12020,7 +12020,7 @@
       ],
       "nome": "Sinesp Cidadão (Site a APP)",
       "output": [],
-      "readme_linha": 3381,
+      "readme_linha": 3371,
       "tipo_fonte": "federal"
     },
     {
@@ -12061,7 +12061,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3390,
+      "readme_linha": 3380,
       "tipo_fonte": "privado"
     },
     {
@@ -12092,7 +12092,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3409,
+      "readme_linha": 3399,
       "tipo_fonte": "privado"
     },
     {
@@ -12121,7 +12121,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3423,
+      "readme_linha": 3413,
       "tipo_fonte": "privado"
     },
     {
@@ -12149,7 +12149,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3450,
+      "readme_linha": 3440,
       "tipo_fonte": "privado"
     },
     {
@@ -12179,7 +12179,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3472,
+      "readme_linha": 3462,
       "tipo_fonte": "privado"
     },
     {
@@ -12206,7 +12206,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3496,
+      "readme_linha": 3486,
       "tipo_fonte": "federal"
     },
     {
@@ -12233,7 +12233,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3519,
+      "readme_linha": 3509,
       "tipo_fonte": "federal"
     },
     {
@@ -12263,7 +12263,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3523,
+      "readme_linha": 3513,
       "tipo_fonte": "ong"
     },
     {
@@ -12289,7 +12289,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3546,
+      "readme_linha": 3536,
       "tipo_fonte": "federal"
     },
     {
@@ -12313,7 +12313,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3550,
+      "readme_linha": 3540,
       "tipo_fonte": "federal"
     },
     {
@@ -12336,7 +12336,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3560,
+      "readme_linha": 3550,
       "tipo_fonte": "federal"
     },
     {
@@ -12359,7 +12359,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3564,
+      "readme_linha": 3554,
       "tipo_fonte": "federal"
     },
     {
@@ -12388,7 +12388,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3568,
+      "readme_linha": 3558,
       "tipo_fonte": "federal"
     },
     {
@@ -12416,7 +12416,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3573,
+      "readme_linha": 3563,
       "tipo_fonte": "federal"
     },
     {
@@ -12439,7 +12439,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3578,
+      "readme_linha": 3568,
       "tipo_fonte": "federal"
     },
     {
@@ -12462,7 +12462,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3582,
+      "readme_linha": 3572,
       "tipo_fonte": "federal"
     },
     {
@@ -12491,7 +12491,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3592,
+      "readme_linha": 3582,
       "tipo_fonte": "federal"
     },
     {
@@ -12515,7 +12515,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3597,
+      "readme_linha": 3587,
       "tipo_fonte": "federal"
     },
     {
@@ -12539,7 +12539,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3601,
+      "readme_linha": 3591,
       "tipo_fonte": "federal"
     },
     {
@@ -12569,7 +12569,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3605,
+      "readme_linha": 3595,
       "tipo_fonte": "ong"
     },
     {
@@ -12599,7 +12599,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3610,
+      "readme_linha": 3600,
       "tipo_fonte": "federal"
     },
     {
@@ -12624,7 +12624,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3615,
+      "readme_linha": 3605,
       "tipo_fonte": "federal"
     },
     {
@@ -12648,7 +12648,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3619,
+      "readme_linha": 3609,
       "tipo_fonte": "federal"
     },
     {
@@ -12672,7 +12672,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3623,
+      "readme_linha": 3613,
       "tipo_fonte": "federal"
     },
     {
@@ -12727,7 +12727,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3633,
+      "readme_linha": 3623,
       "tipo_fonte": "ong"
     },
     {
@@ -12851,7 +12851,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3672,
+      "readme_linha": 3662,
       "tipo_fonte": "estadual"
     },
     {
@@ -12971,7 +12971,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3713,
+      "readme_linha": 3703,
       "tipo_fonte": "ong"
     },
     {
@@ -13005,7 +13005,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3742,
+      "readme_linha": 3732,
       "tipo_fonte": "estadual"
     },
     {
@@ -13031,7 +13031,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3754,
+      "readme_linha": 3744,
       "tipo_fonte": "estadual"
     },
     {
@@ -13057,7 +13057,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3758,
+      "readme_linha": 3748,
       "tipo_fonte": "estadual"
     },
     {
@@ -13081,7 +13081,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3762,
+      "readme_linha": 3752,
       "tipo_fonte": "estadual"
     },
     {
@@ -13104,7 +13104,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3772,
+      "readme_linha": 3762,
       "tipo_fonte": "ong"
     },
     {
@@ -13127,7 +13127,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3776,
+      "readme_linha": 3766,
       "tipo_fonte": "federal"
     },
     {
@@ -13151,7 +13151,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3780,
+      "readme_linha": 3770,
       "tipo_fonte": "ong"
     },
     {
@@ -13174,7 +13174,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3784,
+      "readme_linha": 3774,
       "tipo_fonte": "federal"
     },
     {
@@ -13197,7 +13197,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3788,
+      "readme_linha": 3778,
       "tipo_fonte": "federal"
     },
     {
@@ -13225,7 +13225,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3792,
+      "readme_linha": 3782,
       "tipo_fonte": "privado"
     },
     {
@@ -13313,7 +13313,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3804,
+      "readme_linha": 3794,
       "tipo_fonte": "privado"
     },
     {
@@ -13357,7 +13357,7 @@
       ],
       "nome": "Conhecimento de empreendimentos por dentro",
       "output": [],
-      "readme_linha": 3826,
+      "readme_linha": 3816,
       "tipo_fonte": "privado"
     },
     {
@@ -13380,7 +13380,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3839,
+      "readme_linha": 3829,
       "tipo_fonte": "estadual"
     },
     {
@@ -13413,7 +13413,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3845,
+      "readme_linha": 3835,
       "tipo_fonte": "privado"
     },
     {
@@ -13437,7 +13437,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3856,
+      "readme_linha": 3846,
       "tipo_fonte": "privado"
     },
     {
@@ -13460,7 +13460,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3860,
+      "readme_linha": 3850,
       "tipo_fonte": "federal"
     },
     {
@@ -13494,7 +13494,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3866,
+      "readme_linha": 3856,
       "tipo_fonte": "privado"
     },
     {
@@ -13580,7 +13580,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3876,
+      "readme_linha": 3866,
       "tipo_fonte": "privado"
     },
     {
@@ -13604,7 +13604,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3925,
+      "readme_linha": 3915,
       "tipo_fonte": "estadual"
     },
     {
@@ -13638,7 +13638,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4088,
+      "readme_linha": 4078,
       "tipo_fonte": "privado"
     }
   ],

--- a/data/sources.json
+++ b/data/sources.json
@@ -13190,6 +13190,11 @@
       ],
       "links": [
         {
+          "label": "Busca por médicos",
+          "uf": null,
+          "url": "https://portal.cfm.org.br/busca-medicos/"
+        },
+        {
           "label": "Portal",
           "uf": null,
           "url": "https://www.cremesp.org.br/"
@@ -13354,7 +13359,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3741,
+      "readme_linha": 3744,
       "tipo_fonte": "estadual"
     },
     {
@@ -13474,7 +13479,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3782,
+      "readme_linha": 3785,
       "tipo_fonte": "ong"
     },
     {
@@ -13508,7 +13513,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3811,
+      "readme_linha": 3814,
       "tipo_fonte": "estadual"
     },
     {
@@ -13534,7 +13539,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3823,
+      "readme_linha": 3826,
       "tipo_fonte": "estadual"
     },
     {
@@ -13560,7 +13565,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3827,
+      "readme_linha": 3830,
       "tipo_fonte": "estadual"
     },
     {
@@ -13584,7 +13589,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3831,
+      "readme_linha": 3834,
       "tipo_fonte": "estadual"
     },
     {
@@ -13607,7 +13612,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3841,
+      "readme_linha": 3844,
       "tipo_fonte": "ong"
     },
     {
@@ -13630,7 +13635,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3845,
+      "readme_linha": 3848,
       "tipo_fonte": "federal"
     },
     {
@@ -13654,7 +13659,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3849,
+      "readme_linha": 3852,
       "tipo_fonte": "ong"
     },
     {
@@ -13677,7 +13682,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3853,
+      "readme_linha": 3856,
       "tipo_fonte": "federal"
     },
     {
@@ -13700,7 +13705,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3857,
+      "readme_linha": 3860,
       "tipo_fonte": "federal"
     },
     {
@@ -13728,7 +13733,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3861,
+      "readme_linha": 3864,
       "tipo_fonte": "privado"
     },
     {
@@ -13816,7 +13821,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3873,
+      "readme_linha": 3876,
       "tipo_fonte": "privado"
     },
     {
@@ -13867,7 +13872,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3895,
+      "readme_linha": 3898,
       "tipo_fonte": "privado"
     },
     {
@@ -13890,7 +13895,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3908,
+      "readme_linha": 3911,
       "tipo_fonte": "estadual"
     },
     {
@@ -13923,7 +13928,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3914,
+      "readme_linha": 3917,
       "tipo_fonte": "privado"
     },
     {
@@ -13947,7 +13952,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3925,
+      "readme_linha": 3928,
       "tipo_fonte": "privado"
     },
     {
@@ -13970,7 +13975,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3929,
+      "readme_linha": 3932,
       "tipo_fonte": "federal"
     },
     {
@@ -14004,7 +14009,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3935,
+      "readme_linha": 3938,
       "tipo_fonte": "privado"
     },
     {
@@ -14090,7 +14095,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3945,
+      "readme_linha": 3948,
       "tipo_fonte": "privado"
     },
     {
@@ -14114,7 +14119,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3994,
+      "readme_linha": 3997,
       "tipo_fonte": "estadual"
     },
     {
@@ -14148,7 +14153,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4157,
+      "readme_linha": 4160,
       "tipo_fonte": "privado"
     }
   ],

--- a/data/sources.json
+++ b/data/sources.json
@@ -2700,6 +2700,111 @@
       "categoria": "Registros Eleitorais e Políticos",
       "categoria_id": "registros-eleitorais-e-politicos",
       "classificacao": "heuristica",
+      "descricao": "Emissão de certidão que comprova a inexistência de inscrição eleitoral para o cidadão.",
+      "id": "registros-eleitorais-e-politicos/certidao-negativa-de-alistamento",
+      "input": [
+        "cpf",
+        "nome",
+        "titulo_eleitor"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/certidao-negativa-alistamento"
+        }
+      ],
+      "nome": "Certidão Negativa de Alistamento",
+      "output": [
+        "certidao",
+        "dados_cadastrais"
+      ],
+      "readme_linha": 897,
+      "tipo_fonte": "judiciario"
+    },
+    {
+      "categoria": "Registros Eleitorais e Políticos",
+      "categoria_id": "registros-eleitorais-e-politicos",
+      "classificacao": "heuristica",
+      "descricao": "Emissão de certidão com os dados cadastrais do eleitor e a situação da coleta biométrica.",
+      "id": "registros-eleitorais-e-politicos/certidao-simplificada-de-dados-e-biometria",
+      "input": [
+        "cpf",
+        "nome",
+        "titulo_eleitor"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/certidao-simplificada-dados-cadastrais"
+        }
+      ],
+      "nome": "Certidão Simplificada de Dados e Biometria",
+      "output": [
+        "certidao",
+        "dados_cadastrais"
+      ],
+      "readme_linha": 901,
+      "tipo_fonte": "judiciario"
+    },
+    {
+      "categoria": "Registros Eleitorais e Políticos",
+      "categoria_id": "registros-eleitorais-e-politicos",
+      "classificacao": "heuristica",
+      "descricao": "Emissão de certidão que comprova a inexistência de débito referente à última eleição.",
+      "id": "registros-eleitorais-e-politicos/certidao-de-ausencia-de-debito-da-ultima-eleicao",
+      "input": [
+        "cpf",
+        "nome",
+        "titulo_eleitor"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/certidao-ausencia-debito-ultima-eleicao"
+        }
+      ],
+      "nome": "Certidão de Ausência de Débito da Última Eleição",
+      "output": [
+        "certidao",
+        "dados_cadastrais",
+        "debito"
+      ],
+      "readme_linha": 905,
+      "tipo_fonte": "judiciario"
+    },
+    {
+      "categoria": "Registros Eleitorais e Políticos",
+      "categoria_id": "registros-eleitorais-e-politicos",
+      "classificacao": "heuristica",
+      "descricao": "Verifica a autenticidade de certidões e documentos emitidos pela Justiça Eleitoral a partir do código de validação.",
+      "id": "registros-eleitorais-e-politicos/validacao-de-documento-da-justica-eleitoral",
+      "input": [
+        "cpf",
+        "nome",
+        "titulo_eleitor"
+      ],
+      "links": [
+        {
+          "label": "",
+          "uf": null,
+          "url": "https://www.tse.jus.br/servicos-eleitorais/autoatendimento-eleitoral#/certidoes-eleitor/validacao"
+        }
+      ],
+      "nome": "Validação de Documento da Justiça Eleitoral",
+      "output": [
+        "certidao",
+        "dados_cadastrais"
+      ],
+      "readme_linha": 909,
+      "tipo_fonte": "judiciario"
+    },
+    {
+      "categoria": "Registros Eleitorais e Políticos",
+      "categoria_id": "registros-eleitorais-e-politicos",
+      "classificacao": "heuristica",
       "descricao": "Verifica se o eleitor possui débitos eleitorais pendentes, como multas por ausência nas eleições sem justificativa.",
       "id": "registros-eleitorais-e-politicos/consulta-debitos-eleitorais",
       "input": [
@@ -2721,7 +2826,7 @@
         "debito",
         "multa"
       ],
-      "readme_linha": 897,
+      "readme_linha": 913,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2746,7 +2851,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 901,
+      "readme_linha": 917,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2772,7 +2877,7 @@
         "dados_cadastrais",
         "situacao_cadastral"
       ],
-      "readme_linha": 905,
+      "readme_linha": 921,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2797,7 +2902,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 909,
+      "readme_linha": 925,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2825,7 +2930,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 913,
+      "readme_linha": 929,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2850,7 +2955,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 917,
+      "readme_linha": 933,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2875,7 +2980,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 922,
+      "readme_linha": 938,
       "tipo_fonte": "judiciario"
     },
     {
@@ -2901,7 +3006,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 926,
+      "readme_linha": 942,
       "tipo_fonte": "ong"
     },
     {
@@ -2925,7 +3030,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 936,
+      "readme_linha": 952,
       "tipo_fonte": "ong"
     },
     {
@@ -2949,7 +3054,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 940,
+      "readme_linha": 956,
       "tipo_fonte": "estadual"
     },
     {
@@ -2973,7 +3078,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 944,
+      "readme_linha": 960,
       "tipo_fonte": "municipal"
     },
     {
@@ -2997,7 +3102,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 948,
+      "readme_linha": 964,
       "tipo_fonte": "federal"
     },
     {
@@ -3021,7 +3126,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 952,
+      "readme_linha": 968,
       "tipo_fonte": "federal"
     },
     {
@@ -3047,7 +3152,7 @@
         "certidao",
         "imovel"
       ],
-      "readme_linha": 956,
+      "readme_linha": 972,
       "tipo_fonte": "ong"
     },
     {
@@ -3071,7 +3176,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 966,
+      "readme_linha": 982,
       "tipo_fonte": "federal"
     },
     {
@@ -3095,7 +3200,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 970,
+      "readme_linha": 986,
       "tipo_fonte": "federal"
     },
     {
@@ -3119,7 +3224,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 974,
+      "readme_linha": 990,
       "tipo_fonte": "federal"
     },
     {
@@ -3143,7 +3248,7 @@
         "auto_infracao",
         "licenca_ambiental"
       ],
-      "readme_linha": 978,
+      "readme_linha": 994,
       "tipo_fonte": "estadual"
     },
     {
@@ -3168,7 +3273,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 982,
+      "readme_linha": 998,
       "tipo_fonte": "ong"
     },
     {
@@ -3193,7 +3298,7 @@
         "estatistica",
         "licenca_ambiental"
       ],
-      "readme_linha": 986,
+      "readme_linha": 1002,
       "tipo_fonte": "ong"
     },
     {
@@ -3218,7 +3323,7 @@
         "licenca_ambiental",
         "mapa"
       ],
-      "readme_linha": 990,
+      "readme_linha": 1006,
       "tipo_fonte": "ong"
     },
     {
@@ -3241,7 +3346,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1000,
+      "readme_linha": 1016,
       "tipo_fonte": "federal"
     },
     {
@@ -3264,7 +3369,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1004,
+      "readme_linha": 1020,
       "tipo_fonte": "federal"
     },
     {
@@ -3287,7 +3392,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1008,
+      "readme_linha": 1024,
       "tipo_fonte": "federal"
     },
     {
@@ -3310,7 +3415,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 1012,
+      "readme_linha": 1028,
       "tipo_fonte": "federal"
     },
     {
@@ -3334,7 +3439,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1022,
+      "readme_linha": 1038,
       "tipo_fonte": "federal"
     },
     {
@@ -3358,7 +3463,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1026,
+      "readme_linha": 1042,
       "tipo_fonte": "federal"
     },
     {
@@ -3382,7 +3487,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1030,
+      "readme_linha": 1046,
       "tipo_fonte": "federal"
     },
     {
@@ -3408,7 +3513,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1040,
+      "readme_linha": 1056,
       "tipo_fonte": "federal"
     },
     {
@@ -3434,7 +3539,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1044,
+      "readme_linha": 1060,
       "tipo_fonte": "federal"
     },
     {
@@ -3466,7 +3571,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1048,
+      "readme_linha": 1064,
       "tipo_fonte": "federal"
     },
     {
@@ -3493,7 +3598,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1089,
+      "readme_linha": 1105,
       "tipo_fonte": "federal"
     },
     {
@@ -3520,7 +3625,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1093,
+      "readme_linha": 1109,
       "tipo_fonte": "federal"
     },
     {
@@ -3546,7 +3651,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1097,
+      "readme_linha": 1113,
       "tipo_fonte": "federal"
     },
     {
@@ -3572,7 +3677,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1101,
+      "readme_linha": 1117,
       "tipo_fonte": "federal"
     },
     {
@@ -3600,7 +3705,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1105,
+      "readme_linha": 1121,
       "tipo_fonte": "federal"
     },
     {
@@ -3626,7 +3731,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1109,
+      "readme_linha": 1125,
       "tipo_fonte": "federal"
     },
     {
@@ -3693,7 +3798,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 1113,
+      "readme_linha": 1129,
       "tipo_fonte": "federal"
     },
     {
@@ -3719,7 +3824,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1130,
+      "readme_linha": 1146,
       "tipo_fonte": "federal"
     },
     {
@@ -3745,7 +3850,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1134,
+      "readme_linha": 1150,
       "tipo_fonte": "federal"
     },
     {
@@ -3771,7 +3876,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1138,
+      "readme_linha": 1154,
       "tipo_fonte": "federal"
     },
     {
@@ -3797,7 +3902,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1142,
+      "readme_linha": 1158,
       "tipo_fonte": "federal"
     },
     {
@@ -3823,7 +3928,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1146,
+      "readme_linha": 1162,
       "tipo_fonte": "federal"
     },
     {
@@ -3849,7 +3954,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1150,
+      "readme_linha": 1166,
       "tipo_fonte": "federal"
     },
     {
@@ -3875,7 +3980,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1154,
+      "readme_linha": 1170,
       "tipo_fonte": "federal"
     },
     {
@@ -3902,7 +4007,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1158,
+      "readme_linha": 1174,
       "tipo_fonte": "federal"
     },
     {
@@ -3928,7 +4033,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1162,
+      "readme_linha": 1178,
       "tipo_fonte": "estadual"
     },
     {
@@ -3955,7 +4060,7 @@
         "remuneracao",
         "sancao"
       ],
-      "readme_linha": 1166,
+      "readme_linha": 1182,
       "tipo_fonte": "estadual"
     },
     {
@@ -3981,7 +4086,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1170,
+      "readme_linha": 1186,
       "tipo_fonte": "federal"
     },
     {
@@ -4052,7 +4157,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1174,
+      "readme_linha": 1190,
       "tipo_fonte": "estadual"
     },
     {
@@ -4078,7 +4183,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1218,
+      "readme_linha": 1234,
       "tipo_fonte": "federal"
     },
     {
@@ -4244,7 +4349,7 @@
         "licitacao",
         "sancao"
       ],
-      "readme_linha": 1222,
+      "readme_linha": 1238,
       "tipo_fonte": "estadual"
     },
     {
@@ -4268,7 +4373,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1291,
+      "readme_linha": 1307,
       "tipo_fonte": "federal"
     },
     {
@@ -4292,7 +4397,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1295,
+      "readme_linha": 1311,
       "tipo_fonte": "federal"
     },
     {
@@ -4316,7 +4421,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1299,
+      "readme_linha": 1315,
       "tipo_fonte": "ong"
     },
     {
@@ -4470,7 +4575,7 @@
       "output": [
         "diario_oficial"
       ],
-      "readme_linha": 1303,
+      "readme_linha": 1319,
       "tipo_fonte": "estadual"
     },
     {
@@ -4496,7 +4601,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 1368,
+      "readme_linha": 1384,
       "tipo_fonte": "federal"
     },
     {
@@ -4520,7 +4625,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1372,
+      "readme_linha": 1388,
       "tipo_fonte": "federal"
     },
     {
@@ -4544,7 +4649,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1376,
+      "readme_linha": 1392,
       "tipo_fonte": "federal"
     },
     {
@@ -4568,7 +4673,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1380,
+      "readme_linha": 1396,
       "tipo_fonte": "federal"
     },
     {
@@ -4592,7 +4697,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1384,
+      "readme_linha": 1400,
       "tipo_fonte": "federal"
     },
     {
@@ -4616,7 +4721,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1388,
+      "readme_linha": 1404,
       "tipo_fonte": "federal"
     },
     {
@@ -4640,7 +4745,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1392,
+      "readme_linha": 1408,
       "tipo_fonte": "federal"
     },
     {
@@ -4664,7 +4769,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1396,
+      "readme_linha": 1412,
       "tipo_fonte": "federal"
     },
     {
@@ -4688,7 +4793,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1400,
+      "readme_linha": 1416,
       "tipo_fonte": "federal"
     },
     {
@@ -4712,7 +4817,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1404,
+      "readme_linha": 1420,
       "tipo_fonte": "federal"
     },
     {
@@ -4746,7 +4851,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1413,
+      "readme_linha": 1429,
       "tipo_fonte": "privado"
     },
     {
@@ -4774,7 +4879,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1426,
+      "readme_linha": 1442,
       "tipo_fonte": "privado"
     },
     {
@@ -4812,7 +4917,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1431,
+      "readme_linha": 1447,
       "tipo_fonte": "privado"
     },
     {
@@ -4836,7 +4941,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1443,
+      "readme_linha": 1459,
       "tipo_fonte": "privado"
     },
     {
@@ -4900,7 +5005,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1449,
+      "readme_linha": 1465,
       "tipo_fonte": "ong"
     },
     {
@@ -4925,7 +5030,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1467,
+      "readme_linha": 1483,
       "tipo_fonte": "federal"
     },
     {
@@ -4950,7 +5055,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1471,
+      "readme_linha": 1487,
       "tipo_fonte": "federal"
     },
     {
@@ -4974,7 +5079,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1475,
+      "readme_linha": 1491,
       "tipo_fonte": "federal"
     },
     {
@@ -4997,7 +5102,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1479,
+      "readme_linha": 1495,
       "tipo_fonte": "federal"
     },
     {
@@ -5020,7 +5125,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1483,
+      "readme_linha": 1499,
       "tipo_fonte": "federal"
     },
     {
@@ -5049,7 +5154,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1487,
+      "readme_linha": 1503,
       "tipo_fonte": "privado"
     },
     {
@@ -5073,7 +5178,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1492,
+      "readme_linha": 1508,
       "tipo_fonte": "federal"
     },
     {
@@ -5096,7 +5201,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1496,
+      "readme_linha": 1512,
       "tipo_fonte": "federal"
     },
     {
@@ -5121,7 +5226,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1500,
+      "readme_linha": 1516,
       "tipo_fonte": "federal"
     },
     {
@@ -5147,7 +5252,7 @@
         "operadora",
         "outorga"
       ],
-      "readme_linha": 1508,
+      "readme_linha": 1524,
       "tipo_fonte": "federal"
     },
     {
@@ -5172,7 +5277,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1514,
+      "readme_linha": 1530,
       "tipo_fonte": "federal"
     },
     {
@@ -5197,7 +5302,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1520,
+      "readme_linha": 1536,
       "tipo_fonte": "federal"
     },
     {
@@ -5222,7 +5327,7 @@
         "mapa",
         "operadora"
       ],
-      "readme_linha": 1526,
+      "readme_linha": 1542,
       "tipo_fonte": "federal"
     },
     {
@@ -5246,7 +5351,7 @@
         "estatistica",
         "operadora"
       ],
-      "readme_linha": 1533,
+      "readme_linha": 1549,
       "tipo_fonte": "federal"
     },
     {
@@ -5269,7 +5374,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1540,
+      "readme_linha": 1556,
       "tipo_fonte": "federal"
     },
     {
@@ -5296,7 +5401,7 @@
         "outorga",
         "radiofrequencia"
       ],
-      "readme_linha": 1547,
+      "readme_linha": 1563,
       "tipo_fonte": "federal"
     },
     {
@@ -5321,7 +5426,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1554,
+      "readme_linha": 1570,
       "tipo_fonte": "federal"
     },
     {
@@ -5344,7 +5449,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1561,
+      "readme_linha": 1577,
       "tipo_fonte": "federal"
     },
     {
@@ -5368,7 +5473,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1568,
+      "readme_linha": 1584,
       "tipo_fonte": "federal"
     },
     {
@@ -5392,7 +5497,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1575,
+      "readme_linha": 1591,
       "tipo_fonte": "federal"
     },
     {
@@ -5416,7 +5521,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1588,
+      "readme_linha": 1604,
       "tipo_fonte": "federal"
     },
     {
@@ -5441,7 +5546,7 @@
         "operadora",
         "radiofrequencia"
       ],
-      "readme_linha": 1594,
+      "readme_linha": 1610,
       "tipo_fonte": "ong"
     },
     {
@@ -5474,7 +5579,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1600,
+      "readme_linha": 1616,
       "tipo_fonte": "privado"
     },
     {
@@ -5502,7 +5607,7 @@
       "output": [
         "operadora"
       ],
-      "readme_linha": 1611,
+      "readme_linha": 1627,
       "tipo_fonte": "ong"
     },
     {
@@ -5573,7 +5678,7 @@
         "erb",
         "operadora"
       ],
-      "readme_linha": 1620,
+      "readme_linha": 1636,
       "tipo_fonte": "privado"
     },
     {
@@ -5597,7 +5702,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1646,
+      "readme_linha": 1662,
       "tipo_fonte": "privado"
     },
     {
@@ -5623,7 +5728,7 @@
         "processo",
         "publicacao_academica"
       ],
-      "readme_linha": 1652,
+      "readme_linha": 1668,
       "tipo_fonte": "federal"
     },
     {
@@ -5647,7 +5752,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1658,
+      "readme_linha": 1674,
       "tipo_fonte": "privado"
     },
     {
@@ -5671,7 +5776,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1662,
+      "readme_linha": 1678,
       "tipo_fonte": "academico"
     },
     {
@@ -5695,7 +5800,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1666,
+      "readme_linha": 1682,
       "tipo_fonte": "academico"
     },
     {
@@ -5719,7 +5824,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1670,
+      "readme_linha": 1686,
       "tipo_fonte": "academico"
     },
     {
@@ -5743,7 +5848,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1674,
+      "readme_linha": 1690,
       "tipo_fonte": "academico"
     },
     {
@@ -5767,7 +5872,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1678,
+      "readme_linha": 1694,
       "tipo_fonte": "federal"
     },
     {
@@ -5791,7 +5896,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1682,
+      "readme_linha": 1698,
       "tipo_fonte": "privado"
     },
     {
@@ -5815,7 +5920,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1686,
+      "readme_linha": 1702,
       "tipo_fonte": "federal"
     },
     {
@@ -5839,7 +5944,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1690,
+      "readme_linha": 1706,
       "tipo_fonte": "ong"
     },
     {
@@ -5864,7 +5969,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1694,
+      "readme_linha": 1710,
       "tipo_fonte": "federal"
     },
     {
@@ -5890,7 +5995,7 @@
         "estatistica",
         "publicacao_academica"
       ],
-      "readme_linha": 1698,
+      "readme_linha": 1714,
       "tipo_fonte": "federal"
     },
     {
@@ -5915,7 +6020,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 1702,
+      "readme_linha": 1718,
       "tipo_fonte": "federal"
     },
     {
@@ -5939,7 +6044,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1706,
+      "readme_linha": 1722,
       "tipo_fonte": "federal"
     },
     {
@@ -5963,7 +6068,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1710,
+      "readme_linha": 1726,
       "tipo_fonte": "federal"
     },
     {
@@ -5987,7 +6092,7 @@
         "curriculo",
         "publicacao_academica"
       ],
-      "readme_linha": 1714,
+      "readme_linha": 1730,
       "tipo_fonte": "federal"
     },
     {
@@ -6127,7 +6232,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1723,
+      "readme_linha": 1739,
       "tipo_fonte": "privado"
     },
     {
@@ -6158,7 +6263,7 @@
         "area_rural",
         "mapa"
       ],
-      "readme_linha": 1757,
+      "readme_linha": 1773,
       "tipo_fonte": "federal"
     },
     {
@@ -6182,7 +6287,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1764,
+      "readme_linha": 1780,
       "tipo_fonte": "federal"
     },
     {
@@ -6211,7 +6316,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1770,
+      "readme_linha": 1786,
       "tipo_fonte": "federal"
     },
     {
@@ -6235,7 +6340,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1777,
+      "readme_linha": 1793,
       "tipo_fonte": "privado"
     },
     {
@@ -6276,7 +6381,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1781,
+      "readme_linha": 1797,
       "tipo_fonte": "internacional"
     },
     {
@@ -6305,7 +6410,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1793,
+      "readme_linha": 1809,
       "tipo_fonte": "federal"
     },
     {
@@ -6330,7 +6435,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1800,
+      "readme_linha": 1816,
       "tipo_fonte": "federal"
     },
     {
@@ -6354,7 +6459,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1806,
+      "readme_linha": 1822,
       "tipo_fonte": "federal"
     },
     {
@@ -6393,7 +6498,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1810,
+      "readme_linha": 1826,
       "tipo_fonte": "federal"
     },
     {
@@ -6417,7 +6522,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1822,
+      "readme_linha": 1838,
       "tipo_fonte": "federal"
     },
     {
@@ -6441,7 +6546,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 1826,
+      "readme_linha": 1842,
       "tipo_fonte": "federal"
     },
     {
@@ -6466,7 +6571,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1836,
+      "readme_linha": 1852,
       "tipo_fonte": "federal"
     },
     {
@@ -6491,7 +6596,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1843,
+      "readme_linha": 1859,
       "tipo_fonte": "federal"
     },
     {
@@ -6518,7 +6623,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1850,
+      "readme_linha": 1866,
       "tipo_fonte": "federal"
     },
     {
@@ -6547,7 +6652,7 @@
         "imovel",
         "mapa"
       ],
-      "readme_linha": 1857,
+      "readme_linha": 1873,
       "tipo_fonte": "federal"
     },
     {
@@ -6573,7 +6678,7 @@
         "mapa",
         "sancao"
       ],
-      "readme_linha": 1864,
+      "readme_linha": 1880,
       "tipo_fonte": "federal"
     },
     {
@@ -6598,7 +6703,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1871,
+      "readme_linha": 1887,
       "tipo_fonte": "federal"
     },
     {
@@ -6625,7 +6730,7 @@
         "imagem_satelite",
         "mapa"
       ],
-      "readme_linha": 1878,
+      "readme_linha": 1894,
       "tipo_fonte": "federal"
     },
     {
@@ -6651,7 +6756,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1885,
+      "readme_linha": 1901,
       "tipo_fonte": "privado"
     },
     {
@@ -6676,7 +6781,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1892,
+      "readme_linha": 1908,
       "tipo_fonte": "federal"
     },
     {
@@ -6703,7 +6808,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1899,
+      "readme_linha": 1915,
       "tipo_fonte": "federal"
     },
     {
@@ -6728,7 +6833,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1906,
+      "readme_linha": 1922,
       "tipo_fonte": "federal"
     },
     {
@@ -6754,7 +6859,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1913,
+      "readme_linha": 1929,
       "tipo_fonte": "federal"
     },
     {
@@ -6780,7 +6885,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1920,
+      "readme_linha": 1936,
       "tipo_fonte": "federal"
     },
     {
@@ -6805,7 +6910,7 @@
         "auto_infracao",
         "mapa"
       ],
-      "readme_linha": 1927,
+      "readme_linha": 1943,
       "tipo_fonte": "federal"
     },
     {
@@ -6832,7 +6937,7 @@
         "mapa",
         "processo"
       ],
-      "readme_linha": 1934,
+      "readme_linha": 1950,
       "tipo_fonte": "federal"
     },
     {
@@ -6859,7 +6964,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 1941,
+      "readme_linha": 1957,
       "tipo_fonte": "federal"
     },
     {
@@ -6883,7 +6988,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1952,
+      "readme_linha": 1968,
       "tipo_fonte": "federal"
     },
     {
@@ -6907,7 +7012,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1958,
+      "readme_linha": 1974,
       "tipo_fonte": "federal"
     },
     {
@@ -6932,7 +7037,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1962,
+      "readme_linha": 1978,
       "tipo_fonte": "federal"
     },
     {
@@ -6956,7 +7061,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1966,
+      "readme_linha": 1982,
       "tipo_fonte": "federal"
     },
     {
@@ -6980,7 +7085,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1970,
+      "readme_linha": 1986,
       "tipo_fonte": "federal"
     },
     {
@@ -7004,7 +7109,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1974,
+      "readme_linha": 1990,
       "tipo_fonte": "federal"
     },
     {
@@ -7033,7 +7138,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1978,
+      "readme_linha": 1994,
       "tipo_fonte": "federal"
     },
     {
@@ -7058,7 +7163,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 1983,
+      "readme_linha": 1999,
       "tipo_fonte": "ong"
     },
     {
@@ -7083,7 +7188,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 1987,
+      "readme_linha": 2003,
       "tipo_fonte": "academico"
     },
     {
@@ -7107,7 +7212,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1991,
+      "readme_linha": 2007,
       "tipo_fonte": "academico"
     },
     {
@@ -7141,7 +7246,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 1995,
+      "readme_linha": 2011,
       "tipo_fonte": "federal"
     },
     {
@@ -7179,7 +7284,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2012,
+      "readme_linha": 2028,
       "tipo_fonte": "dork"
     },
     {
@@ -7207,7 +7312,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2025,
+      "readme_linha": 2041,
       "tipo_fonte": "dork"
     },
     {
@@ -7235,7 +7340,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2032,
+      "readme_linha": 2048,
       "tipo_fonte": "dork"
     },
     {
@@ -7268,7 +7373,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2041,
+      "readme_linha": 2057,
       "tipo_fonte": "dork"
     },
     {
@@ -7306,7 +7411,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2052,
+      "readme_linha": 2068,
       "tipo_fonte": "dork"
     },
     {
@@ -7345,7 +7450,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2065,
+      "readme_linha": 2081,
       "tipo_fonte": "dork"
     },
     {
@@ -7384,7 +7489,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2081,
+      "readme_linha": 2097,
       "tipo_fonte": "internacional"
     },
     {
@@ -7418,7 +7523,7 @@
         "dork",
         "perfil_social"
       ],
-      "readme_linha": 2093,
+      "readme_linha": 2109,
       "tipo_fonte": "internacional"
     },
     {
@@ -7446,7 +7551,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2100,
+      "readme_linha": 2116,
       "tipo_fonte": "dork"
     },
     {
@@ -7494,7 +7599,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2107,
+      "readme_linha": 2123,
       "tipo_fonte": "dork"
     },
     {
@@ -7532,7 +7637,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2127,
+      "readme_linha": 2143,
       "tipo_fonte": "dork"
     },
     {
@@ -7571,7 +7676,7 @@
         "dork",
         "video_ao_vivo"
       ],
-      "readme_linha": 2142,
+      "readme_linha": 2158,
       "tipo_fonte": "dork"
     },
     {
@@ -7612,7 +7717,7 @@
         "dork",
         "operadora"
       ],
-      "readme_linha": 2157,
+      "readme_linha": 2173,
       "tipo_fonte": "dork"
     },
     {
@@ -7646,7 +7751,7 @@
         "dork",
         "publicacao_academica"
       ],
-      "readme_linha": 2172,
+      "readme_linha": 2188,
       "tipo_fonte": "dork"
     },
     {
@@ -7679,7 +7784,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2184,
+      "readme_linha": 2200,
       "tipo_fonte": "dork"
     },
     {
@@ -7707,7 +7812,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2196,
+      "readme_linha": 2212,
       "tipo_fonte": "dork"
     },
     {
@@ -7736,7 +7841,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2206,
+      "readme_linha": 2222,
       "tipo_fonte": "internacional"
     },
     {
@@ -7779,7 +7884,7 @@
       "output": [
         "dork"
       ],
-      "readme_linha": 2218,
+      "readme_linha": 2234,
       "tipo_fonte": "dork"
     },
     {
@@ -7804,7 +7909,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2242,
+      "readme_linha": 2258,
       "tipo_fonte": "internacional"
     },
     {
@@ -7839,7 +7944,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2248,
+      "readme_linha": 2264,
       "tipo_fonte": "internacional"
     },
     {
@@ -7869,7 +7974,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2259,
+      "readme_linha": 2275,
       "tipo_fonte": "internacional"
     },
     {
@@ -7894,7 +7999,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2267,
+      "readme_linha": 2283,
       "tipo_fonte": "internacional"
     },
     {
@@ -7920,7 +8025,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2273,
+      "readme_linha": 2289,
       "tipo_fonte": "internacional"
     },
     {
@@ -7946,7 +8051,7 @@
         "estatistica",
         "perfil_social"
       ],
-      "readme_linha": 2279,
+      "readme_linha": 2295,
       "tipo_fonte": "internacional"
     },
     {
@@ -7971,7 +8076,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2285,
+      "readme_linha": 2301,
       "tipo_fonte": "internacional"
     },
     {
@@ -7996,7 +8101,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2291,
+      "readme_linha": 2307,
       "tipo_fonte": "internacional"
     },
     {
@@ -8021,7 +8126,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2295,
+      "readme_linha": 2311,
       "tipo_fonte": "internacional"
     },
     {
@@ -8046,7 +8151,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2299,
+      "readme_linha": 2315,
       "tipo_fonte": "internacional"
     },
     {
@@ -8071,7 +8176,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2303,
+      "readme_linha": 2319,
       "tipo_fonte": "internacional"
     },
     {
@@ -8096,7 +8201,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2307,
+      "readme_linha": 2323,
       "tipo_fonte": "internacional"
     },
     {
@@ -8121,7 +8226,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2311,
+      "readme_linha": 2327,
       "tipo_fonte": "internacional"
     },
     {
@@ -8147,7 +8252,7 @@
         "mandado_prisao",
         "perfil_social"
       ],
-      "readme_linha": 2317,
+      "readme_linha": 2333,
       "tipo_fonte": "privado"
     },
     {
@@ -8177,7 +8282,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2323,
+      "readme_linha": 2339,
       "tipo_fonte": "privado"
     },
     {
@@ -8207,7 +8312,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2330,
+      "readme_linha": 2346,
       "tipo_fonte": "internacional"
     },
     {
@@ -8233,7 +8338,7 @@
         "api_json",
         "perfil_social"
       ],
-      "readme_linha": 2336,
+      "readme_linha": 2352,
       "tipo_fonte": "internacional"
     },
     {
@@ -8258,7 +8363,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2343,
+      "readme_linha": 2359,
       "tipo_fonte": "privado"
     },
     {
@@ -8283,7 +8388,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2349,
+      "readme_linha": 2365,
       "tipo_fonte": "internacional"
     },
     {
@@ -8366,7 +8471,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2362,
+      "readme_linha": 2378,
       "tipo_fonte": "privado"
     },
     {
@@ -8429,7 +8534,7 @@
       "output": [
         "perfil_social"
       ],
-      "readme_linha": 2387,
+      "readme_linha": 2403,
       "tipo_fonte": "privado"
     },
     {
@@ -8452,7 +8557,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2414,
+      "readme_linha": 2430,
       "tipo_fonte": "federal"
     },
     {
@@ -8475,7 +8580,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2420,
+      "readme_linha": 2436,
       "tipo_fonte": "privado"
     },
     {
@@ -8498,7 +8603,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2426,
+      "readme_linha": 2442,
       "tipo_fonte": "federal"
     },
     {
@@ -8521,7 +8626,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2432,
+      "readme_linha": 2448,
       "tipo_fonte": "privado"
     },
     {
@@ -8544,7 +8649,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2438,
+      "readme_linha": 2454,
       "tipo_fonte": "federal"
     },
     {
@@ -8567,7 +8672,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2444,
+      "readme_linha": 2460,
       "tipo_fonte": "federal"
     },
     {
@@ -8590,7 +8695,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2450,
+      "readme_linha": 2466,
       "tipo_fonte": "federal"
     },
     {
@@ -8614,7 +8719,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2456,
+      "readme_linha": 2472,
       "tipo_fonte": "federal"
     },
     {
@@ -8643,7 +8748,7 @@
         "dataset",
         "publicacao_academica"
       ],
-      "readme_linha": 2460,
+      "readme_linha": 2476,
       "tipo_fonte": "federal"
     },
     {
@@ -8666,7 +8771,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2467,
+      "readme_linha": 2483,
       "tipo_fonte": "federal"
     },
     {
@@ -8689,7 +8794,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2471,
+      "readme_linha": 2487,
       "tipo_fonte": "federal"
     },
     {
@@ -8713,7 +8818,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2477,
+      "readme_linha": 2493,
       "tipo_fonte": "federal"
     },
     {
@@ -8736,7 +8841,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2483,
+      "readme_linha": 2499,
       "tipo_fonte": "estadual"
     },
     {
@@ -8760,7 +8865,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 2489,
+      "readme_linha": 2505,
       "tipo_fonte": "estadual"
     },
     {
@@ -8784,7 +8889,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2495,
+      "readme_linha": 2511,
       "tipo_fonte": "federal"
     },
     {
@@ -8807,7 +8912,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2501,
+      "readme_linha": 2517,
       "tipo_fonte": "federal"
     },
     {
@@ -8830,7 +8935,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2507,
+      "readme_linha": 2523,
       "tipo_fonte": "estadual"
     },
     {
@@ -8854,7 +8959,7 @@
         "dataset",
         "mapa"
       ],
-      "readme_linha": 2513,
+      "readme_linha": 2529,
       "tipo_fonte": "federal"
     },
     {
@@ -8877,7 +8982,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2519,
+      "readme_linha": 2535,
       "tipo_fonte": "estadual"
     },
     {
@@ -8900,7 +9005,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2525,
+      "readme_linha": 2541,
       "tipo_fonte": "estadual"
     },
     {
@@ -8923,7 +9028,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2531,
+      "readme_linha": 2547,
       "tipo_fonte": "federal"
     },
     {
@@ -8946,7 +9051,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2537,
+      "readme_linha": 2553,
       "tipo_fonte": "estadual"
     },
     {
@@ -8969,7 +9074,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2543,
+      "readme_linha": 2559,
       "tipo_fonte": "estadual"
     },
     {
@@ -8992,7 +9097,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2547,
+      "readme_linha": 2563,
       "tipo_fonte": "federal"
     },
     {
@@ -9015,7 +9120,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2553,
+      "readme_linha": 2569,
       "tipo_fonte": "federal"
     },
     {
@@ -9038,7 +9143,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2559,
+      "readme_linha": 2575,
       "tipo_fonte": "estadual"
     },
     {
@@ -9061,7 +9166,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2565,
+      "readme_linha": 2581,
       "tipo_fonte": "federal"
     },
     {
@@ -9089,7 +9194,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2571,
+      "readme_linha": 2587,
       "tipo_fonte": "federal"
     },
     {
@@ -9114,7 +9219,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2578,
+      "readme_linha": 2594,
       "tipo_fonte": "estadual"
     },
     {
@@ -9137,7 +9242,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2582,
+      "readme_linha": 2598,
       "tipo_fonte": "federal"
     },
     {
@@ -9161,7 +9266,7 @@
         "dataset",
         "diario_oficial"
       ],
-      "readme_linha": 2586,
+      "readme_linha": 2602,
       "tipo_fonte": "ong"
     },
     {
@@ -9184,7 +9289,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2592,
+      "readme_linha": 2608,
       "tipo_fonte": "ong"
     },
     {
@@ -9207,7 +9312,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2596,
+      "readme_linha": 2612,
       "tipo_fonte": "federal"
     },
     {
@@ -9230,7 +9335,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2600,
+      "readme_linha": 2616,
       "tipo_fonte": "federal"
     },
     {
@@ -9253,7 +9358,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2604,
+      "readme_linha": 2620,
       "tipo_fonte": "privado"
     },
     {
@@ -9276,7 +9381,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2608,
+      "readme_linha": 2624,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9299,7 +9404,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2612,
+      "readme_linha": 2628,
       "tipo_fonte": "legislativo"
     },
     {
@@ -9323,7 +9428,7 @@
         "dataset",
         "processo"
       ],
-      "readme_linha": 2616,
+      "readme_linha": 2632,
       "tipo_fonte": "federal"
     },
     {
@@ -9346,7 +9451,7 @@
       "output": [
         "dataset"
       ],
-      "readme_linha": 2620,
+      "readme_linha": 2636,
       "tipo_fonte": "federal"
     },
     {
@@ -9370,7 +9475,7 @@
         "dataset",
         "endereco"
       ],
-      "readme_linha": 2624,
+      "readme_linha": 2640,
       "tipo_fonte": "privado"
     },
     {
@@ -9395,7 +9500,7 @@
         "beneficio",
         "remuneracao"
       ],
-      "readme_linha": 2634,
+      "readme_linha": 2650,
       "tipo_fonte": "ong"
     },
     {
@@ -9419,7 +9524,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2642,
+      "readme_linha": 2658,
       "tipo_fonte": "estadual"
     },
     {
@@ -9443,7 +9548,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2646,
+      "readme_linha": 2662,
       "tipo_fonte": "estadual"
     },
     {
@@ -9542,7 +9647,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2652,
+      "readme_linha": 2668,
       "tipo_fonte": "privado"
     },
     {
@@ -9601,7 +9706,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2675,
+      "readme_linha": 2691,
       "tipo_fonte": "ong"
     },
     {
@@ -9630,7 +9735,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2690,
+      "readme_linha": 2706,
       "tipo_fonte": "privado"
     },
     {
@@ -9654,7 +9759,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2697,
+      "readme_linha": 2713,
       "tipo_fonte": "privado"
     },
     {
@@ -9678,7 +9783,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2703,
+      "readme_linha": 2719,
       "tipo_fonte": "federal"
     },
     {
@@ -9702,7 +9807,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2709,
+      "readme_linha": 2725,
       "tipo_fonte": "federal"
     },
     {
@@ -9727,7 +9832,7 @@
         "veiculo",
         "video_ao_vivo"
       ],
-      "readme_linha": 2715,
+      "readme_linha": 2731,
       "tipo_fonte": "internacional"
     },
     {
@@ -9751,7 +9856,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2719,
+      "readme_linha": 2735,
       "tipo_fonte": "internacional"
     },
     {
@@ -9776,7 +9881,7 @@
         "multa",
         "veiculo"
       ],
-      "readme_linha": 2723,
+      "readme_linha": 2739,
       "tipo_fonte": "federal"
     },
     {
@@ -9802,7 +9907,7 @@
         "dados_cadastrais",
         "veiculo"
       ],
-      "readme_linha": 2727,
+      "readme_linha": 2743,
       "tipo_fonte": "federal"
     },
     {
@@ -9826,7 +9931,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2731,
+      "readme_linha": 2747,
       "tipo_fonte": "federal"
     },
     {
@@ -9850,7 +9955,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2735,
+      "readme_linha": 2751,
       "tipo_fonte": "privado"
     },
     {
@@ -9874,7 +9979,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2741,
+      "readme_linha": 2757,
       "tipo_fonte": "federal"
     },
     {
@@ -9898,7 +10003,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2747,
+      "readme_linha": 2763,
       "tipo_fonte": "federal"
     },
     {
@@ -9923,7 +10028,7 @@
         "dataset",
         "veiculo"
       ],
-      "readme_linha": 2753,
+      "readme_linha": 2769,
       "tipo_fonte": "federal"
     },
     {
@@ -9952,7 +10057,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2759,
+      "readme_linha": 2775,
       "tipo_fonte": "estadual"
     },
     {
@@ -9981,7 +10086,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2766,
+      "readme_linha": 2782,
       "tipo_fonte": "estadual"
     },
     {
@@ -10150,7 +10255,7 @@
       "output": [
         "veiculo"
       ],
-      "readme_linha": 2773,
+      "readme_linha": 2789,
       "tipo_fonte": "estadual"
     },
     {
@@ -10174,7 +10279,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 2843,
+      "readme_linha": 2859,
       "tipo_fonte": "privado"
     },
     {
@@ -10197,7 +10302,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2849,
+      "readme_linha": 2865,
       "tipo_fonte": "privado"
     },
     {
@@ -10240,7 +10345,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2855,
+      "readme_linha": 2871,
       "tipo_fonte": "estadual"
     },
     {
@@ -10263,7 +10368,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2875,
+      "readme_linha": 2891,
       "tipo_fonte": "privado"
     },
     {
@@ -10286,7 +10391,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2881,
+      "readme_linha": 2897,
       "tipo_fonte": "privado"
     },
     {
@@ -10309,7 +10414,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 2887,
+      "readme_linha": 2903,
       "tipo_fonte": "privado"
     },
     {
@@ -10334,7 +10439,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 2899,
+      "readme_linha": 2915,
       "tipo_fonte": "federal"
     },
     {
@@ -10360,7 +10465,7 @@
         "estatistica",
         "multa"
       ],
-      "readme_linha": 2903,
+      "readme_linha": 2919,
       "tipo_fonte": "privado"
     },
     {
@@ -10383,7 +10488,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2907,
+      "readme_linha": 2923,
       "tipo_fonte": "federal"
     },
     {
@@ -10406,7 +10511,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2911,
+      "readme_linha": 2927,
       "tipo_fonte": "federal"
     },
     {
@@ -10429,7 +10534,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2915,
+      "readme_linha": 2931,
       "tipo_fonte": "federal"
     },
     {
@@ -10452,7 +10557,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2919,
+      "readme_linha": 2935,
       "tipo_fonte": "federal"
     },
     {
@@ -10480,7 +10585,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2923,
+      "readme_linha": 2939,
       "tipo_fonte": "internacional"
     },
     {
@@ -10503,7 +10608,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2928,
+      "readme_linha": 2944,
       "tipo_fonte": "privado"
     },
     {
@@ -10526,7 +10631,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2932,
+      "readme_linha": 2948,
       "tipo_fonte": "privado"
     },
     {
@@ -10549,7 +10654,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2936,
+      "readme_linha": 2952,
       "tipo_fonte": "privado"
     },
     {
@@ -10572,7 +10677,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2946,
+      "readme_linha": 2962,
       "tipo_fonte": "federal"
     },
     {
@@ -10598,7 +10703,7 @@
         "dados_cadastrais",
         "licitacao"
       ],
-      "readme_linha": 2952,
+      "readme_linha": 2968,
       "tipo_fonte": "privado"
     },
     {
@@ -10621,7 +10726,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2958,
+      "readme_linha": 2974,
       "tipo_fonte": "federal"
     },
     {
@@ -10646,7 +10751,7 @@
         "dados_cadastrais",
         "multa"
       ],
-      "readme_linha": 2964,
+      "readme_linha": 2980,
       "tipo_fonte": "federal"
     },
     {
@@ -10724,7 +10829,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 2968,
+      "readme_linha": 2984,
       "tipo_fonte": "federal"
     },
     {
@@ -10747,7 +10852,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 2996,
+      "readme_linha": 3012,
       "tipo_fonte": "estadual"
     },
     {
@@ -10770,7 +10875,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3002,
+      "readme_linha": 3018,
       "tipo_fonte": "privado"
     },
     {
@@ -10793,7 +10898,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3006,
+      "readme_linha": 3022,
       "tipo_fonte": "estadual"
     },
     {
@@ -10816,7 +10921,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3010,
+      "readme_linha": 3026,
       "tipo_fonte": "internacional"
     },
     {
@@ -10859,7 +10964,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3014,
+      "readme_linha": 3030,
       "tipo_fonte": "privado"
     },
     {
@@ -10907,7 +11012,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3029,
+      "readme_linha": 3045,
       "tipo_fonte": "privado"
     },
     {
@@ -11010,7 +11115,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3043,
+      "readme_linha": 3059,
       "tipo_fonte": "privado"
     },
     {
@@ -11033,7 +11138,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3084,
+      "readme_linha": 3100,
       "tipo_fonte": "privado"
     },
     {
@@ -11081,7 +11186,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3088,
+      "readme_linha": 3104,
       "tipo_fonte": "estadual"
     },
     {
@@ -11404,7 +11509,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3102,
+      "readme_linha": 3118,
       "tipo_fonte": "privado"
     },
     {
@@ -11427,7 +11532,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3177,
+      "readme_linha": 3193,
       "tipo_fonte": "privado"
     },
     {
@@ -11450,7 +11555,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3181,
+      "readme_linha": 3197,
       "tipo_fonte": "privado"
     },
     {
@@ -11473,7 +11578,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3185,
+      "readme_linha": 3201,
       "tipo_fonte": "estadual"
     },
     {
@@ -11496,7 +11601,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3189,
+      "readme_linha": 3205,
       "tipo_fonte": "federal"
     },
     {
@@ -11525,7 +11630,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3193,
+      "readme_linha": 3209,
       "tipo_fonte": "internacional"
     },
     {
@@ -11549,7 +11654,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3198,
+      "readme_linha": 3214,
       "tipo_fonte": "internacional"
     },
     {
@@ -11573,7 +11678,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3202,
+      "readme_linha": 3218,
       "tipo_fonte": "internacional"
     },
     {
@@ -11597,7 +11702,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3206,
+      "readme_linha": 3222,
       "tipo_fonte": "internacional"
     },
     {
@@ -11621,7 +11726,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3210,
+      "readme_linha": 3226,
       "tipo_fonte": "internacional"
     },
     {
@@ -11645,7 +11750,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3214,
+      "readme_linha": 3230,
       "tipo_fonte": "internacional"
     },
     {
@@ -11669,7 +11774,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3218,
+      "readme_linha": 3234,
       "tipo_fonte": "internacional"
     },
     {
@@ -11693,7 +11798,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3222,
+      "readme_linha": 3238,
       "tipo_fonte": "internacional"
     },
     {
@@ -11716,7 +11821,7 @@
       "output": [
         "video_ao_vivo"
       ],
-      "readme_linha": 3226,
+      "readme_linha": 3242,
       "tipo_fonte": "estadual"
     },
     {
@@ -11790,7 +11895,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3236,
+      "readme_linha": 3252,
       "tipo_fonte": "ministerio_publico"
     },
     {
@@ -11850,7 +11955,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3277,
+      "readme_linha": 3293,
       "tipo_fonte": "defensoria"
     },
     {
@@ -11884,7 +11989,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3309,
+      "readme_linha": 3325,
       "tipo_fonte": "ong"
     },
     {
@@ -11913,7 +12018,7 @@
       "output": [
         "processo"
       ],
-      "readme_linha": 3326,
+      "readme_linha": 3342,
       "tipo_fonte": "estadual"
     },
     {
@@ -11942,7 +12047,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3346,
+      "readme_linha": 3362,
       "tipo_fonte": "privado"
     },
     {
@@ -11991,7 +12096,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3351,
+      "readme_linha": 3367,
       "tipo_fonte": "estadual"
     },
     {
@@ -12016,7 +12121,7 @@
         "dataset",
         "estatistica"
       ],
-      "readme_linha": 3370,
+      "readme_linha": 3386,
       "tipo_fonte": "federal"
     },
     {
@@ -12041,7 +12146,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3374,
+      "readme_linha": 3390,
       "tipo_fonte": "ong"
     },
     {
@@ -12066,7 +12171,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3378,
+      "readme_linha": 3394,
       "tipo_fonte": "federal"
     },
     {
@@ -12089,7 +12194,7 @@
       "output": [
         "estatistica"
       ],
-      "readme_linha": 3382,
+      "readme_linha": 3398,
       "tipo_fonte": "privado"
     },
     {
@@ -12114,7 +12219,7 @@
         "contrato_publico",
         "estatistica"
       ],
-      "readme_linha": 3386,
+      "readme_linha": 3402,
       "tipo_fonte": "federal"
     },
     {
@@ -12137,7 +12242,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3390,
+      "readme_linha": 3406,
       "tipo_fonte": "federal"
     },
     {
@@ -12158,7 +12263,7 @@
       "output": [
         "antecedentes"
       ],
-      "readme_linha": 3394,
+      "readme_linha": 3410,
       "tipo_fonte": "federal"
     },
     {
@@ -12186,7 +12291,7 @@
         "mandado_prisao",
         "veiculo"
       ],
-      "readme_linha": 3398,
+      "readme_linha": 3414,
       "tipo_fonte": "federal"
     },
     {
@@ -12227,7 +12332,7 @@
       ],
       "nome": "Consulta Informações Sobre Domínios",
       "output": [],
-      "readme_linha": 3407,
+      "readme_linha": 3423,
       "tipo_fonte": "privado"
     },
     {
@@ -12258,7 +12363,7 @@
         "dados_cadastrais",
         "endereco"
       ],
-      "readme_linha": 3426,
+      "readme_linha": 3442,
       "tipo_fonte": "privado"
     },
     {
@@ -12287,7 +12392,7 @@
         "situacao_cadastral",
         "socios"
       ],
-      "readme_linha": 3440,
+      "readme_linha": 3456,
       "tipo_fonte": "privado"
     },
     {
@@ -12315,7 +12420,7 @@
         "api_json",
         "endereco"
       ],
-      "readme_linha": 3467,
+      "readme_linha": 3483,
       "tipo_fonte": "privado"
     },
     {
@@ -12345,7 +12450,7 @@
         "api_json",
         "dados_cadastrais"
       ],
-      "readme_linha": 3489,
+      "readme_linha": 3505,
       "tipo_fonte": "privado"
     },
     {
@@ -12372,7 +12477,7 @@
         "estatistica",
         "mapa"
       ],
-      "readme_linha": 3513,
+      "readme_linha": 3529,
       "tipo_fonte": "federal"
     },
     {
@@ -12399,7 +12504,7 @@
         "estatistica",
         "licitacao"
       ],
-      "readme_linha": 3536,
+      "readme_linha": 3552,
       "tipo_fonte": "federal"
     },
     {
@@ -12429,7 +12534,7 @@
         "api_json",
         "diario_oficial"
       ],
-      "readme_linha": 3540,
+      "readme_linha": 3556,
       "tipo_fonte": "ong"
     },
     {
@@ -12455,7 +12560,7 @@
         "processo",
         "sancao"
       ],
-      "readme_linha": 3563,
+      "readme_linha": 3579,
       "tipo_fonte": "federal"
     },
     {
@@ -12479,7 +12584,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3567,
+      "readme_linha": 3583,
       "tipo_fonte": "federal"
     },
     {
@@ -12502,7 +12607,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3577,
+      "readme_linha": 3593,
       "tipo_fonte": "federal"
     },
     {
@@ -12525,7 +12630,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3581,
+      "readme_linha": 3597,
       "tipo_fonte": "federal"
     },
     {
@@ -12554,7 +12659,7 @@
         "mapa",
         "video_ao_vivo"
       ],
-      "readme_linha": 3585,
+      "readme_linha": 3601,
       "tipo_fonte": "federal"
     },
     {
@@ -12582,7 +12687,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3590,
+      "readme_linha": 3606,
       "tipo_fonte": "federal"
     },
     {
@@ -12605,7 +12710,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3595,
+      "readme_linha": 3611,
       "tipo_fonte": "federal"
     },
     {
@@ -12628,7 +12733,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3599,
+      "readme_linha": 3615,
       "tipo_fonte": "federal"
     },
     {
@@ -12657,7 +12762,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3609,
+      "readme_linha": 3625,
       "tipo_fonte": "federal"
     },
     {
@@ -12681,7 +12786,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3614,
+      "readme_linha": 3630,
       "tipo_fonte": "federal"
     },
     {
@@ -12705,7 +12810,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3618,
+      "readme_linha": 3634,
       "tipo_fonte": "federal"
     },
     {
@@ -12735,7 +12840,7 @@
         "dados_cadastrais",
         "video_ao_vivo"
       ],
-      "readme_linha": 3622,
+      "readme_linha": 3638,
       "tipo_fonte": "ong"
     },
     {
@@ -12765,7 +12870,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3627,
+      "readme_linha": 3643,
       "tipo_fonte": "federal"
     },
     {
@@ -12790,7 +12895,7 @@
         "dados_cadastrais",
         "mapa"
       ],
-      "readme_linha": 3632,
+      "readme_linha": 3648,
       "tipo_fonte": "federal"
     },
     {
@@ -12814,7 +12919,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3636,
+      "readme_linha": 3652,
       "tipo_fonte": "federal"
     },
     {
@@ -12838,7 +12943,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3640,
+      "readme_linha": 3656,
       "tipo_fonte": "federal"
     },
     {
@@ -12893,7 +12998,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3650,
+      "readme_linha": 3666,
       "tipo_fonte": "ong"
     },
     {
@@ -13017,7 +13122,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3689,
+      "readme_linha": 3705,
       "tipo_fonte": "estadual"
     },
     {
@@ -13137,7 +13242,7 @@
         "certidao",
         "dados_cadastrais"
       ],
-      "readme_linha": 3730,
+      "readme_linha": 3746,
       "tipo_fonte": "ong"
     },
     {
@@ -13171,7 +13276,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3759,
+      "readme_linha": 3775,
       "tipo_fonte": "estadual"
     },
     {
@@ -13197,7 +13302,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3771,
+      "readme_linha": 3787,
       "tipo_fonte": "estadual"
     },
     {
@@ -13223,7 +13328,7 @@
         "dados_cadastrais",
         "processo"
       ],
-      "readme_linha": 3775,
+      "readme_linha": 3791,
       "tipo_fonte": "estadual"
     },
     {
@@ -13247,7 +13352,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3779,
+      "readme_linha": 3795,
       "tipo_fonte": "estadual"
     },
     {
@@ -13270,7 +13375,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3789,
+      "readme_linha": 3805,
       "tipo_fonte": "ong"
     },
     {
@@ -13293,7 +13398,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3793,
+      "readme_linha": 3809,
       "tipo_fonte": "federal"
     },
     {
@@ -13317,7 +13422,7 @@
         "dados_cadastrais",
         "estatistica"
       ],
-      "readme_linha": 3797,
+      "readme_linha": 3813,
       "tipo_fonte": "ong"
     },
     {
@@ -13340,7 +13445,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3801,
+      "readme_linha": 3817,
       "tipo_fonte": "federal"
     },
     {
@@ -13363,7 +13468,7 @@
       "output": [
         "licenca_ambiental"
       ],
-      "readme_linha": 3805,
+      "readme_linha": 3821,
       "tipo_fonte": "federal"
     },
     {
@@ -13391,7 +13496,7 @@
       "output": [
         "mapa"
       ],
-      "readme_linha": 3809,
+      "readme_linha": 3825,
       "tipo_fonte": "privado"
     },
     {
@@ -13479,7 +13584,7 @@
       "output": [
         "imovel"
       ],
-      "readme_linha": 3821,
+      "readme_linha": 3837,
       "tipo_fonte": "privado"
     },
     {
@@ -13530,7 +13635,7 @@
         "endereco",
         "imovel"
       ],
-      "readme_linha": 3843,
+      "readme_linha": 3859,
       "tipo_fonte": "privado"
     },
     {
@@ -13553,7 +13658,7 @@
       "output": [
         "sancao"
       ],
-      "readme_linha": 3856,
+      "readme_linha": 3872,
       "tipo_fonte": "estadual"
     },
     {
@@ -13586,7 +13691,7 @@
       "output": [
         "certidao"
       ],
-      "readme_linha": 3862,
+      "readme_linha": 3878,
       "tipo_fonte": "privado"
     },
     {
@@ -13610,7 +13715,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3873,
+      "readme_linha": 3889,
       "tipo_fonte": "privado"
     },
     {
@@ -13633,7 +13738,7 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 3877,
+      "readme_linha": 3893,
       "tipo_fonte": "federal"
     },
     {
@@ -13667,7 +13772,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3883,
+      "readme_linha": 3899,
       "tipo_fonte": "privado"
     },
     {
@@ -13753,7 +13858,7 @@
         "licitacao",
         "processo"
       ],
-      "readme_linha": 3893,
+      "readme_linha": 3909,
       "tipo_fonte": "privado"
     },
     {
@@ -13777,7 +13882,7 @@
         "contrato_publico",
         "licitacao"
       ],
-      "readme_linha": 3942,
+      "readme_linha": 3958,
       "tipo_fonte": "estadual"
     },
     {
@@ -13811,9 +13916,9 @@
       "output": [
         "dados_cadastrais"
       ],
-      "readme_linha": 4105,
+      "readme_linha": 4121,
       "tipo_fonte": "privado"
     }
   ],
-  "total": 437
+  "total": 441
 }

--- a/tools/checar_links.py
+++ b/tools/checar_links.py
@@ -11,12 +11,16 @@ Uso:
     python3 tools/checar_links.py --filtro detran     só URLs que contêm o texto
     python3 tools/checar_links.py --csv links.csv     grava o resultado completo
 
+URLs de exemplo (com {VALOR}, SEU_ALVO, exemplo, zeros) são rotuladas como
+"modelo" e não são requisitadas.
+
 Sem dependências além do Python 3.
 """
 
 import argparse
 import csv
 import json
+import re
 import socket
 import ssl
 import sys
@@ -35,7 +39,10 @@ UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) OSINT-Brazuca/checar_links (+htt
 TIMEOUT = 20
 
 # Rótulo por situação, para o resumo final.
-OK, REDIRECT, BLOQUEIO, OFFLINE, ERRO = "ok", "redirect", "bloqueio", "offline", "erro"
+OK, REDIRECT, BLOQUEIO, OFFLINE, ERRO, MODELO = "ok", "redirect", "bloqueio", "offline", "erro", "modelo"
+
+# URLs de exemplo, com valor a preencher: nunca respondem e não são links quebrados.
+RE_MODELO = re.compile(r"\{[^}]*\}|SEU_|seu_dominio|exemplo|0000000000|/ws/$|/v1/cnpj/$", re.I)
 
 
 def classifica(status, destino, url):
@@ -88,9 +95,13 @@ def main():
     urls = sorted(fontes)
     if args.filtro:
         urls = [u for u in urls if args.filtro.lower() in u.lower()]
-    print(f"verificando {len(urls)} URLs distintas com {args.paralelo} conexões...\n")
+    modelos = [u for u in urls if RE_MODELO.search(u)]
+    urls = [u for u in urls if u not in modelos]
+    print(f"verificando {len(urls)} URLs distintas com {args.paralelo} conexões"
+          f" ({len(modelos)} URLs modelo ignoradas)...\n")
 
-    resultados = []
+    resultados = [(MODELO, "", u, "", 0, "URL de exemplo, com valor a preencher", ";".join(fontes[u]))
+                  for u in modelos]
     with ThreadPoolExecutor(max_workers=args.paralelo) as pool:
         futuros = {pool.submit(requisita, u): u for u in urls}
         for i, fut in enumerate(as_completed(futuros), start=1):
@@ -105,7 +116,7 @@ def main():
 
     resumo = Counter(r[0] for r in resultados)
     print("\nresumo")
-    for chave in (OK, REDIRECT, BLOQUEIO, OFFLINE, ERRO):
+    for chave in (OK, REDIRECT, BLOQUEIO, OFFLINE, ERRO, MODELO):
         print(f"  {chave:9} {resumo.get(chave, 0)}")
     print("\nbloqueio = 401/403/405/429/503, provável anti-robô: confira no navegador antes de reportar.")
 

--- a/tools/checar_links.py
+++ b/tools/checar_links.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Verifica quais URLs do catálogo respondem, para curadoria local.
+
+Lê data/index.json (rode tools/build_dataset.py antes) e faz uma requisição
+em cada URL distinta. Não integra o CI: muitos sites .gov.br bloqueiam
+robôs ou oscilam, então o resultado precisa de revisão humana antes de
+virar issue ou correção no README.
+
+Uso:
+    python3 tools/checar_links.py                     todas as URLs
+    python3 tools/checar_links.py --filtro detran     só URLs que contêm o texto
+    python3 tools/checar_links.py --csv links.csv     grava o resultado completo
+
+Sem dependências além do Python 3.
+"""
+
+import argparse
+import csv
+import json
+import socket
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from urllib.parse import urlsplit
+
+RAIZ = Path(__file__).resolve().parent.parent
+INDEX = RAIZ / "data" / "index.json"
+
+UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) OSINT-Brazuca/checar_links (+https://github.com/osintbrazuca/osint-brazuca)"
+TIMEOUT = 20
+
+# Rótulo por situação, para o resumo final.
+OK, REDIRECT, BLOQUEIO, OFFLINE, ERRO = "ok", "redirect", "bloqueio", "offline", "erro"
+
+
+def classifica(status, destino, url):
+    if status is None:
+        return ERRO
+    if status in (401, 403, 405, 429, 503):
+        return BLOQUEIO  # provável anti-robô ou exige sessão; conferir no navegador
+    if status >= 400:
+        return OFFLINE
+    if destino and urlsplit(destino).netloc != urlsplit(url).netloc:
+        return REDIRECT
+    return OK
+
+
+def requisita(url):
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    inicio = time.monotonic()
+    for metodo in ("HEAD", "GET"):
+        req = urllib.request.Request(url, method=metodo, headers={"User-Agent": UA, "Accept": "*/*"})
+        try:
+            with urllib.request.urlopen(req, timeout=TIMEOUT, context=ctx) as resp:
+                return resp.status, resp.geturl(), round(time.monotonic() - inicio, 1), ""
+        except urllib.error.HTTPError as e:
+            if metodo == "HEAD" and e.code in (400, 403, 404, 405, 501):
+                continue  # muitos servidores rejeitam HEAD; tenta GET
+            return e.code, e.geturl() if hasattr(e, "geturl") else "", round(time.monotonic() - inicio, 1), ""
+        except (urllib.error.URLError, socket.timeout, ssl.SSLError, ConnectionError, OSError) as e:
+            if metodo == "HEAD":
+                continue
+            return None, "", round(time.monotonic() - inicio, 1), type(e).__name__ + ": " + str(getattr(e, "reason", e))[:80]
+    return None, "", round(time.monotonic() - inicio, 1), "sem resposta"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--filtro", help="só URLs que contenham este texto")
+    parser.add_argument("--csv", help="grava o resultado completo neste arquivo")
+    parser.add_argument("--paralelo", type=int, default=12, help="requisições simultâneas (padrão 12)")
+    args = parser.parse_args()
+
+    if not INDEX.exists():
+        print("data/index.json não existe; rode: python3 tools/build_dataset.py", file=sys.stderr)
+        return 2
+    links = json.loads(INDEX.read_text(encoding="utf-8"))["links"]
+    fontes = {}
+    for l in links:
+        fontes.setdefault(l["url"], []).append(l["fonte_id"])
+    urls = sorted(fontes)
+    if args.filtro:
+        urls = [u for u in urls if args.filtro.lower() in u.lower()]
+    print(f"verificando {len(urls)} URLs distintas com {args.paralelo} conexões...\n")
+
+    resultados = []
+    with ThreadPoolExecutor(max_workers=args.paralelo) as pool:
+        futuros = {pool.submit(requisita, u): u for u in urls}
+        for i, fut in enumerate(as_completed(futuros), start=1):
+            url = futuros[fut]
+            status, destino, segundos, detalhe = fut.result()
+            situacao = classifica(status, destino, url)
+            resultados.append((situacao, status, url, destino, segundos, detalhe, ";".join(fontes[url])))
+            if situacao != OK:
+                print(f"[{i:4}/{len(urls)}] {situacao:8} {status or '-':>4} {url}"
+                      + (f"  -> {destino}" if situacao == REDIRECT else "")
+                      + (f"  ({detalhe})" if detalhe else ""))
+
+    resumo = Counter(r[0] for r in resultados)
+    print("\nresumo")
+    for chave in (OK, REDIRECT, BLOQUEIO, OFFLINE, ERRO):
+        print(f"  {chave:9} {resumo.get(chave, 0)}")
+    print("\nbloqueio = 401/403/405/429/503, provável anti-robô: confira no navegador antes de reportar.")
+
+    if args.csv:
+        with open(args.csv, "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(["situacao", "status", "url", "destino", "segundos", "detalhe", "fontes"])
+            w.writerows(sorted(resultados))
+        print(f"resultado gravado em {args.csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Valida documentos e dataset antes do commit. Ativar com:
+#   git config core.hooksPath tools/hooks
+set -e
+cd "$(git rev-parse --show-toplevel)"
+
+# 1. Regras de formatação (travessão, menu, âncoras) e avisos de curadoria
+if ! git diff --cached --quiet -- '*.md' data tools; then
+  python3 tools/validar_docs.py --avisos
+fi
+
+# 2. Dataset: só quando README, data ou tools mudaram
+if git diff --cached --quiet -- README.md data tools; then
+  exit 0
+fi
+
+python3 tools/build_dataset.py --check
+
+relatorio=$(python3 tools/build_dataset.py --report)
+if echo "$relatorio" | grep -q "fontes sem nenhum link"; then
+  echo "$relatorio" | sed -n '/fontes sem nenhum link/,/^$/p'
+  echo "ERRO: há fontes sem nenhum link no README.md" >&2
+  exit 1
+fi
+if echo "$relatorio" | grep -q "sem classificação, candidatas a override"; then
+  echo "$relatorio" | sed -n '/sem classificação/,/^$/p'
+  echo "ERRO: há fontes sem classificação. Adicione-as em data/overrides.json" >&2
+  exit 1
+fi

--- a/tools/validar_docs.py
+++ b/tools/validar_docs.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Valida as regras de formatação dos documentos do OSINT Brazuca.
+
+Erros (saída 1), conforme CONTRIBUICAO.md:
+    travessão (—) fora de crases em qualquer .md
+    menu de navegação (bloco de badges) diferente entre os documentos
+    link interno (#ancora) sem âncora correspondente no README.md
+
+Avisos (não falham; só com --avisos):
+    URL repetida em mais de uma fonte do catálogo
+    URL em http:// em vez de https://
+
+Uso:
+    python3 tools/validar_docs.py            só erros
+    python3 tools/validar_docs.py --avisos   erros e avisos
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.parse
+from collections import defaultdict
+from pathlib import Path
+
+RAIZ = Path(__file__).resolve().parent.parent
+DOCS = ["README.md", "CONTRIBUICAO.md", "EXEMPLOS_PRATICOS.md", "FLUXOGRAMA.md", "GUIA_RAPIDO.md"]
+
+RE_TRAVESSAO = re.compile(r"(?<!`)—(?!`)")
+RE_MENU = re.compile(r'^<p align="center">\n((?:  <a href=.*\n)+)</p>$', re.M)
+RE_ANCORA = re.compile(r'<a name="([^"]+)"')
+RE_LINK_INTERNO = re.compile(r"\]\(#([^)]+)\)")
+
+
+def le(nome):
+    return (RAIZ / nome).read_text(encoding="utf-8")
+
+
+def checa_travessao():
+    erros = []
+    for nome in DOCS:
+        for n, linha in enumerate(le(nome).splitlines(), start=1):
+            if RE_TRAVESSAO.search(linha):
+                erros.append(f"{nome}:{n}: travessão (—); use vírgula, dois-pontos, ponto final ou parênteses")
+    return erros
+
+
+def checa_menu():
+    menus = {}
+    for nome in DOCS:
+        m = RE_MENU.search(le(nome))
+        if not m:
+            return [f"{nome}: menu de navegação (bloco de badges) não encontrado"]
+        menus[nome] = m.group(1)
+    referencia = menus["README.md"]
+    return [
+        f"{nome}: menu de navegação diferente do README.md; replique a mudança em todos os documentos"
+        for nome, menu in menus.items()
+        if menu != referencia
+    ]
+
+
+def checa_ancoras():
+    texto = le("README.md")
+    ancoras = set(RE_ANCORA.findall(texto))
+    # Títulos também geram âncoras no GitHub; aceita o slug simples deles.
+    for titulo in re.findall(r"^#{1,6}\s+(.*)$", texto, re.M):
+        ancoras.add(slug_github(titulo))
+    erros = []
+    for n, linha in enumerate(texto.splitlines(), start=1):
+        for alvo in RE_LINK_INTERNO.findall(linha):
+            alvo = urllib.parse.unquote(alvo)
+            if alvo not in ancoras and alvo.lower() not in ancoras:
+                erros.append(f"README.md:{n}: link interno #{alvo} sem âncora correspondente")
+    return erros
+
+
+def slug_github(titulo):
+    titulo = re.sub(r"<[^>]+>", "", titulo)
+    titulo = re.sub(r"[^\w\s-]", "", titulo.strip().lower(), flags=re.UNICODE)
+    return re.sub(r"\s+", "-", titulo).strip("-")
+
+
+def avisos_catalogo():
+    caminho = RAIZ / "data" / "index.json"
+    if not caminho.exists():
+        return ["data/index.json não existe; rode tools/build_dataset.py"]
+    links = json.loads(caminho.read_text(encoding="utf-8"))["links"]
+    avisos = []
+    por_url = defaultdict(set)
+    for link in links:
+        por_url[link["url"]].add(link["fonte_id"])
+    for url, fontes in sorted(por_url.items()):
+        if len(fontes) > 1:
+            avisos.append(f"URL repetida em {len(fontes)} fontes: {url}\n    " + "\n    ".join(sorted(fontes)))
+    inseguras = sorted({l["url"] for l in links if l["url"].startswith("http://")})
+    if inseguras:
+        avisos.append(f"{len(inseguras)} URLs em http://; confira se há versão https:")
+        avisos.extend(f"    {u}" for u in inseguras)
+    return avisos
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--avisos", action="store_true", help="mostra também URLs repetidas e http://")
+    args = parser.parse_args()
+
+    erros = checa_travessao() + checa_menu() + checa_ancoras()
+
+    if args.avisos:
+        avisos = avisos_catalogo()
+        if avisos:
+            print(f"AVISOS ({len(avisos)}):")
+            for a in avisos:
+                print(f"  {a}")
+            print()
+
+    if erros:
+        print(f"ERROS ({len(erros)}):", file=sys.stderr)
+        for e in erros:
+            print(f"  {e}", file=sys.stderr)
+        return 1
+    print("OK: documentos seguem as regras de formatação.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Tipo de Mudança
- [ ] Nova fonte
- [ ] Correção de link
- [x] Melhoria de documentação
- [x] Outra: validação automática do catálogo (CI, pre-commit e ferramentas locais)

## Descrição
Adiciona validação automática para o que o CONTRIBUICAO.md já exige, sem nenhuma dependência além do Python 3:

- `.github/workflows/validar-dataset.yml`: em pull request e push na `main` (quando `*.md`, `data/**` ou `tools/**` mudam) roda `build_dataset.py --check`, falha se houver fonte sem link ou sem classificação (`--report`) e aplica as regras de formatação.
- `tools/validar_docs.py`: erros para travessão fora de crases, menu de navegação diferente entre os documentos e link interno sem âncora; com `--avisos`, lista URLs repetidas entre fontes e URLs em `http://` (só curadoria, não bloqueia).
- `tools/hooks/pre-commit`: as mesmas verificações antes do commit, ativado com `git config core.hooksPath tools/hooks`.
- `tools/checar_links.py`: verificação local de todas as URLs do catálogo (ok/redirect/bloqueio/offline/erro/modelo). Fica fora do CI de propósito: sites `.gov.br` bloqueiam robôs com frequência (102 de 1037 URLs deram 403 na primeira execução).
- `CONTRIBUICAO.md`: seções "Validação automática" e "Ferramentas de curadoria (só local)".

Testado no GitHub Actions do fork: passa no estado atual do catálogo e falha no passo certo com um commit de teste contendo travessão (https://github.com/opastorello/OSINT-Brazuca/pull/1).

Depende do #156: a branch parte dele porque o CI só passa com o dataset regenerado e as 4 fontes sem link corrigidas lá. Até o merge do #156, os 18 commits dele aparecem aqui também; depois restam apenas os 2 commits desta mudança (`d80ac78` e `0566c84`).

## Checklist
- [x] Testei todos os links adicionados
- [x] Segui o padrão de formatação do projeto
- [x] Verifiquei que não há duplicatas
- [x] Rodei `python3 tools/build_dataset.py` e incluí os JSON atualizados
- [x] Li as diretrizes de contribuição
- [x] Minhas mudanças respeitam a LGPD
